### PR TITLE
PLU-861 feat(multirow): add opt-in Autofill button for multirow-multicol fields

### DIFF
--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -60,7 +60,7 @@ const createRowAction: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type to create a column',
+          placeholder: 'Select or type',
           key: 'columnName',
           type: 'dropdown' as const,
           required: true,

--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -60,7 +60,7 @@ const createRowAction: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type',
+          placeholder: 'Select or type to create a column',
           key: 'columnName',
           type: 'dropdown' as const,
           required: true,

--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -52,6 +52,7 @@ const createRowAction: IRawAction = {
       label: 'New row data',
       key: 'rowData',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       hiddenIf: {
         fieldKey: 'tableName',

--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -61,6 +61,7 @@ const action: IRawAction = {
       label: 'Case fields',
       key: 'caseFields',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       description:
         'Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.',

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -47,6 +47,7 @@ const action: IRawAction = {
       label: 'Case fields',
       key: 'caseFields',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: false,
       description:
         'Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.',

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -68,6 +68,7 @@ const action: IRawAction = {
       label: 'Personalised fields',
       key: 'letterParams',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       description:
         'Specify values for each personalised field in your template.',

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -85,6 +85,7 @@ const action: IRawAction = {
       label: 'New row data',
       key: 'columnValues',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -37,6 +37,7 @@ const action: IRawAction = {
       description:
         'Enter the data to update the row with. Columns not specified will not be updated',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -53,7 +53,7 @@ const action: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type',
+          placeholder: 'Select or type to create a column',
           key: 'columnId',
           type: 'dropdown' as const,
           required: true,

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -53,7 +53,7 @@ const action: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type to create a column',
+          placeholder: 'Select or type',
           key: 'columnId',
           type: 'dropdown' as const,
           required: true,

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -45,6 +45,7 @@ const action: IRawAction = {
       label: 'New row data',
       key: 'rowData',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -59,6 +59,7 @@ const action: IRawAction = {
       label: 'Row data',
       key: 'rowData',
       type: 'multirow-multicol' as const,
+      autofillable: true,
       description:
         'Enter the data to update the row with. Columns not specified will not be updated.',
       required: true,

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -252,6 +252,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         addRowButtonText={schema.addRowButtonText}
         showDivider={type !== 'multirow-multicol'}
         type={type}
+        autofillable={'autofillable' in schema && schema.autofillable}
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
         maxRows={schema.maxRows}

--- a/packages/frontend/src/components/MultiRow/AutofillConfirmDialog.tsx
+++ b/packages/frontend/src/components/MultiRow/AutofillConfirmDialog.tsx
@@ -1,0 +1,50 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+} from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import type { AutofillConfirmState } from './useAutofill'
+
+type AutofillConfirmDialogProps = {
+  confirm: AutofillConfirmState
+}
+
+export default function AutofillConfirmDialog({
+  confirm: { isOpen, cancelRef, onClose, onConfirm },
+}: AutofillConfirmDialogProps): JSX.Element {
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader>Autofill rows</AlertDialogHeader>
+          <AlertDialogBody>
+            Autofill will replace all existing rows below. This cannot be
+            undone.
+          </AlertDialogBody>
+          <AlertDialogFooter>
+            <Button
+              colorScheme="neutral"
+              variant="clear"
+              ref={cancelRef}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button onClick={onConfirm} ml={3}>
+              Yes, autofill
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  )
+}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -12,7 +12,9 @@ import { EditorContext } from '@/contexts/Editor'
 
 import MultiCol from '../MultiCol.tsx'
 
+import AutofillConfirmDialog from './AutofillConfirmDialog'
 import RowDivider from './RowDivider'
+import useAutofill from './useAutofill'
 
 export type MultiRowProps = {
   name: string
@@ -26,6 +28,8 @@ export type MultiRowProps = {
   type?: string
   maxRows?: number
   defaultValue?: string | IJSONValue
+  // See IFieldMultiRowMultiCol.autofillable.
+  autofillable?: boolean
   // Optional node rendered beside the "+ And" add-row button (e.g. a wrapper's
   // own controls). Renders even when the add-row button is hidden at maxRows.
   addButtonSuffix?: ReactNode
@@ -49,6 +53,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     type,
     maxRows,
     defaultValue,
+    autofillable,
     addButtonSuffix,
     onRequestRemoveLastRow,
     ...forwardedInputCreatorProps
@@ -72,6 +77,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     fields: rows,
     append,
     remove,
+    replace,
   } = useFieldArray({
     name,
     rules: { required },
@@ -102,6 +108,23 @@ function MultiRow(props: MultiRowProps): JSX.Element {
       shouldValidate: true,
     })
   }, [append, newRowDefaultValue, subFields, setValue, getValues, name])
+
+  const {
+    canAutofill,
+    isLoading: isDynamicDataLoading,
+    onAutofillClick,
+    confirm,
+  } = useAutofill({
+    autofillable,
+    type,
+    subFields,
+    stepId: forwardedInputCreatorProps.stepId,
+    name,
+    newRowDefaultValue,
+    replace,
+    getValues,
+    setValue,
+  })
 
   return (
     // Use Controller's defaultValue to introduce 1 blank row by default. We
@@ -233,8 +256,21 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                   {addRowButtonText ?? 'And'}
                 </Button>
               )}
+              {canAutofill && (
+                <Button
+                  variant="outline"
+                  maxW="fit-content"
+                  isDisabled={isEditorReadOnly}
+                  isLoading={isDynamicDataLoading}
+                  onClick={onAutofillClick}
+                >
+                  <BiPlus /> Autofill
+                </Button>
+              )}
               {addButtonSuffix}
             </Flex>
+
+            {canAutofill && <AutofillConfirmDialog confirm={confirm} />}
           </Flex>
         )
       }}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -2,7 +2,7 @@ import type { IField, IJSONValue } from '@plumber/types'
 
 import { ReactNode, useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
-import { BiPlus, BiTrash } from 'react-icons/bi'
+import { BiListPlus, BiPlus, BiTrash } from 'react-icons/bi'
 import Markdown from 'react-markdown'
 import { Flex } from '@chakra-ui/react'
 import { Button, FormLabel, IconButton } from '@opengovsg/design-system-react'
@@ -112,6 +112,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
   const {
     canAutofill,
     isLoading: isDynamicDataLoading,
+    optionCount,
     onAutofillClick,
     confirm,
   } = useAutofill({
@@ -253,18 +254,21 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                   isDisabled={isEditorReadOnly}
                   maxW="fit-content"
                 >
-                  {addRowButtonText ?? 'And'}
+                  {addRowButtonText ?? 'Add'}
                 </Button>
               )}
               {canAutofill && (
                 <Button
-                  variant="outline"
+                  variant="clear"
+                  leftIcon={<BiListPlus />}
                   maxW="fit-content"
-                  isDisabled={isEditorReadOnly}
+                  isDisabled={
+                    isEditorReadOnly || optionCount == null || optionCount === 0
+                  }
                   isLoading={isDynamicDataLoading}
                   onClick={onAutofillClick}
                 >
-                  <BiPlus /> Autofill
+                  {optionCount != null ? `Add all ${optionCount} fields` : 'Add all'}
                 </Button>
               )}
               {addButtonSuffix}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -254,7 +254,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                   isDisabled={isEditorReadOnly}
                   maxW="fit-content"
                 >
-                  {addRowButtonText ?? 'Add'}
+                  {addRowButtonText ?? 'And'}
                 </Button>
               )}
               {canAutofill && (
@@ -268,7 +268,9 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                   isLoading={isDynamicDataLoading}
                   onClick={onAutofillClick}
                 >
-                  {optionCount != null ? `Add all ${optionCount} fields` : 'Add all'}
+                  {optionCount != null
+                    ? `Add all ${optionCount} fields`
+                    : 'Add all'}
                 </Button>
               )}
               {addButtonSuffix}

--- a/packages/frontend/src/components/MultiRow/useAutofill.ts
+++ b/packages/frontend/src/components/MultiRow/useAutofill.ts
@@ -1,0 +1,135 @@
+import type { IField } from '@plumber/types'
+
+import { RefObject, useCallback, useRef } from 'react'
+import { useDisclosure } from '@chakra-ui/react'
+
+import useDynamicData from '@/hooks/useDynamicData.js'
+
+export type AutofillConfirmState = {
+  isOpen: boolean
+  cancelRef: RefObject<HTMLButtonElement>
+  onClose: () => void
+  onConfirm: () => void
+}
+
+export type UseAutofillResult = {
+  // Whether the "Autofill" button should render at all for this field.
+  canAutofill: boolean
+  isLoading: boolean
+  // Click handler for the "Autofill" button itself: applies immediately if
+  // every row is still empty, otherwise opens the confirm dialog.
+  onAutofillClick: () => void
+  confirm: AutofillConfirmState
+}
+
+type UseAutofillArgs = {
+  // Whether the field schema opted into Autofill (see IFieldMultiRowMultiCol.autofillable).
+  autofillable: boolean | undefined
+  type: string | undefined
+  subFields: IField[]
+  stepId: string | undefined
+  name: string
+  newRowDefaultValue: Record<string, unknown>
+  replace: (rows: Record<string, unknown>[]) => void
+  getValues: (name: string) => unknown
+  setValue: (
+    name: string,
+    value: unknown,
+    opts: { shouldDirty: boolean; shouldValidate: boolean },
+  ) => void
+}
+
+const rowHasValue = (row: Record<string, unknown>) =>
+  Object.entries(row).some(
+    ([key, value]) => key !== 'id' && value != null && value !== '',
+  )
+
+/**
+ * Bulk-populates a multirow-multicol field's rows straight from the
+ * dynamic-data options of its first sub-field (e.g. GatherSG's case field
+ * list), instead of the user adding rows one at a time. Row keys are derived
+ * generically from `subFields` so this works for any multirow-multicol
+ * consumer that opts in via `autofillable`, not just GatherSG.
+ */
+export default function useAutofill({
+  autofillable,
+  type,
+  subFields,
+  stepId,
+  name,
+  newRowDefaultValue,
+  replace,
+  getValues,
+  setValue,
+}: UseAutofillArgs): UseAutofillResult {
+  const canAutofill =
+    !!autofillable &&
+    type === 'multirow-multicol' &&
+    subFields?.[0]?.type === 'dropdown' &&
+    !!subFields[0].source
+
+  const { loading: isLoading, refetch } = useDynamicData(
+    stepId,
+    subFields?.[0],
+    name,
+  )
+
+  const buildAutofillRows = useCallback(
+    (items: { value: string; type?: string }[]) =>
+      items.map((item) => ({
+        ...newRowDefaultValue,
+        [subFields[0].key]: item.value,
+        ...(subFields[1] && item.type ? { [subFields[1].key]: item.type } : {}),
+      })),
+    [newRowDefaultValue, subFields],
+  )
+
+  const applyAutofill = useCallback(async () => {
+    const { data: refetchedData } = await refetch()
+    replace(buildAutofillRows(refetchedData?.getDynamicData ?? []))
+    // A nested useFieldArray's `replace` updates the form value but does not
+    // fire the form's `watch` subject, so subscribers such as the step
+    // validator gating "Check step" never recompute. Re-assert the
+    // already-updated value through `setValue`, which does notify.
+    setValue(name, getValues(name), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [refetch, buildAutofillRows, replace, setValue, getValues, name])
+
+  const {
+    isOpen: isConfirmOpen,
+    onOpen: onConfirmOpen,
+    onClose: onConfirmClose,
+  } = useDisclosure()
+  const confirmCancelRef = useRef<HTMLButtonElement>(null)
+
+  const onAutofillClick = useCallback(() => {
+    if (isLoading) {
+      return
+    }
+    const currentRows = (getValues(name) as Record<string, unknown>[]) ?? []
+    if (currentRows.some(rowHasValue)) {
+      onConfirmOpen()
+      return
+    }
+    applyAutofill()
+  }, [isLoading, getValues, name, onConfirmOpen, applyAutofill])
+
+  const onAutofillConfirm = useCallback(() => {
+    onConfirmClose()
+    applyAutofill()
+  }, [onConfirmClose, applyAutofill])
+
+  return {
+    canAutofill,
+    isLoading,
+    onAutofillClick,
+    confirm: {
+      isOpen: isConfirmOpen,
+      cancelRef: confirmCancelRef,
+      onClose: onConfirmClose,
+      onConfirm: onAutofillConfirm,
+    },
+  }
+}

--- a/packages/frontend/src/components/MultiRow/useAutofill.ts
+++ b/packages/frontend/src/components/MultiRow/useAutofill.ts
@@ -17,7 +17,7 @@ export type UseAutofillResult = {
   canAutofill: boolean
   isLoading: boolean
   // Count of options currently available from subFields[0]'s dynamic-data
-  // source 
+  // source
   optionCount: number | undefined
   // Click handler for the "Autofill" button itself: applies immediately if
   // every row is still empty, otherwise opens the confirm dialog.

--- a/packages/frontend/src/components/MultiRow/useAutofill.ts
+++ b/packages/frontend/src/components/MultiRow/useAutofill.ts
@@ -16,6 +16,9 @@ export type UseAutofillResult = {
   // Whether the "Autofill" button should render at all for this field.
   canAutofill: boolean
   isLoading: boolean
+  // Count of options currently available from subFields[0]'s dynamic-data
+  // source 
+  optionCount: number | undefined
   // Click handler for the "Autofill" button itself: applies immediately if
   // every row is still empty, otherwise opens the confirm dialog.
   onAutofillClick: () => void
@@ -68,11 +71,13 @@ export default function useAutofill({
     subFields?.[0]?.type === 'dropdown' &&
     !!subFields[0].source
 
-  const { loading: isLoading, refetch } = useDynamicData(
-    stepId,
-    subFields?.[0],
-    name,
-  )
+  const {
+    data: dynamicDataOptions,
+    loading: isLoading,
+    refetch,
+  } = useDynamicData(stepId, subFields?.[0], name)
+
+  const optionCount = dynamicDataOptions?.length
 
   const buildAutofillRows = useCallback(
     (items: { value: string; type?: string }[]) =>
@@ -124,6 +129,7 @@ export default function useAutofill({
   return {
     canAutofill,
     isLoading,
+    optionCount,
     onAutofillClick,
     confirm: {
       isOpen: isConfirmOpen,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -487,6 +487,14 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
   addRowButtonText?: string
   subFields: IFieldMultiRowMultiColSubField[]
   maxRows?: number
+  /**
+   * Opt-in for the "Autofill" button, which bulk-replaces rows with one row
+   * per option from subFields[0]'s dynamic-data source. Only sensible when
+   * every option from that source should get its own row (e.g. "set a value
+   * for every field/column") — not for filter/lookup-style fields where a
+   * user picks a handful of specific conditions.
+   */
+  autofillable?: boolean
 }
 
 export interface IFieldMultiRow extends IBaseField {


### PR DESCRIPTION
## TL;DR

Adds an opt-in "Autofill" button to `multirow-multicol` fields that bulk-populates rows from a dropdown sub-field's dynamic-data options, instead of the user adding rows one at a time.

## What changed?

- New `useAutofill` hook (`MultiRow/useAutofill.ts`) owns all the Autofill logic: gating (`canAutofill`), refetching fresh dynamic data on click, building rows generically from `subFields` (not hardcoded to any one app's field/column key names), and replacing existing rows via `replace()` rather than duplicating them on repeat clicks.
- New `AutofillConfirmDialog` component for the "this will replace existing rows" confirmation, shown only when at least one row already has a value.
- `MultiRow/index.tsx` shrank to just wiring the hook's output into JSX (state/logic extracted, not inlined).
- Added `IFieldMultiRowMultiCol.autofillable?: boolean` (`@plumber/types`) as an explicit, default-off opt-in — the button only renders when both `autofillable` is set on the field schema *and* the first sub-field is a dynamic-data-sourced dropdown.
- Enabled `autofillable: true` on the 8 actions where "one row per dynamic-data option, ready to fill in a value" matches how the field is actually used:
  - gathersg create-case / update-case (`caseFields`)
  - tiles create-row / update-row (`rowData`)
  - m365-excel create-table-row / update-table-row (`columnValues` / `columnsToUpdate`)
  - databricks create-row (`rowData`)
  - lettersg create-letter (`letterParams`)
- Deliberately left off the 4 filter/lookup-style fields (tiles find-single-row/find-multiple-rows, m365-excel get-table-row/get-table-rows), where a user builds a handful of targeted conditions rather than wanting one row per table column.

## Tests

- [ ] `npm run -w backend test:unit` passes locally for gathersg, tiles, m365-excel, databricks, lettersg (241 tests, unaffected by this frontend-only change plus the `autofillable` schema additions)
- [ ] `npm run -w frontend lint` / `tsc --noEmit` pass locally
- [ ] Manually open a gathersg Create/Update Case step, select a case type, click Autofill, and confirm rows populate with the correct field name + type per row
- [ ] Manually click Autofill a second time with rows already filled in and confirm the "replace rows" dialog appears before anything is overwritten
- [ ] Manually spot-check Autofill on at least one non-gathersg action (e.g. tiles create-row) to confirm it behaves sensibly there too
- [ ] Manually confirm the Autofill button does *not* appear on tiles find-single-row/find-multiple-rows or m365-excel get-table-row/get-table-rows

## Deploy notes

No migrations, config, or env var changes. Base: #1913 (merge that first). This is the top of the case-fields-schema/email-type/type-mapping/autofill stack (#1914).

## Screenshots

https://github.com/user-attachments/assets/3adba830-e109-4682-a678-414488b5babd

