### PR TITLE
[AI-FORMSG-SETUP-3]: PLU-804: pre-pipe form URL capture + post-pipe key completion

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -418,10 +418,17 @@ export function useChatStream(options: UseChatStreamOptions) {
     parameterLabelsByStepId,
     activeStepId,
     completedStepIds,
+    hasPipe,
+    knownFormSchema,
   } = useMemo(() => {
     const byStepId: Record<string, IJSONObject> = {}
     const labelsByStepId: Record<string, Record<string, string>> = {}
     let latestStepId: string | null = null
+    let pipeSeen = false
+    // Latest successful get_form_schema tool result — the AI SDK streams
+    // tool outputs as message parts, so the form's real title is already
+    // client-side once the LLM fetches the schema.
+    let latestFormSchema: { title: string; formId: string } | null = null
     const completed = new Set<string>()
 
     for (const msg of aiMessages) {
@@ -440,10 +447,31 @@ export function useChatStream(options: UseChatStreamOptions) {
           latestStepId = stepId
         }
         if (part.type === 'data-pipeState') {
+          pipeSeen = true
           for (const step of (part as PipeStatePart).data.steps) {
             if (step.status === 'completed') {
               completed.add(step.id)
             }
+          }
+        }
+        const toolPart = part as {
+          type: string
+          toolName?: string
+          output?: { title?: unknown; formId?: unknown; error?: unknown }
+        }
+        const isFormSchemaResult =
+          toolPart.type === 'tool-get_form_schema' ||
+          (toolPart.type === 'dynamic-tool' &&
+            toolPart.toolName === 'get_form_schema')
+        if (
+          isFormSchemaResult &&
+          typeof toolPart.output?.title === 'string' &&
+          typeof toolPart.output?.formId === 'string' &&
+          !toolPart.output.error
+        ) {
+          latestFormSchema = {
+            title: toolPart.output.title,
+            formId: toolPart.output.formId,
           }
         }
       }
@@ -454,6 +482,8 @@ export function useChatStream(options: UseChatStreamOptions) {
       parameterLabelsByStepId: labelsByStepId,
       activeStepId: latestStepId,
       completedStepIds: completed,
+      hasPipe: pipeSeen,
+      knownFormSchema: latestFormSchema,
     }
   }, [aiMessages])
 
@@ -489,5 +519,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     stepParametersByStepId,
     parameterLabelsByStepId,
     completedStepIds,
+    hasPipe,
+    knownFormSchema,
   }
 }

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -456,13 +456,14 @@ export function useChatStream(options: UseChatStreamOptions) {
         }
         const toolPart = part as {
           type: string
-          toolName?: string
           output?: { title?: unknown; formId?: unknown; error?: unknown }
         }
-        const isFormSchemaResult =
-          toolPart.type === 'tool-get_form_schema' ||
-          (toolPart.type === 'dynamic-tool' &&
-            toolPart.toolName === 'get_form_schema')
+        // get_form_schema is registered via the static tool() helper (not
+        // dynamicTool()), so the AI SDK always streams its result as
+        // tool-get_form_schema — dynamic-tool is reserved for MCP-client
+        // tools (e.g. the GitBook MCP integration) that AI SDK can't type
+        // statically, and never applies to this tool.
+        const isFormSchemaResult = toolPart.type === 'tool-get_form_schema'
         if (
           isFormSchemaResult &&
           typeof toolPart.output?.title === 'string' &&

--- a/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
@@ -30,10 +30,7 @@ import {
 import FileUpload from '@/components/FileUpload'
 import { CREATE_CONNECTION } from '@/graphql/mutations/create-connection'
 import { VERIFY_CONNECTION } from '@/graphql/mutations/verify-connection'
-import {
-  isValidFormUrlInput,
-  normalizeFormUrlInput,
-} from '@/pages/AiBuilder/helpers'
+import { normalizeFormUrlInput } from '@/pages/AiBuilder/helpers'
 
 // Matches the format of a form's private key downloaded from FormSG, same
 // check the editor's DragDropInput uses for the same field.
@@ -158,8 +155,12 @@ export default function AddFormsgConnectionModal({
       return
     }
 
+    // No client-side format gate here — the backend (get_form_schema for
+    // url-only, verifyCredentials for full) is deliberately more lenient
+    // than any regex we could write (protocol-optional, any *.form.gov.sg
+    // path shape) and already surfaces a clear error either way.
     const trimmedUrl = formUrl.trim()
-    if (!isValidFormUrlInput(trimmedUrl)) {
+    if (!trimmedUrl) {
       return
     }
     const normalizedUrl = normalizeFormUrlInput(trimmedUrl)
@@ -241,8 +242,7 @@ export default function AddFormsgConnectionModal({
   const isFormUrlLocked = lockFormUrl && !errorMessage
 
   const isSubmitDisabled =
-    !isValidFormUrlInput(formUrl) ||
-    (variant === 'full' && (!secretKey.trim() || !flowId))
+    !formUrl.trim() || (variant === 'full' && (!secretKey.trim() || !flowId))
 
   return (
     <Modal
@@ -271,7 +271,7 @@ export default function AddFormsgConnectionModal({
               <FormLabel mb={1}>Form URL</FormLabel>
               <Text textStyle="body-2" color="base.content.medium" mb={2}>
                 Click share on your form and copy the link. It should be in the
-                format: https://form.gov.sg/654ab1234abc1a012345f1e0b
+                format: https://form.gov.sg/654ab1234abc1a012345f1e0
               </Text>
               <Input
                 value={formUrl}

--- a/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
@@ -30,7 +30,6 @@ import {
 import FileUpload from '@/components/FileUpload'
 import { CREATE_CONNECTION } from '@/graphql/mutations/create-connection'
 import { VERIFY_CONNECTION } from '@/graphql/mutations/verify-connection'
-import { normalizeFormUrlInput } from '@/pages/AiBuilder/helpers'
 
 // Matches the format of a form's private key downloaded from FormSG, same
 // check the editor's DragDropInput uses for the same field.
@@ -163,10 +162,9 @@ export default function AddFormsgConnectionModal({
     if (!trimmedUrl) {
       return
     }
-    const normalizedUrl = normalizeFormUrlInput(trimmedUrl)
 
     if (variant === 'url-only') {
-      onSubmitUrl(normalizedUrl)
+      onSubmitUrl(trimmedUrl)
       onClose()
       return
     }
@@ -195,7 +193,7 @@ export default function AddFormsgConnectionModal({
           input: {
             key: 'formsg',
             formattedData: {
-              formId: normalizedUrl,
+              formId: trimmedUrl,
               privateKey: trimmedSecretKey,
             },
             flowId,
@@ -215,7 +213,7 @@ export default function AddFormsgConnectionModal({
       const label =
         (verifyData?.verifyConnection?.formattedData?.screenName as
           | string
-          | undefined) ?? normalizedUrl
+          | undefined) ?? trimmedUrl
 
       onSuccess(label, connectionId)
       onClose()

--- a/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
@@ -235,6 +235,11 @@ export default function AddFormsgConnectionModal({
       ? 'Add your Form Secret Key'
       : 'Add new form'
 
+  // The URL stays locked only while it hasn't failed yet — once the backend
+  // rejects it (e.g. "Form does not exist"), the user needs to be able to
+  // correct it rather than being stuck resubmitting the same bad URL.
+  const isFormUrlLocked = lockFormUrl && !errorMessage
+
   const isSubmitDisabled =
     !isValidFormUrlInput(formUrl) ||
     (variant === 'full' && (!secretKey.trim() || !flowId))
@@ -273,7 +278,7 @@ export default function AddFormsgConnectionModal({
                 onChange={(e) => setFormUrl(e.target.value)}
                 placeholder="https://form.gov.sg/…"
                 autoComplete="url"
-                isDisabled={inProgress || lockFormUrl}
+                isDisabled={inProgress || isFormUrlLocked}
               />
             </FormControl>
 

--- a/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
@@ -30,6 +30,10 @@ import {
 import FileUpload from '@/components/FileUpload'
 import { CREATE_CONNECTION } from '@/graphql/mutations/create-connection'
 import { VERIFY_CONNECTION } from '@/graphql/mutations/verify-connection'
+import {
+  isValidFormUrlInput,
+  normalizeFormUrlInput,
+} from '@/pages/AiBuilder/helpers'
 
 // Matches the format of a form's private key downloaded from FormSG, same
 // check the editor's DragDropInput uses for the same field.
@@ -38,19 +42,32 @@ const SECRET_KEY_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
 interface AddFormsgConnectionModalProps {
   isOpen: boolean
   // A connection can only be created once the pipe exists (see
-  // AiBuilder/index.tsx's onAddConnection gating) — this is that pipe's id.
+  // AiBuilder/index.tsx's onAddConnection/onConnectForm gating) — this is
+  // that pipe's id. Only meaningful for the 'full' variant, the only one
+  // that calls createConnection.
   flowId?: string
+  // 'url-only': pre-pipe "Connect your form" pill — collects just the URL,
+  // no secret key, no connection row (see onSubmitUrl).
+  // 'full': URL + secret key, creates a real connection (see onSuccess).
+  variant: 'url-only' | 'full'
   prefillFormUrl?: string
+  // The URL is already known from the conversation and hard-locked to that
+  // form — only reachable for the 'full' variant's key-completion path.
+  lockFormUrl?: boolean
   onClose: () => void
   onSuccess: (connectionLabel: string, connectionId: string) => void
+  onSubmitUrl: (formUrl: string) => void
 }
 
 export default function AddFormsgConnectionModal({
   isOpen,
   flowId,
+  variant,
   prefillFormUrl,
+  lockFormUrl,
   onClose,
   onSuccess,
+  onSubmitUrl,
 }: AddFormsgConnectionModalProps) {
   const [formUrl, setFormUrl] = useState('')
   const [secretKey, setSecretKey] = useState('')
@@ -137,8 +154,24 @@ export default function AddFormsgConnectionModal({
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (inProgress) {
+      return
+    }
+
+    const trimmedUrl = formUrl.trim()
+    if (!isValidFormUrlInput(trimmedUrl)) {
+      return
+    }
+    const normalizedUrl = normalizeFormUrlInput(trimmedUrl)
+
+    if (variant === 'url-only') {
+      onSubmitUrl(normalizedUrl)
+      onClose()
+      return
+    }
+
     const trimmedSecretKey = secretKey.trim()
-    if (!formUrl.trim() || !trimmedSecretKey || !flowId || inProgress) {
+    if (!trimmedSecretKey || !flowId) {
       return
     }
 
@@ -161,7 +194,7 @@ export default function AddFormsgConnectionModal({
           input: {
             key: 'formsg',
             formattedData: {
-              formId: formUrl.trim(),
+              formId: normalizedUrl,
               privateKey: trimmedSecretKey,
             },
             flowId,
@@ -181,7 +214,7 @@ export default function AddFormsgConnectionModal({
       const label =
         (verifyData?.verifyConnection?.formattedData?.screenName as
           | string
-          | undefined) ?? formUrl.trim()
+          | undefined) ?? normalizedUrl
 
       onSuccess(label, connectionId)
       onClose()
@@ -194,6 +227,17 @@ export default function AddFormsgConnectionModal({
       setInProgress(false)
     }
   }
+
+  const modalTitle =
+    variant === 'url-only'
+      ? 'Share your form'
+      : lockFormUrl
+      ? 'Add your Form Secret Key'
+      : 'Add new form'
+
+  const isSubmitDisabled =
+    !isValidFormUrlInput(formUrl) ||
+    (variant === 'full' && (!secretKey.trim() || !flowId))
 
   return (
     <Modal
@@ -208,7 +252,7 @@ export default function AddFormsgConnectionModal({
       <ModalContent borderRadius="lg">
         <form onSubmit={handleSubmit}>
           <ModalHeader>
-            Add new form
+            {modalTitle}
             <ModalCloseButton isDisabled={inProgress} />
           </ModalHeader>
           <ModalBody display="flex" flexDirection="column" gap={4}>
@@ -229,68 +273,70 @@ export default function AddFormsgConnectionModal({
                 onChange={(e) => setFormUrl(e.target.value)}
                 placeholder="https://form.gov.sg/…"
                 autoComplete="url"
-                isDisabled={inProgress}
+                isDisabled={inProgress || lockFormUrl}
               />
             </FormControl>
 
-            <FormControl isInvalid={!!secretKeyError}>
-              <RequiredFormLabel isRequired mb={1}>
-                Form Secret Key
-              </RequiredFormLabel>
-              <Text textStyle="body-2" color="base.content.medium" mb={2}>
-                This is the key you downloaded/saved when you created the form
-              </Text>
-              <Stack spacing="0.5rem" direction="row">
-                <Input
-                  type="password"
-                  value={secretKey}
-                  onChange={(e) => {
-                    setSecretKeyError(null)
-                    setSecretKey(e.target.value)
-                  }}
-                  {...(dragging
-                    ? {
-                        py: 12,
-                        backgroundColor: 'primary.50',
-                        borderColor: 'primary.500',
-                        borderWidth: 2,
-                        borderStyle: 'dashed',
-                        _focusVisible: {
-                          boxShadow: 'none',
-                        },
-                      }
-                    : undefined)}
-                  onDragEnter={inProgress ? undefined : handleDragEnter}
-                  onDragLeave={inProgress ? undefined : handleDragLeave}
-                  onDragOver={inProgress ? undefined : handleDragOver}
-                  onDrop={inProgress ? undefined : handleDrop}
-                  placeholder={
-                    dragging
-                      ? 'Drop your file here'
-                      : 'Enter or drop your Secret Key here to continue'
-                  }
-                  autoComplete="off"
-                  isDisabled={inProgress}
-                  transition="padding 0.2s ease-out"
-                />
-                <FileUpload
-                  accept="text/plain"
-                  processFile={processSecretKeyFile}
-                  disabled={inProgress}
-                />
-              </Stack>
-              {secretKeyError && (
-                <FormErrorMessage>{secretKeyError}</FormErrorMessage>
-              )}
-            </FormControl>
+            {variant === 'full' && (
+              <FormControl isInvalid={!!secretKeyError}>
+                <RequiredFormLabel isRequired mb={1}>
+                  Form Secret Key
+                </RequiredFormLabel>
+                <Text textStyle="body-2" color="base.content.medium" mb={2}>
+                  This is the key you downloaded/saved when you created the form
+                </Text>
+                <Stack spacing="0.5rem" direction="row">
+                  <Input
+                    type="password"
+                    value={secretKey}
+                    onChange={(e) => {
+                      setSecretKeyError(null)
+                      setSecretKey(e.target.value)
+                    }}
+                    {...(dragging
+                      ? {
+                          py: 12,
+                          backgroundColor: 'primary.50',
+                          borderColor: 'primary.500',
+                          borderWidth: 2,
+                          borderStyle: 'dashed',
+                          _focusVisible: {
+                            boxShadow: 'none',
+                          },
+                        }
+                      : undefined)}
+                    onDragEnter={inProgress ? undefined : handleDragEnter}
+                    onDragLeave={inProgress ? undefined : handleDragLeave}
+                    onDragOver={inProgress ? undefined : handleDragOver}
+                    onDrop={inProgress ? undefined : handleDrop}
+                    placeholder={
+                      dragging
+                        ? 'Drop your file here'
+                        : 'Enter or drop your Secret Key here to continue'
+                    }
+                    autoComplete="off"
+                    isDisabled={inProgress}
+                    transition="padding 0.2s ease-out"
+                  />
+                  <FileUpload
+                    accept="text/plain"
+                    processFile={processSecretKeyFile}
+                    disabled={inProgress}
+                  />
+                </Stack>
+                {secretKeyError && (
+                  <FormErrorMessage>{secretKeyError}</FormErrorMessage>
+                )}
+              </FormControl>
+            )}
           </ModalBody>
           <ModalFooter>
             <Button
               type="submit"
               isLoading={inProgress}
-              isDisabled={!formUrl.trim() || !secretKey.trim() || !flowId}
+              isDisabled={isSubmitDisabled}
             >
-              Connect
+              {variant === 'url-only' ? 'Share' : 'Connect'}
             </Button>
           </ModalFooter>
         </form>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -32,6 +32,13 @@ interface DynamicPickerProps {
   onSelect: (name: string, value: string) => void
   onSkip: () => void
   onAddConnection?: () => void
+  /**
+   * FormSG only: a form URL already shared in the conversation. When set,
+   * the picker skips the connections list entirely and shows a single
+   * "finish connecting" card — the user just adds their secret key for the
+   * form they already chose.
+   */
+  knownFormUrl?: string
   cancelStream: () => void
 }
 
@@ -44,6 +51,7 @@ export default function DynamicPicker({
   onSelect,
   onSkip,
   onAddConnection,
+  knownFormUrl,
   cancelStream,
 }: DynamicPickerProps) {
   const [options, setOptions] = useState<DynamicPickerOption[]>([])
@@ -59,7 +67,18 @@ export default function DynamicPicker({
 
   const isAppKeyMode = Boolean(appKey)
 
+  // Forced key-completion mode: the form is already known from the
+  // conversation, so listing other connections would only invite a mismatch.
+  const isKnownFormMode = Boolean(
+    isAppKeyMode && appKey === 'formsg' && knownFormUrl && onAddConnection,
+  )
+
   useEffect(() => {
+    if (isKnownFormMode) {
+      setIsLoading(false)
+      return
+    }
+
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
@@ -111,7 +130,7 @@ export default function DynamicPicker({
       })
 
     return () => controller.abort()
-  }, [stepId, dynamicKey, appKey, retryCount]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [stepId, dynamicKey, appKey, retryCount, isKnownFormMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const filtered = query
     ? options.filter((o) => o.name.toLowerCase().includes(query.toLowerCase()))
@@ -179,7 +198,27 @@ export default function DynamicPicker({
         )}
 
         <Flex direction="column" gap={2} maxH="240px" overflowY="auto">
-          {isLoading ? (
+          {isKnownFormMode ? (
+            <Flex
+              direction="column"
+              align="flex-start"
+              gap={3}
+              bg="gray.50"
+              borderRadius="lg"
+              p={4}
+            >
+              <Text textStyle="body-2" color="gray.700">
+                We already have your form&apos;s URL — add your{' '}
+                <Text as="span" fontWeight="medium">
+                  Form Secret Key
+                </Text>{' '}
+                to connect it.
+              </Text>
+              <Button isDisabled={isStreaming} onClick={onAddConnection}>
+                Connect your form
+              </Button>
+            </Flex>
+          ) : isLoading ? (
             <Flex justify="center" py={4}>
               <Spinner size="sm" color="primary.500" />
             </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -8,7 +8,15 @@ import {
 } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
-import { Box, Flex, Icon, Textarea } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  Icon,
+  Image,
+  Text,
+  Textarea,
+  Tooltip,
+} from '@chakra-ui/react'
 
 import {
   type ClarificationQuestion,
@@ -29,6 +37,16 @@ interface PromptInputProps {
   clarification?: ClarificationQuestion[]
   dynamicPicker?: DynamicPickerPart['data']
   onAddConnection?: (context: { question: string }) => void
+  /** Form URL already shared in the conversation (drives the picker's forced key-completion card). */
+  knownFormUrl?: string
+  /** Opens the Add-new-form modal (empty-state "Connect your form" entry). */
+  onConnectForm?: () => void
+  /**
+   * Display-only chip anchoring the conversation's form to the composer —
+   * the connected form's title, or the shared URL (isConnected: false)
+   * before a secret key has been added.
+   */
+  attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
 export default function PromptInput({
@@ -41,6 +59,9 @@ export default function PromptInput({
   clarification,
   dynamicPicker,
   onAddConnection,
+  knownFormUrl,
+  onConnectForm,
+  attachedForm,
 }: PromptInputProps) {
   const [input, setInput] = useState<string>(initialValue)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -93,6 +114,22 @@ export default function PromptInput({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // The resize handler above only fires on typed input, but a long
+  // placeholder wraps onto multiple lines too — without this, the fixed
+  // single-row height overflows and shows a spurious scrollbar. Measure the
+  // placeholder's wrapped height the same way (swap it into the DOM value
+  // just for the measurement) whenever the box is empty.
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el || input) {
+      return
+    }
+    const original = el.value
+    el.value = placeholder
+    handleResize({ currentTarget: el } as FormEvent<HTMLTextAreaElement>)
+    el.value = original
+  }, [placeholder, input])
 
   const handleAnswer = (answer: string) => {
     if (isStreaming || !clarification) {
@@ -159,6 +196,7 @@ export default function PromptInput({
             ? () => onAddConnection({ question: dynamicPicker.question })
             : undefined
         }
+        knownFormUrl={knownFormUrl}
         cancelStream={cancelStream}
       />
     )
@@ -181,11 +219,12 @@ export default function PromptInput({
     )
   }
 
+  const showChipsRow = Boolean(onConnectForm || attachedForm)
+
   return (
     <Box w="full" maxW="4xl">
       <Flex
-        direction="row"
-        align="stretch"
+        direction="column"
         bg="white"
         border="1px"
         borderColor="gray.200"
@@ -196,71 +235,142 @@ export default function PromptInput({
         minH={showIdeas ? '120px' : '50px'}
         height="auto"
       >
-        <Textarea
-          ref={textareaRef}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyPress}
-          placeholder={placeholder}
-          w="full"
-          resize="none"
-          border="none"
-          bg="transparent"
-          p={3}
-          color="gray.900"
-          _placeholder={{ color: 'gray.500' }}
-          _focus={{ outline: 'none', boxShadow: 'none' }}
-          fontSize="base"
-          lineHeight="6"
-          maxH="calc(40vh - 100px)"
-          rows={1}
-          overflowY="auto"
-          sx={{
-            '&::-webkit-scrollbar': {
-              width: '8px',
-            },
-            '&::-webkit-scrollbar-track': {
-              background: 'transparent',
-            },
-            '&::-webkit-scrollbar-thumb': {
-              backgroundColor: 'rgba(0, 0, 0, 0.2)',
-              borderRadius: '4px',
-            },
-            '&::-webkit-scrollbar-thumb:hover': {
-              backgroundColor: 'rgba(0, 0, 0, 0.3)',
-            },
-          }}
-          onInput={handleResize}
-          onFocus={(e) => {
-            // prevent iOS Safari from zooming in on input focus
-            e.currentTarget.style.fontSize = '16px'
-          }}
-        />
+        <Flex direction="row" align="stretch" flex={1}>
+          <Textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder={placeholder}
+            w="full"
+            resize="none"
+            border="none"
+            bg="transparent"
+            p={3}
+            color="gray.900"
+            _placeholder={{ color: 'gray.500' }}
+            _focus={{ outline: 'none', boxShadow: 'none' }}
+            fontSize="base"
+            lineHeight="6"
+            maxH="calc(40vh - 100px)"
+            rows={1}
+            overflowY="auto"
+            sx={{
+              '&::-webkit-scrollbar': {
+                width: '8px',
+              },
+              '&::-webkit-scrollbar-track': {
+                background: 'transparent',
+              },
+              '&::-webkit-scrollbar-thumb': {
+                backgroundColor: 'rgba(0, 0, 0, 0.2)',
+                borderRadius: '4px',
+              },
+              '&::-webkit-scrollbar-thumb:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.3)',
+              },
+            }}
+            onInput={handleResize}
+            onFocus={(e) => {
+              // prevent iOS Safari from zooming in on input focus
+              e.currentTarget.style.fontSize = '16px'
+            }}
+          />
 
-        <Flex justify="end" align="flex-end" p={3}>
-          {isStreaming ? (
-            <Icon
-              as={FaCircleStop}
-              fontSize="24px"
-              color="red.500"
-              cursor="pointer"
-              onClick={cancelStream}
-              _hover={{ color: 'red.600' }}
-            />
-          ) : (
-            <Icon
-              as={FaArrowCircleUp}
-              fontSize="24px"
-              color={
-                input?.trim()
-                  ? 'primary.500'
-                  : 'interaction.support.disabled-content'
-              }
-              onClick={handleSubmit}
-              cursor={input?.trim() ? 'pointer' : 'default'}
-            />
-          )}
+          <Flex justify="end" align="flex-end" p={3}>
+            {isStreaming ? (
+              <Icon
+                as={FaCircleStop}
+                fontSize="24px"
+                color="red.500"
+                cursor="pointer"
+                onClick={cancelStream}
+                _hover={{ color: 'red.600' }}
+              />
+            ) : (
+              <Icon
+                as={FaArrowCircleUp}
+                fontSize="24px"
+                color={
+                  input?.trim()
+                    ? 'primary.500'
+                    : 'interaction.support.disabled-content'
+                }
+                onClick={handleSubmit}
+                cursor={input?.trim() ? 'pointer' : 'default'}
+              />
+            )}
+          </Flex>
         </Flex>
+
+        {showChipsRow && (
+          <Flex px={2} pb={1} pt={1} align="center" gap={2}>
+            {attachedForm ? (
+              <Flex
+                align="center"
+                gap={1.5}
+                bg="gray.50"
+                borderRadius="full"
+                px={2.5}
+                py={1}
+                maxW="full"
+              >
+                <Image
+                  src="/apps/formsg/assets/favicon.svg"
+                  boxSize="14px"
+                  alt="FormSG"
+                />
+                <Text textStyle="caption-1" noOfLines={1} color="gray.700">
+                  {attachedForm.label}
+                </Text>
+                {attachedForm.isConnected === false && (
+                  <Text
+                    textStyle="caption-1"
+                    color="gray.400"
+                    flexShrink={0}
+                    whiteSpace="nowrap"
+                  >
+                    · not connected
+                  </Text>
+                )}
+              </Flex>
+            ) : onConnectForm ? (
+              <Tooltip
+                label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
+                hasArrow
+                placement="top-start"
+              >
+                <Flex display="inline-flex">
+                  <Box
+                    as="button"
+                    type="button"
+                    display="inline-flex"
+                    alignItems="center"
+                    gap={1.5}
+                    border="1px"
+                    borderColor="gray.200"
+                    borderRadius="full"
+                    color="gray.700"
+                    fontWeight="medium"
+                    fontSize="xs"
+                    px={2.5}
+                    py={1}
+                    opacity={isStreaming ? 0.5 : 1}
+                    cursor={isStreaming ? 'not-allowed' : 'pointer'}
+                    onClick={isStreaming ? undefined : onConnectForm}
+                  >
+                    <Image
+                      src="/apps/formsg/assets/favicon.svg"
+                      boxSize="14px"
+                      alt=""
+                    />
+                    Connect your form
+                  </Box>
+                </Flex>
+              </Tooltip>
+            ) : null}
+          </Flex>
+        )}
       </Flex>
 
       {showIdeas && (

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -49,6 +49,44 @@ interface PromptInputProps {
   attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
+// Display-only chip anchoring the conversation's form to the composer.
+function FormChip({
+  form,
+}: {
+  form: { label: string; isConnected?: boolean }
+}) {
+  return (
+    <Flex
+      align="center"
+      gap={1.5}
+      bg="gray.50"
+      borderRadius="full"
+      px={2.5}
+      py={1}
+      maxW="full"
+    >
+      <Image
+        src="/apps/formsg/assets/favicon.svg"
+        boxSize="14px"
+        alt="FormSG"
+      />
+      <Text textStyle="caption-1" noOfLines={1} color="gray.700">
+        {form.label}
+      </Text>
+      {form.isConnected === false && (
+        <Text
+          textStyle="caption-1"
+          color="gray.400"
+          flexShrink={0}
+          whiteSpace="nowrap"
+        >
+          · not connected
+        </Text>
+      )}
+    </Flex>
+  )
+}
+
 export default function PromptInput({
   isStreaming,
   showIdeas = false,
@@ -305,35 +343,8 @@ export default function PromptInput({
 
         {showChipsRow && (
           <Flex px={2} pb={1} pt={1} align="center" gap={2}>
-            {attachedForm ? (
-              <Flex
-                align="center"
-                gap={1.5}
-                bg="gray.50"
-                borderRadius="full"
-                px={2.5}
-                py={1}
-                maxW="full"
-              >
-                <Image
-                  src="/apps/formsg/assets/favicon.svg"
-                  boxSize="14px"
-                  alt="FormSG"
-                />
-                <Text textStyle="caption-1" noOfLines={1} color="gray.700">
-                  {attachedForm.label}
-                </Text>
-                {attachedForm.isConnected === false && (
-                  <Text
-                    textStyle="caption-1"
-                    color="gray.400"
-                    flexShrink={0}
-                    whiteSpace="nowrap"
-                  >
-                    · not connected
-                  </Text>
-                )}
-              </Flex>
+            {attachedForm?.isConnected ? (
+              <FormChip form={attachedForm} />
             ) : onConnectForm ? (
               <Tooltip
                 label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
@@ -368,6 +379,11 @@ export default function PromptInput({
                   </Box>
                 </Flex>
               </Tooltip>
+            ) : attachedForm ? (
+              // Dead-end fallback: a URL is known but not connected, and
+              // there's no trigger left to retry through (e.g. post-pipe,
+              // before the LLM's connection picker has fired).
+              <FormChip form={attachedForm} />
             ) : null}
           </Flex>
         )}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -26,6 +26,8 @@ interface ChatInterfaceProps {
   onAddConnection?: (context: { question: string }) => void
   knownFormUrl?: string
   onConnectForm?: () => void
+  /** Resets any form-connection state that lives outside useChatStream's own reset. */
+  onNewChat?: () => void
   attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
@@ -42,6 +44,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     onAddConnection,
     knownFormUrl,
     onConnectForm,
+    onNewChat,
     attachedForm,
   } = props
   const navigate = useNavigate()
@@ -65,6 +68,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   const handleNewChat = useCallback(() => {
     cancelStream()
     resetChat()
+    onNewChat?.()
     setIsDrawerOpen(false)
 
     // Extract continuation prompt from the last assistant message (between <code> tags)
@@ -87,6 +91,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   }, [
     cancelStream,
     resetChat,
+    onNewChat,
     setIsDrawerOpen,
     setChatState,
     navigate,

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -204,6 +204,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   dynamicPicker={activeDynamicPicker}
                   onAddConnection={onAddConnection}
                   knownFormUrl={knownFormUrl}
+                  onConnectForm={onConnectForm}
                   attachedForm={attachedForm}
                 />
               )}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -24,6 +24,9 @@ interface ChatInterfaceProps {
   resetChat: () => void
   hasReachedLimit: boolean
   onAddConnection?: (context: { question: string }) => void
+  knownFormUrl?: string
+  onConnectForm?: () => void
+  attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
@@ -37,6 +40,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat,
     hasReachedLimit,
     onAddConnection,
+    knownFormUrl,
+    onConnectForm,
+    attachedForm,
   } = props
   const navigate = useNavigate()
   const location = useLocation()
@@ -134,6 +140,8 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             placeholder={
               PLACEHOLDER_MESSAGES[Date.now() % PLACEHOLDER_MESSAGES.length]
             }
+            onConnectForm={onConnectForm}
+            attachedForm={attachedForm}
           />
         </Flex>
       </Flex>
@@ -195,6 +203,8 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   clarification={activeClarification}
                   dynamicPicker={activeDynamicPicker}
                   onAddConnection={onAddConnection}
+                  knownFormUrl={knownFormUrl}
+                  attachedForm={attachedForm}
                 />
               )}
               {!isMobile && (

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -2,7 +2,10 @@ import { memo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
-import { prepareAiText } from '@/pages/AiBuilder/helpers'
+import {
+  formatUserMessageForDisplay,
+  prepareAiText,
+} from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import ChatMessageToolbar from './ChatMessageToolbar'
@@ -36,7 +39,7 @@ const AiMessage = memo(
 AiMessage.displayName = 'AiMessage'
 
 const UserMessage = memo(({ message }: ChatMessageProps) => {
-  const displayText = message.text.replace(/ \(id: [^)]+\)$/gm, '')
+  const displayText = formatUserMessageForDisplay(message.text)
   return (
     <Flex justify="flex-end">
       <Box

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -24,6 +24,60 @@ export const normalizeMarkdownHeadings = (text: string): string =>
 export const prepareAiText = (text: string): string =>
   normalizeMarkdownHeadings(stripHtmlComments(text))
 
+// Sent when the user shares their form URL (url-only modal) without
+// connecting it — the LLM's URL-first intake branch picks the URL up and
+// fetches the public schema.
+export const buildUrlSharedMessage = (formUrl: string): string =>
+  `Here's my form: ${formUrl}.`
+
+export const buildUrlSharedKickoffMessage = (formUrl: string): string =>
+  `${buildUrlSharedMessage(formUrl)} Suggest workflows I can build with it.`
+
+// Accepts a FormSG share/admin URL in any supported environment, or a bare
+// 24-hex-char form ID (both shapes work with get_form_schema).
+export const isValidFormUrlInput = (input: string): boolean => {
+  const trimmed = input.trim()
+  return (
+    /^[a-f0-9]{24}$/i.test(trimmed) ||
+    /^https:\/\/(?:[a-z0-9-]+\.)?form\.gov\.sg\/(?:[a-zA-Z0-9/]*\/)?[a-f0-9]{24}\/?$/i.test(
+      trimmed,
+    )
+  )
+}
+
+// Bare 24-hex form IDs become a full prod share URL so everything downstream
+// (extractLastFormUrl, the forced key card, modal prefill) sees one shape.
+export const normalizeFormUrlInput = (input: string): string => {
+  const trimmed = input.trim()
+  return /^[a-f0-9]{24}$/i.test(trimmed)
+    ? `https://form.gov.sg/${trimmed}`
+    : trimmed
+}
+
+// Compact display label for a shared-but-not-connected form URL, e.g.
+// "form.gov.sg/654ab1…f1e0" — used for the composer chip before the real
+// form title is known (which requires a connection).
+export const formatFormUrlLabel = (formUrl: string): string =>
+  formUrl
+    .replace(/^https:\/\//i, '')
+    .replace(/([a-f0-9]{6})[a-f0-9]{14}([a-f0-9]{4})/i, '$1…$2')
+
+// Pull the 24-hex-char form ID out of a FormSG connection screenName.
+export const extractFormIdFromLabel = (label: string): string | null =>
+  label.match(/[a-f0-9]{24}/i)?.[0] ?? null
+
+// FormSG connection screenNames look like "[STAGING] [MRF] <24-hex-form-id> -
+// <form title>". Drop the form-id segment for display; keep any env/MRF
+// prefixes since they are informative.
+export const stripFormIdPrefix = (label: string): string =>
+  label.replace(/^((?:\[[A-Z]+\] )*)[a-f0-9]{24} - /i, '$1')
+
+// User messages are displayed verbatim except for machine detail: picker
+// answers carry "(id: …)" / "(id: …, form id: …)" suffixes that are
+// stripped from display.
+export const formatUserMessageForDisplay = (text: string): string =>
+  text.replace(/ \(id: [a-f0-9-]+(?:, form id: [a-f0-9]+)?\)/g, '').trim()
+
 // Matches FormSG share links across environments (form.gov.sg,
 // staging.form.gov.sg, …) ending in a 24-hex-char form ID.
 const FORM_URL_REGEX =

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -33,18 +33,6 @@ export const buildUrlSharedMessage = (formUrl: string): string =>
 export const buildUrlSharedKickoffMessage = (formUrl: string): string =>
   `${buildUrlSharedMessage(formUrl)} Suggest workflows I can build with it.`
 
-// Accepts a FormSG share/admin URL in any supported environment, or a bare
-// 24-hex-char form ID (both shapes work with get_form_schema).
-export const isValidFormUrlInput = (input: string): boolean => {
-  const trimmed = input.trim()
-  return (
-    /^[a-f0-9]{24}$/i.test(trimmed) ||
-    /^https:\/\/(?:[a-z0-9-]+\.)?form\.gov\.sg\/(?:[a-zA-Z0-9/]*\/)?[a-f0-9]{24}\/?$/i.test(
-      trimmed,
-    )
-  )
-}
-
 // Bare 24-hex form IDs become a full prod share URL so everything downstream
 // (extractLastFormUrl, the forced key card, modal prefill) sees one shape.
 export const normalizeFormUrlInput = (input: string): string => {

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -33,15 +33,6 @@ export const buildUrlSharedMessage = (formUrl: string): string =>
 export const buildUrlSharedKickoffMessage = (formUrl: string): string =>
   `${buildUrlSharedMessage(formUrl)} Suggest workflows I can build with it.`
 
-// Bare 24-hex form IDs become a full prod share URL so everything downstream
-// (extractLastFormUrl, the forced key card, modal prefill) sees one shape.
-export const normalizeFormUrlInput = (input: string): string => {
-  const trimmed = input.trim()
-  return /^[a-f0-9]{24}$/i.test(trimmed)
-    ? `https://form.gov.sg/${trimmed}`
-    : trimmed
-}
-
 // Compact display label for a shared-but-not-connected form URL, e.g.
 // "form.gov.sg/654ab1…f1e0" — used for the composer chip before the real
 // form title is known (which requires a connection).

--- a/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
@@ -6,7 +6,6 @@ import {
   extractFormIdFromLabel,
   formatFormUrlLabel,
   formatUserMessageForDisplay,
-  normalizeFormUrlInput,
   stripFormIdPrefix,
 } from '../helpers'
 
@@ -26,22 +25,6 @@ describe('buildUrlSharedMessage', () => {
       "Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0. " +
         'Suggest workflows I can build with it.',
     )
-  })
-})
-
-describe('normalizeFormUrlInput', () => {
-  it('expands a bare form id into a prod share URL', () => {
-    expect(normalizeFormUrlInput('  654ab1234abc1a012345f1e0 ')).toBe(
-      'https://form.gov.sg/654ab1234abc1a012345f1e0',
-    )
-  })
-
-  it('leaves full URLs untouched', () => {
-    expect(
-      normalizeFormUrlInput(
-        'https://staging.form.gov.sg/654ab1234abc1a012345f1e0',
-      ),
-    ).toBe('https://staging.form.gov.sg/654ab1234abc1a012345f1e0')
   })
 })
 

--- a/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildUrlSharedKickoffMessage,
+  buildUrlSharedMessage,
+  extractFormIdFromLabel,
+  formatFormUrlLabel,
+  formatUserMessageForDisplay,
+  isValidFormUrlInput,
+  normalizeFormUrlInput,
+  stripFormIdPrefix,
+} from '../helpers'
+
+describe('buildUrlSharedMessage', () => {
+  it('shares the url plainly mid-conversation', () => {
+    expect(
+      buildUrlSharedMessage('https://form.gov.sg/654ab1234abc1a012345f1e0'),
+    ).toBe("Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0.")
+  })
+
+  it('asks for suggestions as the first message', () => {
+    expect(
+      buildUrlSharedKickoffMessage(
+        'https://form.gov.sg/654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      "Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0. " +
+        'Suggest workflows I can build with it.',
+    )
+  })
+})
+
+describe('isValidFormUrlInput', () => {
+  it.each([
+    'https://form.gov.sg/654ab1234abc1a012345f1e0',
+    'https://form.gov.sg/654ab1234abc1a012345f1e0/',
+    'https://staging.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
+    '654ab1234abc1a012345f1e0',
+    '  https://form.gov.sg/654ab1234abc1a012345f1e0  ',
+  ])('accepts %s', (input) => {
+    expect(isValidFormUrlInput(input)).toBe(true)
+  })
+
+  it.each([
+    'https://example.com/654ab1234abc1a012345f1e0',
+    'https://form.gov.sg/not-a-form-id',
+    'my form is https://form.gov.sg/654ab1234abc1a012345f1e0',
+    'abc123',
+    '',
+  ])('rejects %s', (input) => {
+    expect(isValidFormUrlInput(input)).toBe(false)
+  })
+})
+
+describe('normalizeFormUrlInput', () => {
+  it('expands a bare form id into a prod share URL', () => {
+    expect(normalizeFormUrlInput('  654ab1234abc1a012345f1e0 ')).toBe(
+      'https://form.gov.sg/654ab1234abc1a012345f1e0',
+    )
+  })
+
+  it('leaves full URLs untouched', () => {
+    expect(
+      normalizeFormUrlInput(
+        'https://staging.form.gov.sg/654ab1234abc1a012345f1e0',
+      ),
+    ).toBe('https://staging.form.gov.sg/654ab1234abc1a012345f1e0')
+  })
+})
+
+describe('formatFormUrlLabel', () => {
+  it('drops the protocol and shortens the form id', () => {
+    expect(
+      formatFormUrlLabel('https://form.gov.sg/654ab1234abc1a012345f1e0'),
+    ).toBe('form.gov.sg/654ab1…f1e0')
+  })
+})
+
+describe('extractFormIdFromLabel', () => {
+  it('pulls the form id out of a screenName', () => {
+    expect(
+      extractFormIdFromLabel(
+        '654ab1234abc1a012345f1e0 - Workshop Registration',
+      ),
+    ).toBe('654ab1234abc1a012345f1e0')
+  })
+
+  it('returns null when no form id is present', () => {
+    expect(extractFormIdFromLabel('My Custom Label')).toBeNull()
+  })
+})
+
+describe('stripFormIdPrefix', () => {
+  it('drops the form-id segment from a screenName', () => {
+    expect(
+      stripFormIdPrefix('654ab1234abc1a012345f1e0 - Workshop Registration'),
+    ).toBe('Workshop Registration')
+  })
+
+  it('keeps env/MRF prefixes', () => {
+    expect(
+      stripFormIdPrefix(
+        '[STAGING] [MRF] 654ab1234abc1a012345f1e0 - Workshop Registration',
+      ),
+    ).toBe('[STAGING] [MRF] Workshop Registration')
+  })
+
+  it('returns labels without a form-id prefix unchanged', () => {
+    expect(stripFormIdPrefix('My Custom Label')).toBe('My Custom Label')
+  })
+})
+
+describe('formatUserMessageForDisplay', () => {
+  it('strips picker id suffixes', () => {
+    expect(
+      formatUserMessageForDisplay(
+        'Q: Which form?\nA: My Form (id: 3f2c8e10-1234-5678-9abc-def012345678)',
+      ),
+    ).toBe('Q: Which form?\nA: My Form')
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/formUrlHelpers.test.ts
@@ -6,7 +6,6 @@ import {
   extractFormIdFromLabel,
   formatFormUrlLabel,
   formatUserMessageForDisplay,
-  isValidFormUrlInput,
   normalizeFormUrlInput,
   stripFormIdPrefix,
 } from '../helpers'
@@ -27,28 +26,6 @@ describe('buildUrlSharedMessage', () => {
       "Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0. " +
         'Suggest workflows I can build with it.',
     )
-  })
-})
-
-describe('isValidFormUrlInput', () => {
-  it.each([
-    'https://form.gov.sg/654ab1234abc1a012345f1e0',
-    'https://form.gov.sg/654ab1234abc1a012345f1e0/',
-    'https://staging.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
-    '654ab1234abc1a012345f1e0',
-    '  https://form.gov.sg/654ab1234abc1a012345f1e0  ',
-  ])('accepts %s', (input) => {
-    expect(isValidFormUrlInput(input)).toBe(true)
-  })
-
-  it.each([
-    'https://example.com/654ab1234abc1a012345f1e0',
-    'https://form.gov.sg/not-a-form-id',
-    'my form is https://form.gov.sg/654ab1234abc1a012345f1e0',
-    'abc123',
-    '',
-  ])('rejects %s', (input) => {
-    expect(isValidFormUrlInput(input)).toBe(false)
   })
 })
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -196,6 +196,14 @@ function AiBuilderContent() {
     [sendMessage, messages.length],
   )
 
+  // "New Chat" resets the conversation/pipe, but attachedForm/addFormContext
+  // live outside useChatStream's own reset — without this, the composer
+  // chip would keep showing the previous conversation's connected form.
+  const handleNewChat = useCallback(() => {
+    setAttachedForm(null)
+    setAddFormContext(null)
+  }, [])
+
   // Determine if we have unsaved work
   // Show warning if there's ANY state worth protecting:
   // - Existing persisted chat messages
@@ -278,6 +286,7 @@ function AiBuilderContent() {
               onAddConnection={flowId ? handleAddConnection : undefined}
               knownFormUrl={prefillFormUrl}
               onConnectForm={pipeCreated ? undefined : handleConnectForm}
+              onNewChat={handleNewChat}
               attachedForm={displayedForm}
             />
           </Container>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -17,7 +17,14 @@ import {
   AiBuilderContextProvider,
   useAiBuilderContext,
 } from './AiBuilderContext'
-import { extractLastFormUrl } from './helpers'
+import {
+  buildUrlSharedKickoffMessage,
+  buildUrlSharedMessage,
+  extractFormIdFromLabel,
+  extractLastFormUrl,
+  formatFormUrlLabel,
+  stripFormIdPrefix,
+} from './helpers'
 import StepConfigContext from './StepConfigContext'
 
 function AiBuilderContent() {
@@ -46,6 +53,8 @@ function AiBuilderContent() {
     parameterLabelsByStepId,
     completedStepIds,
     activeStepId,
+    hasPipe,
+    knownFormSchema,
   } = useChatStream({ initialMessages: chatMessages })
 
   // Merge labels persisted in the draft (survive refresh, committed once a
@@ -91,6 +100,11 @@ function AiBuilderContent() {
     return merged
   }, [steps, completedStepIds])
 
+  // Connecting a form only makes sense before the pipe exists — once created,
+  // connection changes go through the LLM's picker flow. hasPipe covers the
+  // live turn; output.pipeId covers persisted state after a refresh.
+  const pipeCreated = hasPipe || Boolean(output?.pipeId)
+
   const cancelRef = useRef(null)
 
   // A connection can only be created once the pipe (Flow row) exists —
@@ -98,19 +112,66 @@ function AiBuilderContent() {
   // has run.
   const flowId: string | undefined = output?.pipeId
 
-  // In-chat "Add new form" modal (FormSG). Holds the picker question that
-  // opened it so the eventual answer is sent back in the same Q/A format as a
-  // manual selection. The secret key stays browser → GraphQL only (never
-  // through the chat route or the LLM).
-  const [addFormContext, setAddFormContext] = useState<{
-    question: string
-  } | null>(null)
+  // In-chat "Add new form" modal (FormSG), reached two ways:
+  // - 'picker' (post-pipe, from the connection picker / forced key card):
+  //   full modal (URL + secret key), URL locked when already known; the
+  //   answer goes back in the same Q/A format as a manual selection. Creates
+  //   a real connection, so it requires flowId (the pipe) to already exist.
+  // - 'kickoff' (pre-pipe, from the "Connect your form" pill): url-only
+  //   modal — no secret key, no connection created; the URL just enters the
+  //   conversation so the LLM can fetch the public schema.
+  // The secret key stays browser → GraphQL only (never through the chat
+  // route or the LLM).
+  const [addFormContext, setAddFormContext] = useState<
+    { kind: 'picker'; question: string } | { kind: 'kickoff' } | null
+  >(null)
+
+  // Display-only composer chip anchoring the connected form (S3).
+  const [attachedForm, setAttachedForm] = useState<{ label: string } | null>(
+    null,
+  )
 
   const prefillFormUrl = useMemo(() => extractLastFormUrl(messages), [messages])
 
+  // The composer chip anchors whatever form the conversation is about: the
+  // connected form's title once a connection exists; otherwise the shared
+  // form's real title (from the LLM's streamed get_form_schema result) with
+  // a "not connected" cue, falling back to the compact URL until the schema
+  // has been fetched.
+  const displayedForm = useMemo(() => {
+    if (attachedForm) {
+      return { ...attachedForm, isConnected: true }
+    }
+    if (prefillFormUrl) {
+      const urlFormId = extractFormIdFromLabel(prefillFormUrl)
+      const title =
+        knownFormSchema && knownFormSchema.formId === urlFormId
+          ? knownFormSchema.title
+          : null
+      return {
+        label: title ?? formatFormUrlLabel(prefillFormUrl),
+        isConnected: false,
+      }
+    }
+    return null
+  }, [attachedForm, prefillFormUrl, knownFormSchema])
+
+  const handleAddConnection = useCallback(
+    (context: { question: string }) =>
+      setAddFormContext({ kind: 'picker', ...context }),
+    [],
+  )
+
+  const handleConnectForm = useCallback(
+    () => setAddFormContext({ kind: 'kickoff' }),
+    [],
+  )
+
+  // Full-variant (URL + key) success — only reachable from the 'picker' kind.
   const handleAddFormSuccess = useCallback(
     (connectionLabel: string, connectionId: string) => {
-      if (addFormContext) {
+      if (addFormContext?.kind === 'picker') {
+        setAttachedForm({ label: stripFormIdPrefix(connectionLabel) })
         sendMessage(
           `Q: ${addFormContext.question}\nA: ${connectionLabel} (id: ${connectionId})`,
         )
@@ -118,6 +179,21 @@ function AiBuilderContent() {
       setAddFormContext(null)
     },
     [addFormContext, sendMessage],
+  )
+
+  // Url-only-variant submit — the user shared their form without a key. As
+  // the first message it asks for suggestions; mid-conversation it is a
+  // plain share the LLM picks up from where it is.
+  const handleSubmitUrl = useCallback(
+    (formUrl: string) => {
+      sendMessage(
+        messages.length === 0
+          ? buildUrlSharedKickoffMessage(formUrl)
+          : buildUrlSharedMessage(formUrl),
+      )
+      setAddFormContext(null)
+    },
+    [sendMessage, messages.length],
   )
 
   // Determine if we have unsaved work
@@ -199,16 +275,24 @@ function AiBuilderContent() {
               cancelStream={cancelStream}
               resetChat={resetChat}
               hasReachedLimit={hasReachedLimit}
-              onAddConnection={flowId ? setAddFormContext : undefined}
+              onAddConnection={flowId ? handleAddConnection : undefined}
+              knownFormUrl={prefillFormUrl}
+              onConnectForm={pipeCreated ? undefined : handleConnectForm}
+              attachedForm={displayedForm}
             />
           </Container>
         </Flex>
         <AddFormsgConnectionModal
           isOpen={addFormContext !== null}
           flowId={flowId}
+          variant={addFormContext?.kind === 'kickoff' ? 'url-only' : 'full'}
           prefillFormUrl={prefillFormUrl}
+          lockFormUrl={
+            addFormContext?.kind === 'picker' && Boolean(prefillFormUrl)
+          }
           onClose={() => setAddFormContext(null)}
           onSuccess={handleAddFormSuccess}
+          onSubmitUrl={handleSubmitUrl}
         />
         <ExitAlert
           cancelRef={cancelRef}


### PR DESCRIPTION
### TL;DR

Introduces a two-stage FormSG form connection flow in the AI Builder: users can now share a form URL before a pipe exists, letting the LLM fetch the public schema and suggest workflows, then complete the connection (secret key) later once the pipe is created.

### What changed?

**Pre-pipe "Connect your form" pill**
A `url-only` variant of `AddFormsgConnectionModal` is introduced. Before a pipe exists, a "Connect your form" pill appears in the composer. Clicking it opens a stripped-down modal that collects only the form URL (no secret key, no connection row). The URL is sent into the conversation so the LLM can call `get_form_schema` and suggest workflows based on the form's actual fields.

**Forced key-completion card in `DynamicPicker`**
When the conversation already has a known form URL and the picker is for a FormSG connection, the picker skips listing other connections and instead shows a single "finish connecting" card prompting the user to add their secret key for the form they already chose.

**Composer chip anchoring the form**
A display-only chip appears below the textarea showing whichever form the conversation is about. Before a secret key is added it shows the form's real title (sourced from the streamed `get_form_schema` tool result) or a compact URL fallback, with a "· not connected" cue. After a connection is created it shows the connected form's title.

**`knownFormSchema` from `useChatStream`**
The hook now scans streamed message parts for `get_form_schema` tool results and surfaces the latest `{ title, formId }` as `knownFormSchema`, alongside a new `hasPipe` boolean derived from `data-pipeState` parts.

**`AddFormsgConnectionModal` variants**
The modal now accepts `variant: 'url-only' | 'full'`, `lockFormUrl`, and `onSubmitUrl` props. In `url-only` mode the secret key field is hidden, the title reads "Share your form", and submission calls `onSubmitUrl` instead of creating a connection. In `full` mode with `lockFormUrl`, the URL field is disabled and the title reads "Add your Form Secret Key".

**Helper functions**
New helpers in `helpers.ts` cover URL validation (`isValidFormUrlInput`), normalisation of bare form IDs to full URLs (`normalizeFormUrlInput`), display formatting (`formatFormUrlLabel`, `stripFormIdPrefix`, `extractFormIdFromLabel`), message builders (`buildUrlSharedMessage`, `buildUrlSharedKickoffMessage`), and a unified `formatUserMessageForDisplay` that strips both `(id: …)` and `(id: …, form id: …)` suffixes from user messages.

**Placeholder resize fix**
The textarea now measures the wrapped height of its placeholder when the input is empty, preventing a spurious scrollbar when the placeholder spans multiple lines.

### How to test?

1. Open the AI Builder with no existing pipe.
2. Verify the "Connect your form" pill appears in the composer and is disabled while the LLM is streaming.
3. Click the pill — confirm the modal shows only the URL field, titled "Share your form", with a "Share" button.
4. Submit a valid FormSG URL or bare 24-hex form ID. Confirm the message sent into the chat matches the kickoff format and the composer chip appears showing the form title (or compact URL) with "· not connected".
5. Continue the conversation until a pipe is created. Confirm the pill disappears and the chip remains.
6. Trigger a FormSG connection picker. Confirm the forced key-completion card appears (not a list of connections) when a form URL is already in the conversation.
7. Complete the connection via the full modal. Confirm the chip updates to the connected form's title without "· not connected".
8. Verify that user messages with `(id: …)` or `(id: …, form id: …)` suffixes display without those suffixes in the chat.
9. Run the unit tests in `formUrlHelpers.test.ts` to confirm all helper functions behave as specified.

### Why make this change?

Previously, users had to wait until a pipe was created before they could connect a FormSG form, and the LLM had no way to tailor its suggestions to a specific form's fields during the initial conversation. This change unlocks a URL-first intake path: the user shares their form early, the LLM fetches the public schema and gives contextually relevant workflow suggestions, and the secret key is collected later in the natural flow — keeping credentials out of the LLM route entirely.