### PR TITLE
[AI-FORMSG-SETUP-4]: reuse an existing FormSG connection from the empty state

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -8,15 +8,7 @@ import {
 } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
-import {
-  Box,
-  Flex,
-  Icon,
-  Image,
-  Text,
-  Textarea,
-  Tooltip,
-} from '@chakra-ui/react'
+import { Box, Flex, Icon, Image, Text, Textarea } from '@chakra-ui/react'
 
 import {
   type ClarificationQuestion,
@@ -24,6 +16,7 @@ import {
 } from '@/hooks/useChatStream'
 import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicker'
 import DynamicPicker from '@/pages/AiBuilder/components/ChatInterface/DynamicPicker'
+import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
 import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
 
@@ -41,6 +34,8 @@ interface PromptInputProps {
   knownFormUrl?: string
   /** Opens the Add-new-form modal (empty-state "Connect your form" entry). */
   onConnectForm?: () => void
+  /** Kicks off the chat with an existing connection. */
+  onSelectExistingForm?: (label: string, connectionId: string) => void
   /**
    * Display-only chip anchoring the conversation's form to the composer —
    * the connected form's title, or the shared URL (isConnected: false)
@@ -99,6 +94,7 @@ export default function PromptInput({
   onAddConnection,
   knownFormUrl,
   onConnectForm,
+  onSelectExistingForm,
   attachedForm,
 }: PromptInputProps) {
   const [input, setInput] = useState<string>(initialValue)
@@ -257,7 +253,9 @@ export default function PromptInput({
     )
   }
 
-  const showChipsRow = Boolean(onConnectForm || attachedForm)
+  const showChipsRow = Boolean(
+    (onConnectForm && onSelectExistingForm) || attachedForm,
+  )
 
   return (
     <Box w="full" maxW="4xl">
@@ -345,40 +343,12 @@ export default function PromptInput({
           <Flex px={2} pb={1} pt={1} align="center" gap={2}>
             {attachedForm?.isConnected ? (
               <FormChip form={attachedForm} />
-            ) : onConnectForm ? (
-              <Tooltip
-                label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
-                hasArrow
-                placement="top-start"
-              >
-                <Flex display="inline-flex">
-                  <Box
-                    as="button"
-                    type="button"
-                    display="inline-flex"
-                    alignItems="center"
-                    gap={1.5}
-                    border="1px"
-                    borderColor="gray.200"
-                    borderRadius="full"
-                    color="gray.700"
-                    fontWeight="medium"
-                    fontSize="xs"
-                    px={2.5}
-                    py={1}
-                    opacity={isStreaming ? 0.5 : 1}
-                    cursor={isStreaming ? 'not-allowed' : 'pointer'}
-                    onClick={isStreaming ? undefined : onConnectForm}
-                  >
-                    <Image
-                      src="/apps/formsg/assets/favicon.svg"
-                      boxSize="14px"
-                      alt=""
-                    />
-                    Connect your form
-                  </Box>
-                </Flex>
-              </Tooltip>
+            ) : onConnectForm && onSelectExistingForm ? (
+              <ConnectFormPopover
+                isStreaming={isStreaming}
+                onSelectExisting={onSelectExistingForm}
+                onAddNewForm={onConnectForm}
+              />
             ) : attachedForm ? (
               // Dead-end fallback: a URL is known but not connected, and
               // there's no trigger left to retry through (e.g. post-pipe,

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -28,6 +28,7 @@ interface ChatInterfaceProps {
   onConnectForm?: () => void
   /** Resets any form-connection state that lives outside useChatStream's own reset. */
   onNewChat?: () => void
+  onSelectExistingForm?: (label: string, connectionId: string) => void
   attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
@@ -45,6 +46,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     knownFormUrl,
     onConnectForm,
     onNewChat,
+    onSelectExistingForm,
     attachedForm,
   } = props
   const navigate = useNavigate()
@@ -146,6 +148,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
               PLACEHOLDER_MESSAGES[Date.now() % PLACEHOLDER_MESSAGES.length]
             }
             onConnectForm={onConnectForm}
+            onSelectExistingForm={onSelectExistingForm}
             attachedForm={attachedForm}
           />
         </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -213,6 +213,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   onAddConnection={onAddConnection}
                   knownFormUrl={knownFormUrl}
                   onConnectForm={onConnectForm}
+                  onSelectExistingForm={onSelectExistingForm}
                   attachedForm={attachedForm}
                 />
               )}

--- a/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import {
   Box,
   Button,
@@ -42,8 +42,24 @@ export default function ConnectFormPopover({
 }: ConnectFormPopoverProps) {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [options, setOptions] = useState<FormConnectionOption[] | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Closing (Escape, outside click, or picking an option) doesn't unmount
+  // this component — it stays mounted as a persistent composer chip — so a
+  // fetch already in flight keeps running and would otherwise force-open
+  // the Add-new-form modal via the fallback below well after the user
+  // dismissed the popover. Abort it so a closed or superseded request can't
+  // act on a stale result.
+  const handleClose = useCallback(() => {
+    abortRef.current?.abort()
+    onClose()
+  }, [onClose])
 
   const handleOpen = async () => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     setOptions(null)
     onOpen()
 
@@ -51,6 +67,7 @@ export default function ConnectFormPopover({
       const res = await fetch('/api/connections?appKey=formsg', {
         method: 'GET',
         credentials: 'include',
+        signal: controller.signal,
       })
       if (!res.ok) {
         throw new Error(`Fetch failed: ${res.status}`)
@@ -59,20 +76,23 @@ export default function ConnectFormPopover({
       const data: FormConnectionOption[] = json.data ?? []
 
       if (data.length === 0) {
-        onClose()
+        handleClose()
         onAddNewForm()
         return
       }
       setOptions(data)
-    } catch {
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        return
+      }
       // Can't list existing connections — fall back to adding a new form.
-      onClose()
+      handleClose()
       onAddNewForm()
     }
   }
 
   return (
-    <Popover isOpen={isOpen} onClose={onClose} placement="top-start" isLazy>
+    <Popover isOpen={isOpen} onClose={handleClose} placement="top-start" isLazy>
       <Tooltip
         label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
         hasArrow
@@ -130,7 +150,7 @@ export default function ConnectFormPopover({
                     _hover={{ bg: 'primary.50' }}
                     _active={{ bg: 'primary.100' }}
                     onClick={() => {
-                      onClose()
+                      handleClose()
                       onSelectExisting(opt.name, opt.value)
                     }}
                   >
@@ -156,7 +176,7 @@ export default function ConnectFormPopover({
                 _hover={{ bg: 'primary.50' }}
                 _active={{ bg: 'primary.100' }}
                 onClick={() => {
-                  onClose()
+                  handleClose()
                   onAddNewForm()
                 }}
               >

--- a/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Image,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Spinner,
+  Text,
+  Tooltip,
+  useDisclosure,
+} from '@chakra-ui/react'
+
+import { stripFormIdPrefix } from '../helpers'
+
+interface FormConnectionOption {
+  name: string
+  value: string
+}
+
+interface ConnectFormPopoverProps {
+  isStreaming: boolean
+  /** Called with the connection's full label and id when an existing form is picked. */
+  onSelectExisting: (label: string, connectionId: string) => void
+  /** Opens the Add-new-form modal. */
+  onAddNewForm: () => void
+}
+
+/**
+ * Empty-state "Connect your form" chip. Clicking it lists the user's existing
+ * FormSG connections so they can reuse one instead of creating a duplicate;
+ * users with no connections go straight to the Add-new-form modal.
+ */
+export default function ConnectFormPopover({
+  isStreaming,
+  onSelectExisting,
+  onAddNewForm,
+}: ConnectFormPopoverProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [options, setOptions] = useState<FormConnectionOption[] | null>(null)
+
+  const handleOpen = async () => {
+    setOptions(null)
+    onOpen()
+
+    try {
+      const res = await fetch('/api/connections?appKey=formsg', {
+        method: 'GET',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        throw new Error(`Fetch failed: ${res.status}`)
+      }
+      const json = await res.json()
+      const data: FormConnectionOption[] = json.data ?? []
+
+      if (data.length === 0) {
+        onClose()
+        onAddNewForm()
+        return
+      }
+      setOptions(data)
+    } catch {
+      // Can't list existing connections — fall back to adding a new form.
+      onClose()
+      onAddNewForm()
+    }
+  }
+
+  return (
+    <Popover isOpen={isOpen} onClose={onClose} placement="top-start" isLazy>
+      <Tooltip
+        label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
+        hasArrow
+        placement="top-start"
+        isDisabled={isOpen}
+      >
+        <Flex display="inline-flex">
+          <PopoverTrigger>
+            <Button
+              variant="outline"
+              size="xs"
+              borderRadius="full"
+              color="gray.700"
+              borderColor="gray.200"
+              fontWeight="medium"
+              px={2.5}
+              leftIcon={
+                <Image
+                  src="/apps/formsg/assets/favicon.svg"
+                  boxSize="14px"
+                  alt=""
+                />
+              }
+              isDisabled={isStreaming}
+              onClick={handleOpen}
+            >
+              Connect your form
+            </Button>
+          </PopoverTrigger>
+        </Flex>
+      </Tooltip>
+      <PopoverContent w="320px" border="none" boxShadow="lg" borderRadius="lg">
+        <PopoverBody p={2}>
+          {options === null ? (
+            <Flex justify="center" py={3}>
+              <Spinner size="sm" color="primary.500" />
+            </Flex>
+          ) : (
+            <Flex direction="column">
+              <Text textStyle="caption-1" color="gray.500" px={2} py={1}>
+                Choose a form to build with
+              </Text>
+              <Flex direction="column" maxH="240px" overflowY="auto">
+                {options.map((opt, idx) => (
+                  <Box
+                    key={opt.value}
+                    as="button"
+                    type="button"
+                    w="full"
+                    textAlign="left"
+                    px={3}
+                    py={2}
+                    borderRadius="md"
+                    bg={idx % 2 === 0 ? 'gray.50' : 'white'}
+                    _hover={{ bg: 'primary.50' }}
+                    _active={{ bg: 'primary.100' }}
+                    onClick={() => {
+                      onClose()
+                      onSelectExisting(opt.name, opt.value)
+                    }}
+                  >
+                    <Text
+                      textStyle="body-2"
+                      whiteSpace="normal"
+                      color="gray.800"
+                    >
+                      {stripFormIdPrefix(opt.name)}
+                    </Text>
+                  </Box>
+                ))}
+              </Flex>
+              <Divider my={1} />
+              <Box
+                as="button"
+                type="button"
+                w="full"
+                textAlign="left"
+                px={3}
+                py={2}
+                borderRadius="md"
+                _hover={{ bg: 'primary.50' }}
+                _active={{ bg: 'primary.100' }}
+                onClick={() => {
+                  onClose()
+                  onAddNewForm()
+                }}
+              >
+                <Text
+                  textStyle="body-2"
+                  fontWeight="medium"
+                  color="primary.500"
+                >
+                  Add a new form
+                </Text>
+              </Box>
+            </Flex>
+          )}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -81,8 +81,8 @@ export const stripFormIdPrefix = (label: string): string =>
   label.replace(/^((?:\[[A-Z]+\] )*)[a-f0-9]{24} - /i, '$1')
 
 // User messages are displayed verbatim except for machine detail: picker
-// answers carry "(id: …)" / "(id: …, form id: …)" suffixes that are
-// stripped from display.
+// answers and the kickoff message carry "(id: …)" / "(id: …, form id: …)"
+// suffixes that are stripped from display.
 export const formatUserMessageForDisplay = (text: string): string =>
   text.replace(/ \(id: [a-f0-9-]+(?:, form id: [a-f0-9]+)?\)/g, '').trim()
 

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -24,6 +24,35 @@ export const normalizeMarkdownHeadings = (text: string): string =>
 export const prepareAiText = (text: string): string =>
   normalizeMarkdownHeadings(stripHtmlComments(text))
 
+// First user message sent after connecting a form from the empty state.
+// The parenthetical carries the connection id (for assigning the trigger in
+// Phase 2b) and form id (for get_form_schema); it follows the same "(id: …)"
+// convention as picker answers, so the chat display strips it (see
+// formatUserMessageForDisplay) and the user only sees the form title. The
+// exact shape is a contract with the system prompt's connect-first intake
+// branch — change both together.
+export const buildFormConnectedMessage = (
+  formTitle: string,
+  connectionId: string,
+  formId: string | null,
+): string => {
+  const technicalRef = formId
+    ? `(id: ${connectionId}, form id: ${formId})`
+    : `(id: ${connectionId})`
+  return `I've connected my FormSG form "${formTitle}" ${technicalRef}.`
+}
+
+export const buildKickoffMessage = (
+  formTitle: string,
+  connectionId: string,
+  formId: string | null,
+): string =>
+  `${buildFormConnectedMessage(
+    formTitle,
+    connectionId,
+    formId,
+  )} Suggest workflows I can build with this form.`
+
 // Sent when the user shares their form URL (url-only modal) without
 // connecting it — the LLM's URL-first intake branch picks the URL up and
 // fetches the public schema.

--- a/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildFormConnectedMessage,
+  buildKickoffMessage,
+  formatUserMessageForDisplay,
+} from '../helpers'
+
+describe('buildKickoffMessage', () => {
+  // The exact shape is a contract with the system prompt's connect-first
+  // intake branch (Langfuse) — if this test needs updating, the prompt's
+  // recognition rule must be updated in the same release.
+  it('carries the connection and form ids in the parenthetical', () => {
+    expect(
+      buildKickoffMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        '654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678, ' +
+        'form id: 654ab1234abc1a012345f1e0). ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+
+  it('omits the form id when unknown', () => {
+    expect(
+      buildKickoffMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        null,
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678). ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+
+  it('displays without the technical parenthetical', () => {
+    const message = buildKickoffMessage(
+      'Workshop Registration 2026',
+      '3f2c8e10-1234-5678-9abc-def012345678',
+      '654ab1234abc1a012345f1e0',
+    )
+    expect(formatUserMessageForDisplay(message)).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026". ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+})
+
+describe('buildFormConnectedMessage', () => {
+  // Mid-conversation announcement — same shape as the kickoff but without
+  // the suggestion request, so the LLM continues from where it left off.
+  it('omits the workflow-suggestion request', () => {
+    expect(
+      buildFormConnectedMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        '654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678, ' +
+        'form id: 654ab1234abc1a012345f1e0).',
+    )
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -18,6 +18,8 @@ import {
   useAiBuilderContext,
 } from './AiBuilderContext'
 import {
+  buildFormConnectedMessage,
+  buildKickoffMessage,
   buildUrlSharedKickoffMessage,
   buildUrlSharedMessage,
   extractFormIdFromLabel,
@@ -167,6 +169,30 @@ function AiBuilderContent() {
     [],
   )
 
+  // Announces a connected form to the chat. The connection/form ids ride in
+  // the message's "(id: …)" parenthetical (stripped from display) so the LLM
+  // can assign the connection and fetch the schema in later setup. As the
+  // first message it kicks off the conversation with a request for workflow
+  // suggestions; mid-conversation it is a plain announcement so the LLM
+  // continues from wherever the conversation is.
+  const kickoffWithForm = useCallback(
+    (connectionLabel: string, connectionId: string) => {
+      const formTitle = stripFormIdPrefix(connectionLabel)
+      const formId = extractFormIdFromLabel(connectionLabel)
+      setAttachedForm({ label: formTitle })
+      sendMessage(
+        messages.length === 0
+          ? buildKickoffMessage(formTitle, connectionId, formId)
+          : buildFormConnectedMessage(formTitle, connectionId, formId),
+      )
+    },
+    [sendMessage, messages.length],
+  )
+
+  // Reusing an existing connection kicks off the chat exactly like a freshly
+  // added one — no new connection row is created.
+  const handleSelectExistingForm = kickoffWithForm
+
   // Full-variant (URL + key) success — only reachable from the 'picker' kind.
   const handleAddFormSuccess = useCallback(
     (connectionLabel: string, connectionId: string) => {
@@ -287,6 +313,9 @@ function AiBuilderContent() {
               knownFormUrl={prefillFormUrl}
               onConnectForm={pipeCreated ? undefined : handleConnectForm}
               onNewChat={handleNewChat}
+              onSelectExistingForm={
+                pipeCreated ? undefined : handleSelectExistingForm
+              }
               attachedForm={displayedForm}
             />
           </Container>


### PR DESCRIPTION
### TL;DR

The "Connect your form" chip in the AI Builder chat now opens a popover listing the user's existing FormSG connections, allowing them to reuse one instead of always creating a new connection.

### What changed?

- Replaced the inline "Connect your form" tooltip+button with a new `ConnectFormPopover` component. When clicked, the popover fetches `/api/connections?appKey=formsg` and displays existing FormSG connections in a scrollable list. If no connections exist (or the fetch fails), it falls back directly to the Add-new-form modal.
- Added an `onSelectExistingForm` prop to `PromptInput` and `ChatInterface` so that selecting an existing connection from the popover kicks off the chat with that form.
- Added `buildFormConnectedMessage` and `buildKickoffMessage` helpers in `helpers.ts`. The kickoff message embeds the connection and form IDs in a `(id: …, form id: …)` parenthetical (stripped from display via `formatUserMessageForDisplay`) so the LLM can assign the trigger and fetch the form schema. When the conversation is already in progress, only the plain announcement message is sent.
- Added a `kickoffWithForm` callback in `AiBuilderContent` that handles both the empty-state first message (with a workflow suggestion request) and mid-conversation form announcements.
- Added unit tests covering `buildKickoffMessage` and `buildFormConnectedMessage`, including display stripping of the technical parenthetical.

### How to test?

1. Open the AI Builder with no active pipe/conversation.
2. Click "Connect your form" — the popover should appear and list your existing FormSG connections.
3. Select an existing connection — the chat should start with a message announcing the form and requesting workflow suggestions. The `(id: …)` parenthetical should not be visible in the chat UI.
4. If you have no existing connections, clicking "Connect your form" should go directly to the Add-new-form modal.
5. Simulate a fetch failure (e.g. block the `/api/connections` request) and confirm the fallback to the Add-new-form modal works.
6. Mid-conversation, connect a form and confirm only the plain announcement message is sent (no workflow suggestion request appended).

### Why make this change?

Previously, clicking "Connect your form" always opened the Add-new-form modal, forcing users to create a duplicate connection even if they had already connected the same form before. This change lets users reuse an existing FormSG connection directly from the chat composer, reducing friction and avoiding redundant connection entries.