### PR TITLE
fix(archival): decrement archived_execution_count on rehydration

### DIFF
--- a/packages/backend-archive/src/helpers/archival/__tests__/restore-execution.test.ts
+++ b/packages/backend-archive/src/helpers/archival/__tests__/restore-execution.test.ts
@@ -52,9 +52,19 @@ function makeMockKnex({ executionExists = false, stepExists = false } = {}) {
   const insertExecFn = vi.fn().mockReturnValue(execChain)
   const insertStepFn = vi.fn().mockReturnValue(stepChain)
 
-  const trx = (table: string) => ({
-    insert: table === 'executions' ? insertExecFn : insertStepFn,
-  })
+  const decrementFn = vi.fn().mockResolvedValue(1)
+  const flowsWhereChain = {
+    where: vi.fn().mockReturnThis(),
+    decrement: decrementFn,
+  }
+  const flowsWhereFn = vi.fn().mockReturnValue(flowsWhereChain)
+
+  const trx = (table: string) => {
+    if (table === 'flows') {
+      return { where: flowsWhereFn }
+    }
+    return { insert: table === 'executions' ? insertExecFn : insertStepFn }
+  }
   const trxWithRaw = Object.assign(trx, { raw: rawFn })
 
   const knexClient = {
@@ -64,10 +74,14 @@ function makeMockKnex({ executionExists = false, stepExists = false } = {}) {
     _insertExecFn: insertExecFn,
     _insertStepFn: insertStepFn,
     _rawFn: rawFn,
+    _flowsWhereFn: flowsWhereFn,
+    _decrementFn: decrementFn,
   } as unknown as Knex & {
     _insertExecFn: ReturnType<typeof vi.fn>
     _insertStepFn: ReturnType<typeof vi.fn>
     _rawFn: ReturnType<typeof vi.fn>
+    _flowsWhereFn: ReturnType<typeof vi.fn>
+    _decrementFn: ReturnType<typeof vi.fn>
   }
   return knexClient
 }
@@ -119,5 +133,22 @@ describe('restoreExecution', () => {
     const result = await restoreExecution({ ...mockPayload, steps: [] }, knex)
     expect(result.stepsInserted).toBe(0)
     expect((knex as any)._insertStepFn).not.toHaveBeenCalled()
+  })
+
+  it('decrements archived_execution_count when the execution is newly inserted', async () => {
+    const knex = makeMockKnex()
+    await restoreExecution(mockPayload, knex)
+    expect((knex as any)._flowsWhereFn).toHaveBeenCalledWith('id', 'flow-1')
+    expect((knex as any)._decrementFn).toHaveBeenCalledWith(
+      'archived_execution_count',
+      1,
+    )
+  })
+
+  it('does not decrement archived_execution_count when the execution already existed', async () => {
+    const knex = makeMockKnex({ executionExists: true })
+    await restoreExecution(mockPayload, knex)
+    expect((knex as any)._flowsWhereFn).not.toHaveBeenCalled()
+    expect((knex as any)._decrementFn).not.toHaveBeenCalled()
   })
 })

--- a/packages/backend-archive/src/helpers/archival/restore-execution.ts
+++ b/packages/backend-archive/src/helpers/archival/restore-execution.ts
@@ -67,6 +67,17 @@ export async function restoreExecution(
         .returning('id')
       stepsInserted = insertedSteps.length
     }
+
+    // Only decrement when we actually inserted a new row: onConflict().ignore()
+    // above means a retried/idempotent restore of an already-restored execution
+    // must not decrement the counter a second time. Guard against going
+    // negative in case the counter is ever already at 0.
+    if (executionInserted) {
+      await trx('flows')
+        .where('id', execution.flowId)
+        .where('archived_execution_count', '>', 0)
+        .decrement('archived_execution_count', 1)
+    }
   })
 
   return { executionInserted, stepsInserted }


### PR DESCRIPTION
## TL;DR

`flows.archived_execution_count` was only ever incremented (on archive), never decremented (on rehydration), so it drifted from "currently archived" toward "lifetime archived ever." This fixes it to decrement on restore, since we may surface this count on the frontend in future.

## What changed?

- `restoreExecution` (packages/backend-archive/src/helpers/archival/restore-execution.ts) now decrements `flows.archived_execution_count` by 1, in the same transaction as the execution/step re-insert, mirroring the existing increment in `archive-execution.ts`.
- Only decrements when `executionInserted` is true — the insert uses `onConflict('id').ignore()`, so an idempotent retry of an already-restored execution must not double-decrement.
- Guarded with `where('archived_execution_count', '>', 0)` so the update is a no-op instead of going negative if the counter is ever already at 0.

## Tests

- [ ] Archive an execution (or seed `archived_execution_count = 1` on a flow directly), then run `rehydrate-execution --flow-id <id> --execution-id <id> --restore` and confirm the flow's `archived_execution_count` drops by 1 in the DB.
- [ ] Run the same restore command a second time for the same execution (idempotent retry) and confirm the count does *not* decrement further (execution already exists, so `executionInserted` is false).
- [ ] With `archived_execution_count` already at 0, restore an execution and confirm the count stays at 0 rather than going negative.

## Deploy notes

None — no new env vars or migrations, reuses the existing `archived_execution_count` column added in a prior migration.