### PR TITLE
[AI-SETUP-29] feat: render row data as a Column | Value table

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -9,14 +9,21 @@ import {
   useState,
 } from 'react'
 import { useQuery } from '@apollo/client'
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Flex, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react'
 
 import { GET_DYNAMIC_DATA } from '@/graphql/queries/get-dynamic-data'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
-import { parseParameterValue } from '@/pages/AiBuilder/helpers/parseParameterValue'
+import {
+  parseParameterValue,
+  type Segment,
+} from '@/pages/AiBuilder/helpers/parseParameterValue'
 import { useStepConfigContext } from '@/pages/AiBuilder/StepConfigContext'
 
+import {
+  type ColumnValueRow,
+  resolveColumnValueRows,
+} from './helpers/columnValueTable'
 import {
   collectDynamicFields,
   resolveDynamicSourceVariables,
@@ -76,6 +83,109 @@ function DynamicFieldOptionsFetcher({
   }, [serializedOptions, fieldKey, onLoaded])
 
   return null
+}
+
+interface ParameterValueLineProps {
+  line: string
+  variableLabelsByPath: Map<string, string>
+  variableValuesByPath: Map<string, string>
+  stepNameById: Map<string, string>
+  // When true, keeps the line on a single row instead of wrapping — used in
+  // Column/Value table cells, which handle overflow via scroll instead.
+  noWrap?: boolean
+}
+
+// Renders one display line: plain text interleaved with VariablePills for
+// any `{{step.x.y}}` references. Shared between the plain per-line list and
+// each Column/Value table cell.
+function ParameterValueLine({
+  line,
+  variableLabelsByPath,
+  variableValuesByPath,
+  stepNameById,
+  noWrap,
+}: ParameterValueLineProps) {
+  const segments = parseParameterValue(line)
+
+  return (
+    <Box
+      as="span"
+      fontSize="sm"
+      color="base.content.default"
+      lineHeight="1.6"
+      display="flex"
+      flexWrap={noWrap ? 'nowrap' : 'wrap'}
+      whiteSpace={noWrap ? 'nowrap' : undefined}
+      alignItems="center"
+      gap={0.75}
+      w={noWrap ? 'max-content' : undefined}
+    >
+      {segments.map((seg: Segment, i) => {
+        if (seg.type === 'text') {
+          // eslint-disable-next-line react/no-array-index-key
+          return <Fragment key={i}>{seg.text}</Fragment>
+        }
+        const variableKey = `step.${seg.stepId}.${seg.path}`
+        return (
+          <VariablePill
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            label={variableLabelsByPath.get(variableKey) ?? seg.label}
+            value={variableValuesByPath.get(variableKey)}
+            stepName={stepNameById.get(seg.stepId)}
+          />
+        )
+      })}
+    </Box>
+  )
+}
+
+interface ColumnValueTableProps {
+  rows: ColumnValueRow[]
+  variableLabelsByPath: Map<string, string>
+  variableValuesByPath: Map<string, string>
+  stepNameById: Map<string, string>
+}
+
+// Renders a multirow/multirow-multicol value (e.g. Tile row data, Excel
+// column values) as a Column/Value table instead of a comma-joined line. No
+// header — the parameter's own label already reads as the table's caption.
+// The Column cell has a fixed width (via tableLayout="fixed") and the Value
+// cell scrolls horizontally on its own when its content overflows, instead
+// of the whole table scrolling.
+function ColumnValueTable({
+  rows,
+  variableLabelsByPath,
+  variableValuesByPath,
+  stepNameById,
+}: ColumnValueTableProps) {
+  return (
+    <Table size="sm" variant="simple" sx={{ tableLayout: 'fixed' }} w="full">
+      <Tbody>
+        {rows.map((row, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Tr key={i}>
+            <Td w="35%">{row.column}</Td>
+            <Td
+              overflowX="auto"
+              // Forcefully hide the scrollbar, same as the multirow-multicol
+              // input's single-line editor (RichTextEditor.scss), so mouse
+              // users don't get a visible scrollbar misaligning row height.
+              sx={{ '&::-webkit-scrollbar': { display: 'none' } }}
+            >
+              <ParameterValueLine
+                line={row.value}
+                variableLabelsByPath={variableLabelsByPath}
+                variableValuesByPath={variableValuesByPath}
+                stepNameById={stepNameById}
+                noWrap
+              />
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  )
 }
 
 interface ParameterRowProps {
@@ -179,20 +289,26 @@ export default function StepParameterRows({
     .filter(([, value]) => value !== '' && value != null)
     .map(([key, value]) => {
       const field = stepFields.find((f) => f.key === key)
+      const hasAiLabel = parameterLabels[key] != null
       return {
         key,
         label: resolveFieldLabel(stepFields, key),
         // AI-provided labels take priority over static option resolution
-        displayLines:
-          parameterLabels[key] != null
-            ? [parameterLabels[key]]
-            : resolveDisplayValue(stepFields, key, value),
+        // and skip the Column/Value table, since they're already a single
+        // human-readable summary of the whole value.
+        displayLines: hasAiLabel
+          ? [parameterLabels[key]]
+          : resolveDisplayValue(stepFields, key, value),
+        columnValueRows: hasAiLabel
+          ? null
+          : resolveColumnValueRows(field, value),
         hiddenIf: field?.hiddenIf,
       }
     })
     .filter(
-      ({ displayLines, hiddenIf }) =>
-        displayLines.length > 0 && !isFieldHidden(hiddenIf, parameters),
+      ({ displayLines, columnValueRows, hiddenIf }) =>
+        (displayLines.length > 0 || (columnValueRows?.length ?? 0) > 0) &&
+        !isFieldHidden(hiddenIf, parameters),
     )
     .sort((a, b) => {
       const posA = fieldIndexMap.get(a.key) ?? Infinity
@@ -231,44 +347,28 @@ export default function StepParameterRows({
             </Text>
           </ParameterRow>
         )}
-        {rows.map(({ key, label, displayLines }) => (
+        {rows.map(({ key, label, displayLines, columnValueRows }) => (
           <ParameterRow key={key} label={label}>
-            <Flex direction="column" gap={1}>
-              {displayLines.map((line, lineIndex) => {
-                const segments = parseParameterValue(line)
-
-                return (
-                  <Box
+            {columnValueRows && columnValueRows.length > 0 ? (
+              <ColumnValueTable
+                rows={columnValueRows}
+                variableLabelsByPath={variableLabelsByPath}
+                variableValuesByPath={variableValuesByPath}
+                stepNameById={stepNameById}
+              />
+            ) : (
+              <Flex direction="column" gap={1}>
+                {displayLines.map((line, lineIndex) => (
+                  <ParameterValueLine
                     key={lineIndex}
-                    as="span"
-                    fontSize="sm"
-                    color="base.content.default"
-                    lineHeight="1.6"
-                    display="flex"
-                    flexWrap="wrap"
-                    alignItems="center"
-                    gap={0.75}
-                  >
-                    {segments.map((seg, i) => {
-                      if (seg.type === 'text') {
-                        return <Fragment key={i}>{seg.text}</Fragment>
-                      }
-                      const variableKey = `step.${seg.stepId}.${seg.path}`
-                      return (
-                        <VariablePill
-                          key={i}
-                          label={
-                            variableLabelsByPath.get(variableKey) ?? seg.label
-                          }
-                          value={variableValuesByPath.get(variableKey)}
-                          stepName={stepNameById.get(seg.stepId)}
-                        />
-                      )
-                    })}
-                  </Box>
-                )
-              })}
-            </Flex>
+                    line={line}
+                    variableLabelsByPath={variableLabelsByPath}
+                    variableValuesByPath={variableValuesByPath}
+                    stepNameById={stepNameById}
+                  />
+                ))}
+              </Flex>
+            )}
           </ParameterRow>
         ))}
       </Box>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/columnValueTable.ts
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/columnValueTable.ts
@@ -1,0 +1,93 @@
+import type { IField } from '@plumber/types'
+
+import { getDynamicDropdownSource } from './dynamicFieldOptions'
+import {
+  type FieldWithOptions,
+  resolveOptionLabel,
+} from './resolveFieldDisplayValue'
+
+interface ColumnValueFieldShape {
+  columnKey: string
+  valueKey: string
+  columnField: FieldWithOptions
+  valueField: FieldWithOptions
+}
+
+// A multirow/multirow-multicol field reads as a "Column | Value" table when
+// it has exactly two subFields and one of them is a dynamic dropdown (e.g.
+// Tile's columnId, Excel's columnName, LetterSG's field) — i.e. a per-row
+// pick-a-column selector paired with a value. This deliberately excludes
+// fields with a third subField (Tile/Excel's filters: column+operator+value)
+// and fields where the "key" subField is a plain string (PaySG metadata,
+// custom-api headers), since those aren't a dynamic column picker.
+function getColumnValueFieldShape(
+  field: IField | undefined,
+): ColumnValueFieldShape | null {
+  const subFields = (field as { subFields?: IField[] } | undefined)?.subFields
+  if (!subFields || subFields.length !== 2) {
+    return null
+  }
+
+  const dynamicIndex = subFields.findIndex(
+    (f) => getDynamicDropdownSource(f) !== null,
+  )
+  if (dynamicIndex === -1) {
+    return null
+  }
+
+  const columnField = subFields[dynamicIndex]
+  const valueField = subFields[1 - dynamicIndex]
+  if (!columnField.key || !valueField.key) {
+    return null
+  }
+
+  return {
+    columnKey: columnField.key,
+    valueKey: valueField.key,
+    columnField,
+    valueField,
+  }
+}
+
+export interface ColumnValueRow {
+  column: string
+  value: string
+}
+
+// Resolve a multirow/multirow-multicol value into Column/Value table rows,
+// or null if the field's shape doesn't match (caller falls back to the
+// generic per-line rendering). Deliberately shows exactly what's saved,
+// including blank columns/values, rather than filtering rows out: an empty
+// column selector is a real misconfiguration the user should be able to see,
+// not something to hide. Only rows that aren't row objects at all are
+// dropped, since there's nothing to display for those.
+export function resolveColumnValueRows(
+  field: IField | undefined,
+  value: unknown,
+): ColumnValueRow[] | null {
+  const shape = getColumnValueFieldShape(field)
+  if (!shape || !Array.isArray(value)) {
+    return null
+  }
+
+  return value
+    .map((item) => {
+      if (typeof item !== 'object' || item === null) {
+        return null
+      }
+      const obj = item as Record<string, unknown>
+      const rawColumn = obj[shape.columnKey]
+      const rawValue = obj[shape.valueKey]
+      return {
+        column:
+          rawColumn == null
+            ? ''
+            : resolveOptionLabel(shape.columnField, String(rawColumn)),
+        value:
+          rawValue == null
+            ? ''
+            : resolveOptionLabel(shape.valueField, String(rawValue)),
+      }
+    })
+    .filter((row): row is ColumnValueRow => row !== null)
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/dynamicFieldOptions.ts
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/dynamicFieldOptions.ts
@@ -12,19 +12,34 @@ export interface DynamicField {
   source: IFieldDropdownSource
 }
 
-// Fields backed by a `getDynamicData` source (e.g. Tile's column picker) have
-// no static `options` — their labels only exist behind a live query. Walk the
-// step schema (including subFields, since Tile's columnId lives inside
-// multirow-multicol subFields) to find every such field.
+// A field is a "dynamic dropdown" (e.g. Tile's columnId, Excel's columnName,
+// LetterSG's field) when it's backed by a `getDynamicData` source — its
+// options only exist behind a live query, not in the static app schema.
+// Shared by collectDynamicFields (which fields need fetching) and the
+// Column/Value table's shape detection (which subField is "the column").
+export function getDynamicDropdownSource(
+  field: IField,
+): IFieldDropdownSource | null {
+  if (
+    field.type !== 'dropdown' ||
+    field.source?.type !== 'query' ||
+    field.source.name !== 'getDynamicData'
+  ) {
+    return null
+  }
+  return field.source
+}
+
+// Fields backed by a `getDynamicData` source have no static `options` — their
+// labels only exist behind a live query. Walk the step schema (including
+// subFields, since Tile's columnId lives inside multirow-multicol subFields)
+// to find every such field.
 export function collectDynamicFields(fields: IField[]): DynamicField[] {
   const result: DynamicField[] = []
   for (const field of fields) {
-    if (
-      field.type === 'dropdown' &&
-      field.source?.type === 'query' &&
-      field.source.name === 'getDynamicData'
-    ) {
-      result.push({ fieldKey: field.key, source: field.source })
+    const source = getDynamicDropdownSource(field)
+    if (source) {
+      result.push({ fieldKey: field.key, source })
     }
     const subFields = (field as { subFields?: IField[] }).subFields
     if (subFields) {

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
@@ -31,14 +31,14 @@ export function resolveFieldLabel(
   )
 }
 
-type FieldWithOptions = {
+export type FieldWithOptions = {
   key?: string
-  options?: Array<{ label: string; value: string | number }>
+  options?: Array<{ label: string; value: string | number | boolean }>
   subFields?: FieldWithOptions[]
 }
 
 // Resolve a single scalar value against a field's option list.
-function resolveOptionLabel(
+export function resolveOptionLabel(
   field: FieldWithOptions | undefined,
   strValue: string,
 ): string {


### PR DESCRIPTION
## TL;DR

Stacked on #1924. Renders Tile/Excel/Databricks/LetterSG row-data-style values as a "Column | Value" table in the AI Builder step preview, instead of comma-joined text.

## What changed?

- Added `resolveColumnValueRows`/`getColumnValueFieldShape` (`helpers/columnValueTable.ts`): a multirow/multirow-multicol field renders as a Column/Value table when it has exactly two subFields and one is a dynamic dropdown (reusing the `getDynamicDropdownSource` check from #1924, now shared between both files). This covers Tile create/update-row, Excel create/update-table-row, Databricks create-row, and LetterSG create-letter — with no per-app/action allowlist to maintain — while excluding shapes that don't fit (Tile/Excel filters have 3 subfields; PaySG metadata/custom-api headers use a plain string key, not a dynamic column picker).
- The table shows exactly what's saved, including blank columns/values — an empty column selector is a real misconfiguration and should be visible, not silently hidden.
- No table header (the parameter's own label already reads as a caption), and each Value cell scrolls horizontally on its own when its content overflows — via `tableLayout: fixed` + a per-cell `overflowX: auto` — rather than the whole table scrolling. The scrollbar itself is hidden (`::-webkit-scrollbar { display: none }`), matching the multirow-multicol input's own single-line editor styling.
- Fields with an AI-provided label override skip the table (that override is already a single human-readable summary of the whole value).

## Tests

- [ ] Add a Tile "create row" step with several column/value pairs in AI Builder; confirm it renders as a two-column table with real column names, not IDs.
- [ ] Confirm a row with a long value scrolls horizontally within just that cell, without a visible scrollbar or affecting other rows/the Column column.
- [ ] Confirm a step with an empty column or value shows that blank cell rather than dropping the row.
- [ ] Confirm filter/if-then conditions (3-part rows) still render as plain lines, not a table.

## Deploy notes

None — frontend-only change.
