### PR TITLE
chore(skill): add get-metrics-sql skill for business-metrics SQL

### DIFF
--- a/.claude/skills/get-metrics-sql/SKILL.md
+++ b/.claude/skills/get-metrics-sql/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: get-metrics-sql
+description: >
+  Turns plain-English business-metrics questions about Plumber's pipes,
+  executions, and users into Postgres SQL. Use whenever asked for a
+  metrics count/aggregate, a retention/activity metric, or a Grafana
+  panel query. Resolves Plumber-specific traps — soft-delete filtering,
+  opaque app/trigger/action keys, ambiguous terms like "active," and
+  timestamptz timezone handling.
+---
+
+# Plumber metrics SQL
+
+Turn a business-metrics question into correct Postgres SQL against Plumber's domain tables
+(`flows`, `steps`, `executions`, `execution_steps`, `users`, `connections`). Reading the
+[model files](../../../packages/backend/src/models/) directly gets you most of the schema — the
+reference docs below cover what a single model file won't tell you.
+
+Hard rules (non-negotiable):
+
+- **Never write to the database.** All validation runs read-only (see step 5) — never `INSERT` /
+  `UPDATE` / `DELETE`, never skip the `READ ONLY` wrapper.
+- **Ask, don't guess, on genuine ambiguity** — (not an exhaustive list) e.g. an unclear "active," an
+  unspecified Grafana panel design, or a display name that doesn't uniquely resolve to one
+  `(app_key, type, key)`.
+
+## Workflow
+
+### 1. Restate the question in concrete tables/columns
+
+Read [reference/glossary.md](reference/glossary.md) and [reference/gotchas.md](reference/gotchas.md).
+Restate the question in terms of concrete tables/columns, reading the relevant
+[model file(s)](../../../packages/backend/src/models/) directly for schema details. Pin down every
+ambiguous business term against the glossary — in particular, decide whether "active" means
+*published* (`flows.active`) or *active pipe/user* (flowed within a period); ask the user if the
+question doesn't make this clear.
+
+### 2. Resolve any named app/trigger/action
+
+If the question names an app, trigger, or action ("slack action," "gathersg trigger"), follow
+[reference/resolving-app-keys.md](reference/resolving-app-keys.md) to resolve display names to
+`app_key` / `key` / `type` — never guess a key from the display name.
+
+### 3. Compose the SQL
+
+Mandatory checklist:
+
+- `deleted_at IS NULL` for every table referenced, table-qualified in joins — by default. Drop it for
+  a specific table only if the user explicitly wants deleted rows included there, or a specific
+  question intentionally doesn't care about that table's soft-delete state; ask if unsure, and call
+  out which table(s) got the guard relaxed and why in the final explanation.
+- Exclude `test_run = true` for execution-volume questions, unless the user explicitly wants test
+  runs included.
+- Qualify ambiguous columns (e.g. `f.user_id` vs. `u.id`).
+- If bucketing by calendar period (quarter/month/day), convert to SGT before truncating — but check
+  [reference/gotchas.md](reference/gotchas.md) first for which conversion applies: the core tables'
+  timestamp columns are `timestamptz` (a single `AT TIME ZONE 'Asia/Singapore'` conversion), not naive
+  as a migration's `table.timestamps(true, true)` call might suggest. Don't assume; verify against the
+  live schema if unsure.
+- If the query touches `execution_steps` (large and growing on prod), or otherwise aggregates over a
+  row count you're not confident fits in memory, wrap it in the OOM-guard settings block from
+  [reference/gotchas.md](reference/gotchas.md) before delivering it for prod execution.
+
+Check the composed query against [reference/recipes.md](reference/recipes.md) — if the question
+matches one of those shapes, the recipe is the reference implementation.
+
+### 4. Grafana output (if applicable)
+
+If the output targets a Grafana panel, follow [reference/grafana.md](reference/grafana.md): cast
+macro expansions explicitly before passing them into any overloaded function or timezone conversion,
+and pick the panel design (single window vs. fixed trailing window of N periods) — **ask the user**
+if it's ambiguous; this is a real design decision, not something inferable from the question alone.
+
+### 5. Validate locally
+
+Validate the query read-only against the Postgres container brought up by `npm run setup` (the human
+runs this themselves — don't start it yourself; if it doesn't seem to be running, ask). Run `psql`
+inside that container via `docker exec`, rather than a locally-installed client — find the running
+container's name with `docker ps` (it's derived from the `postgres` service in
+[docker-compose.dev.yml](../../../packages/backend/docker-compose.dev.yml)), and read the database and
+user from the same file.
+
+Wrap in a read-only transaction:
+
+```bash
+docker exec <postgres container name> psql -U <user from docker-compose.dev.yml> \
+  -d <database from docker-compose.dev.yml> \
+  -c "BEGIN; SET TRANSACTION READ ONLY; <query> LIMIT 0; ROLLBACK;"
+```
+
+or `EXPLAIN <query>` for a syntax/reference-only check. For queries containing Grafana macros,
+substitute a literal timestamp for each macro first (see
+[reference/grafana.md](reference/grafana.md)) — `psql` doesn't expand them there. Self-correct on
+error, up to a few retries; if it still fails, report the error rather than guessing further.
+
+State plainly that counts of 0 are expected against this container's (test-only) data — the SQL's
+correctness is what's being validated, not the numbers it returns there.
+
+### 6. Output
+
+Present:
+
+- the final SQL in a fenced block (with Grafana macros restored, and any OOM-guard block from step 3
+  included),
+- a one-paragraph plain-English explanation of what it computes and the assumptions made,
+- any Grafana panel configuration notes (query format, visualization type, X-axis, units), and
+- a note that the query is meant to be run against a **prod read-replica**, not local data.
+
+## Keeping this skill in sync
+
+There are no source-code markers pointing back at these docs, so they only stay accurate if updated
+deliberately. If a session surfaces something worth capturing — (not an exhaustive list) e.g. the user
+clarifies an ambiguous term, you find a column whose meaning isn't self-explanatory from its model
+file, or validation reveals that [reference/glossary.md](reference/glossary.md) or
+[reference/gotchas.md](reference/gotchas.md) is stale or wrong — ask the user whether to update the
+relevant doc with what you learned. Don't edit these docs unprompted.

--- a/.claude/skills/get-metrics-sql/reference/glossary.md
+++ b/.claude/skills/get-metrics-sql/reference/glossary.md
@@ -1,0 +1,110 @@
+# Glossary
+
+Business-term definitions, each mapped to a concrete SQL fragment. Pin down every ambiguous term
+against this list before composing a query — several terms collide with each other in ways that
+produce a syntactically valid but wrong query if you guess.
+
+## Published pipe vs. active pipe (term collision — read this one first)
+
+These are two unrelated concepts that happen to share the word "active":
+
+- **Published pipe**: `flows.active = true`. A flag the user sets when they publish a pipe. See
+  [flow.ts](../../../../packages/backend/src/models/flow.ts).
+- **Active pipe**: a pipe with ≥1 *flowed* execution in a given period (see "Flow (verb)" below). Not
+  a column — a computed, time-scoped property derived from `executions`.
+
+If a question says "active pipe" without further context, default to the computed definition (flowed
+within a period) when the question is about usage/engagement, and to `flows.active = true` when it's
+about publish state. When genuinely ambiguous, ask rather than guess.
+
+## Flow (verb): to execute a pipe on non-test data
+
+"Flow" as a verb means: an `executions` row exists with `test_run = false`. This is the building block
+for "active pipe" and "active user" below.
+
+## Active user
+
+A user with ≥1 flowed pipe within a given period. There is no direct `executions.user_id` — join
+through `flows.user_id`:
+
+```sql
+SELECT DISTINCT f.user_id
+FROM executions e
+JOIN flows f ON f.id = e.flow_id AND f.deleted_at IS NULL
+WHERE e.test_run = false
+  AND e.deleted_at IS NULL
+  AND e.created_at >= <period_start> AND e.created_at < <period_end>
+```
+
+(Period bounds must be computed in SGT — see [gotchas.md](gotchas.md)'s timezone rule — before being
+compared against `executions.created_at`, which is `timestamptz`.)
+
+## Quarter
+
+A calendar quarter, half-open bounds. E.g. Q2'2026 = `[2026-04-01 00:00, 2026-07-01 00:00)` in SGT.
+Always compute quarter boundaries in SGT — see [gotchas.md](gotchas.md)'s timezone rule for the
+correct single-conversion pattern for these `timestamptz` columns. Same pattern applies to month/day
+bucketing.
+
+## N-quarter retention (gap-based, not span-based)
+
+N-quarter retention means the target quarter is **N quarters after** the baseline quarter:
+
+- 1-quarter retention: Q1 → Q2
+- 2-quarter retention: Q1 → Q3
+- 3-quarter retention: Q1 → Q4
+- 4-quarter retention: Q1 → Q5
+
+This is a **gap**, not a span — "3-quarter retention" is *not* "a 3-quarter-wide window" (which would
+read as Q1→Q3); it's "the quarter 3 quarters after baseline" (Q1→Q4). See
+[recipes.md](recipes.md) for the full worked retention query using this convention.
+
+## Pipe contains app X
+
+An `EXISTS` check over `steps`:
+
+```sql
+EXISTS (
+  SELECT 1 FROM steps s
+  WHERE s.flow_id = f.id
+    AND s.app_key = '<app_key>'
+    AND s.deleted_at IS NULL
+)
+```
+
+Resolve the app's display name → `app_key` per [resolving-app-keys.md](resolving-app-keys.md). Add
+`AND s.type = 'trigger'` / `'action'` and `AND s.key = '<key>'` if the question names a specific
+trigger/action rather than just the app.
+
+## Execution in period (and the testRun exclusion)
+
+`executions.created_at` within the target window, table-qualified and soft-delete-guarded, **and**
+`test_run = false` unless the user explicitly asks about test runs:
+
+```sql
+e.created_at >= <period_start> AND e.created_at < <period_end>
+AND e.test_run = false
+AND e.deleted_at IS NULL
+```
+
+## Agency
+
+The email domain of `users.email`:
+
+```sql
+split_part(u.email, '@', 2) AS agency
+```
+
+## Owner vs. collaborator
+
+`flows.user_id` is the pipe's **owner**. Collaborators are a separate relation
+(`flow_collaborators`, via `Flow.collaborators` in
+[flow.ts](../../../../packages/backend/src/models/flow.ts)) with roles `owner` / `editor` / `viewer`
+(`IFlowCollabRole`) — a distinct concept from ownership. Default to owner (`flows.user_id`) unless the
+question explicitly says "collaborator" or "shared with."
+
+## Trigger vs. action
+
+`steps.type` is `'trigger'` or `'action'`. A pipe has exactly one trigger step and 0+ action steps —
+see `getTriggerStep()` / the `type` filters in
+[step.ts](../../../../packages/backend/src/models/step.ts).

--- a/.claude/skills/get-metrics-sql/reference/gotchas.md
+++ b/.claude/skills/get-metrics-sql/reference/gotchas.md
@@ -1,0 +1,205 @@
+# Gotchas
+
+Rules that are **not** visible from reading a single model file. Reading `flow.ts`, `step.ts`,
+`execution.ts`, etc. gets you most of the way to correct SQL — these are the traps that bite anyway,
+because the behavior lives elsewhere (a query-builder hook, a config file, a Postgres quirk) or is a
+naming inconsistency across tables.
+
+## 1. Soft-delete auto-append
+
+The ORM's `ExtendedQueryBuilder`
+([packages/backend/src/models/query-builder.ts:18-22](../../../../packages/backend/src/models/query-builder.ts#L18-L22))
+auto-appends a soft-delete guard to every query it builds:
+
+```ts
+qb.onBuild((builder) => {
+  if (!builder.context().withSoftDeleted) {
+    builder.whereNull(`${qb.modelClass().tableName}.${DELETED_COLUMN_NAME}`)
+  }
+})
+```
+
+That's `WHERE <table>.deleted_at IS NULL`, table-qualified. Raw SQL gets none of this — add it back
+manually by default, **once per table referenced, table-qualified** (matching how the ORM does it
+internally), not as a single bare `deleted_at IS NULL` once several soft-deleted tables are joined.
+
+This is a default, not an absolute — a specific question may intentionally want deleted rows included
+for a given table (e.g. an audit/reconciliation count), or simply not care about that table's
+soft-delete state. Relax the guard only for the table(s) the question actually calls for, ask if it's
+unclear which, and say so explicitly in the query's explanation — don't drop it silently, and don't
+drop it for tables the question didn't ask about.
+
+All 6 of these tables carry a real `deleted_at` column
+([20220928162525_soft-delete-base-model.ts](../../../../packages/backend/src/db/migrations/20220928162525_soft-delete-base-model.ts)):
+
+- `flows`
+- `steps`
+- `executions`
+- `execution_steps`
+- `users`
+- `connections`
+
+Example, table-qualified in a join:
+
+```sql
+FROM executions e
+JOIN flows f ON f.id = e.flow_id AND f.deleted_at IS NULL
+WHERE e.deleted_at IS NULL
+```
+
+## 2. Timezone: columns are `timestamptz` — a single conversion, not a round-trip
+
+`created_at` / `updated_at` / `deleted_at` / `published_at` on all 6 core tables (`flows`, `steps`,
+`executions`, `execution_steps`, `users`, `connections`) are **`timestamp with time zone`** in the
+live schema — confirmed via `\d <table>` against the dev Postgres container, not by reading migration
+source.
+This is easy to get backwards: the migrations declare them with the unassuming
+`table.timestamps(true, true)`
+([20220219093113_create_executions.ts](../../../../packages/backend/src/db/migrations/20220219093113_create_executions.ts)
+is a representative example), which reads like it might produce a naive `timestamp` column. It
+doesn't — Knex's Postgres column compiler defaults `useTz` to `true` whenever no explicit options
+object is passed to the underlying `.timestamp()` call, so the bare, no-options form actually
+produces `timestamptz`. **Don't infer naive-vs-tz-aware from the migration call shape** — confirm
+against the live schema (`\d <table>` in psql, or query `information_schema.columns`) before deciding
+how to handle timezones in a query. (There is currently no genuinely naive timestamp column anywhere
+in this codebase — no migration sets `useTz: false` — but a future one could, so always verify rather
+than assume.)
+
+The org's business/display convention is SGT:
+`LuxonSettings.defaultZone = 'Asia/Singapore'`
+([packages/backend/src/config/app.ts:288](../../../../packages/backend/src/config/app.ts#L288)).
+
+**Rule, for a confirmed tz-aware (`timestamptz`) column** — the common case here — a **single**
+conversion is correct; do not round-trip through UTC first:
+
+```sql
+-- Bucketing: timestamptz -> naive SGT wall-clock, then truncate
+date_trunc('quarter', created_at AT TIME ZONE 'Asia/Singapore')
+
+-- Comparing against a literal SGT boundary: naive -> timestamptz, compare directly
+created_at >= (timestamp '2026-04-01 00:00:00' AT TIME ZONE 'Asia/Singapore')
+```
+
+Applying an extra `AT TIME ZONE 'UTC'` first (i.e. `(created_at AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Singapore'`)
+is **wrong** for a `timestamptz` column — it double-shifts the value by the SGT offset and hands
+`date_trunc` a second `timestamptz` back (session-timezone-dependent truncation) instead of a plain
+`timestamp`. Confirmed firsthand: this pattern truncated an instant that is `2026-04-01 03:00` in SGT
+(unambiguously Q2 2026) down to `2026-01-01 00:00` — Q1 — a full quarter off. The single-conversion
+form above truncates the same instant correctly to `2026-04-01 00:00` (Q2).
+
+**If a column is genuinely naive** (verified against the live schema, not assumed) — e.g. it was
+declared with an explicit `useTz: false` — then *that* column needs the round-trip instead:
+
+```sql
+date_trunc('quarter', (naive_created_at AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Singapore')
+```
+
+Always check which case you're in before writing the query.
+
+## 3. Postgres function-overload ambiguity
+
+Passing an untyped literal into an overloaded function like `date_trunc` fails:
+
+```
+ERROR: function date_trunc(unknown, unknown) is not unique (42725)
+```
+
+This bites Grafana macros specifically: `$__timeFrom()` / `$__timeTo()` expand to untyped
+UTC-instant literals. Fix with an explicit cast matching the target column's actual type
+(`::timestamptz` for the tz-aware columns in this codebase — see gotcha 2; `::timestamp` only if you've
+confirmed the specific column you're comparing against is genuinely naive):
+
+```sql
+date_trunc('quarter', $__timeFrom()::timestamptz AT TIME ZONE 'Asia/Singapore')
+```
+
+See [grafana.md](grafana.md) for the full Grafana-specific ruleset.
+
+## 4. `connections.key` is actually the app key — naming diverges from `steps.app_key`
+
+On `steps`, the app is identified by the `app_key` column. On `connections`, the *same concept* (which
+app this connection/credential belongs to, e.g. `'slack'`) is stored in a column just called `key` —
+there is no separate `app_key` column on `connections`. Confirmed by usage across the codebase, e.g.
+`packages/backend/src/graphql/mutations/update-step.ts:64`: `connection.key !== input.appKey`
+(comparing a connection's `key` directly against a step's `appKey`).
+
+**Rule**: when a question involves which app a connection belongs to, filter on `connections.key`, not
+`connections.app_key` (that column doesn't exist). Don't confuse this with `steps.key`, which is the
+trigger/action key (e.g. `'sendMessageToChannel'`) — same column name, different meaning, different
+table.
+
+## 5. `execution_steps` is large and growing on prod — guard against OOM
+
+`execution_steps` (one row per step per execution) is the highest-volume table by far of the 6, and
+prod's database instance has limited memory relative to its size. A query that aggregates, joins, or
+sorts over it can get OOM-killed, especially if the planner parallelizes across several workers (each
+claiming its own `work_mem`) or picks a hash join/aggregate sized more generously than the instance
+can actually give it.
+
+**Rule**: when the final query touches `execution_steps` directly — or does any other large-scale
+aggregation you're not confident fits comfortably in memory — wrap it in this memory-conservative
+settings guard before handing it to the user for **prod** execution (this is separate from, and in
+addition to, the local-validation wrapper in [SKILL.md](../SKILL.md) step 5, which runs against the
+container's tiny dev data and doesn't need it):
+
+```sql
+BEGIN;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SET LOCAL hash_mem_multiplier = 1.0;
+SET LOCAL jit = off;
+SET LOCAL enable_memoize = off;
+
+-- … the query …
+
+COMMIT;
+```
+
+`SET LOCAL` scopes each change to the current transaction only — confirmed (against the dev Postgres
+container) to auto-revert at `COMMIT`, so it never leaks into the rest of the `psql` session.
+Prod and the dev container run the same Postgres version (the team keeps them in sync), so a query and
+this settings guard both working against the dev container is the practical signal that they'll work
+against prod too — check the running version with `SELECT version();` if you need to confirm a
+specific GUC or syntax is available, rather than assuming a version number.
+
+What each setting does (verify against `pg_settings` on whichever Postgres version you're targeting,
+rather than assuming — behavior below was confirmed against the dev container's Postgres 14):
+
+- `max_parallel_workers_per_gather = 0` — disables parallel workers for this transaction. Each
+  parallel worker gets its own `work_mem`, so parallelism multiplies peak memory per node; disabling
+  it trades query speed for a lower, more predictable ceiling. Has a real effect (default is `2`).
+- `jit = off` — skips JIT compilation of expressions, removing one more source of per-query memory
+  overhead on a large scan. Has a real effect (default is `on`).
+- `enable_memoize = off` — this skill's recipes lean heavily on correlated `EXISTS` subqueries (see
+  [recipes.md](recipes.md)), which Postgres can turn into a nested loop with a Memoize cache keyed on
+  the outer row. Memoize's cache sizing depends on planner ndistinct estimates, which can be badly
+  wrong at large scale; disabling it trades some CPU (subqueries re-execute instead of being cached)
+  for a more predictable memory footprint. Has a real effect (default is `on`; requires PG14+ — check
+  `SELECT version();` if targeting an older Postgres).
+- `hash_mem_multiplier = 1.0` — on PG13/14, this is a no-op: the built-in default (`boot_val`) is
+  already `1`. It only defaults to `2` from PG15 onward. Harmless to keep in the snippet regardless
+  (protects against a future major-version upgrade silently doubling hash memory) — check
+  `SHOW hash_mem_multiplier;` if you want to confirm which case applies on the version you're running
+  against.
+
+**Don't apply this by default to every query** — it trades speed for memory safety, and most queries
+in this skill (against `flows`/`steps`/`users`/`connections`, which are far smaller than
+`execution_steps`) don't need it. Reach for it specifically when `execution_steps` is in the query, or
+when a query aggregates over a row count you're not confident fits in memory.
+
+## 6. `status` means a different thing on each of `steps`, `executions`, and `execution_steps`
+
+Three different tables each have their own `status` column, and they are **not** the same concept —
+don't assume a `status` filter written for one table applies to another:
+
+- `steps.status`: `'incomplete' | 'completed'` — whether the step's own configuration/setup is
+  complete, not anything about execution. A step can be `'completed'` (fully configured) and still
+  never have run, or have run and failed.
+- `executions.status`: `'success' | 'failure' | null` — the outcome of the whole execution. `null`
+  means the execution is still in progress/pending, not a third terminal outcome — don't treat
+  `status IS NULL` as an error case.
+- `execution_steps.status`: `'success' | 'failure'` — the outcome of one individual step's run within
+  a specific execution (no `null`/pending state at this granularity).
+
+If a question asks about "failed executions" or "successful steps," pin down which of these three it
+actually means (execution-level outcome vs. individual-step-run outcome vs. step-configuration state)
+before writing the filter, and check [glossary.md](glossary.md) if the business term is ambiguous.

--- a/.claude/skills/get-metrics-sql/reference/grafana.md
+++ b/.claude/skills/get-metrics-sql/reference/grafana.md
@@ -1,0 +1,50 @@
+# Grafana
+
+Grafana is a distinct output target from "SQL for a human to paste into prod" — it has its own traps.
+Follow this doc whenever a metrics question targets a Grafana panel.
+
+## Macro casting
+
+`$__timeFrom()` / `$__timeTo()` expand to **untyped** UTC-instant literals. Passed directly into an
+overloaded function (`date_trunc`) or an `AT TIME ZONE` conversion, they trigger the
+`function date_trunc(unknown, unknown) is not unique (42725)` error described in
+[gotchas.md](gotchas.md). Always cast explicitly first:
+
+```sql
+$__timeFrom()::timestamptz AT TIME ZONE 'Asia/Singapore'
+```
+
+Use `::timestamptz` here — the macro expands to a UTC instant, and this also matches the actual
+declared type of Plumber's own `created_at`-style columns (`timestamptz`; see
+[gotchas.md](gotchas.md)'s timezone gotcha).
+
+## Local validation: no macro expansion in `psql`
+
+`psql` does not expand Grafana macros at all — an unmodified macro-bearing query will simply fail to
+parse when run there. Before running a macro-bearing query against the dev Postgres container,
+substitute a literal timestamp for each macro (e.g. replace `$__timeFrom()` with
+`'2026-01-01T00:00:00Z'`), run it, then swap the literal back out for the macro in the version you hand
+back to the user.
+
+## Bar chart panel config
+
+- Query format: **Table** (not Time series).
+- Visualization type: **Bar chart**.
+- X-axis field: the string/category column (e.g. a `to_char(...)`-formatted period label).
+- Unit: **Percent (0-100)** for any rate/percentage column (e.g. a retention `_pct` column).
+
+## Fixed trailing-window pattern
+
+For a panel that should always show a constant number of bars (e.g. "always show the last 3
+quarters") regardless of the selected time range's width:
+
+- Anchor entirely on `$__timeFrom()`. Ignore `$__timeTo()` — using both means the bar count varies
+  with whatever range the viewer happens to have selected, defeating "always show N."
+- Generate the exact set of period buckets explicitly, e.g. via `generate_series(0, N-1)`, rather than
+  deriving the bucket set from whichever data happens to exist for the range. Otherwise a period with
+  zero activity silently produces a **missing bar** instead of a **zero bar** — a real difference on a
+  dashboard (no bar reads as "no data queried," not "zero users").
+
+See [recipes.md](recipes.md)'s retention query for a full worked example combining both of the rules
+above (a `bounds`/`bars` CTE anchored on `$__timeFrom()`, with `generate_series` producing the fixed
+bar count).

--- a/.claude/skills/get-metrics-sql/reference/recipes.md
+++ b/.claude/skills/get-metrics-sql/reference/recipes.md
@@ -1,0 +1,224 @@
+# Recipes
+
+Worked, end-to-end example queries. Each has every applicable rule from
+[gotchas.md](gotchas.md) already applied. These double as the skill's regression examples — if a
+generated query for one of these questions looks meaningfully different from its recipe, treat that
+as a signal to double-check against [glossary.md](glossary.md)/[gotchas.md](gotchas.md) before
+outputting it.
+
+## Recipe 1: pipes with an execution in the past quarter, containing a specific trigger and action
+
+**Question**: "How many pipes have ≥1 execution in the past quarter AND contain the gathersg trigger
+AND the slack action?"
+
+```sql
+WITH bounds AS (
+  SELECT
+    (date_trunc('quarter', now() AT TIME ZONE 'Asia/Singapore') AT TIME ZONE 'Asia/Singapore') - interval '3 months' AS quarter_start,
+    (date_trunc('quarter', now() AT TIME ZONE 'Asia/Singapore') AT TIME ZONE 'Asia/Singapore') AS quarter_end
+)
+SELECT COUNT(DISTINCT f.id) AS pipe_count
+FROM flows f, bounds b
+WHERE f.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM steps s
+    WHERE s.flow_id = f.id
+      AND s.app_key = 'gathersg'
+      AND s.type = 'trigger'
+      AND s.deleted_at IS NULL
+  )
+  AND EXISTS (
+    SELECT 1 FROM steps s
+    WHERE s.flow_id = f.id
+      AND s.app_key = 'slack'
+      AND s.type = 'action'
+      AND s.deleted_at IS NULL
+  )
+  AND EXISTS (
+    SELECT 1 FROM executions e
+    WHERE e.flow_id = f.id
+      AND e.test_run = false
+      AND e.deleted_at IS NULL
+      AND e.created_at >= b.quarter_start
+      AND e.created_at < b.quarter_end
+  );
+```
+
+Notes:
+- "gathersg trigger" / "slack action" resolved via [resolving-app-keys.md](resolving-app-keys.md) to
+  `app_key='gathersg' AND type='trigger'` and `app_key='slack' AND type='action'`.
+- Each app/trigger/action condition and the execution-in-period condition are separate `EXISTS`
+  subqueries against `flows`, not joins — a pipe can have many matching `steps`/`executions` rows, and
+  joining all three directly would multiply rows and require an extra `DISTINCT` to compensate; `EXISTS`
+  avoids that entirely.
+- "Past quarter" bounds: `now() AT TIME ZONE 'Asia/Singapore'` converts the current instant to a naive
+  SGT wall-clock value, `date_trunc('quarter', ...)` truncates it to the current SGT quarter start, and
+  the outer `AT TIME ZONE 'Asia/Singapore'` converts that naive value back to `timestamptz` — a single
+  conversion each way, per [gotchas.md](gotchas.md)'s timezone rule. `quarter_start`/`quarter_end` are
+  therefore `timestamptz`, directly comparable to `executions.created_at` (also `timestamptz`) with no
+  further conversion needed.
+- `test_run = false` excludes test executions, per [glossary.md](glossary.md).
+
+## Recipe 2: agency breakdown of owners of published pipes containing an app
+
+**Question**: "What agency (email domain) do the owners of published pipes containing the slack
+action mostly come from?"
+
+```sql
+SELECT
+  split_part(u.email, '@', 2) AS agency,
+  COUNT(DISTINCT f.id) AS pipe_count
+FROM flows f
+JOIN users u ON u.id = f.user_id AND u.deleted_at IS NULL
+WHERE f.deleted_at IS NULL
+  AND f.active = true
+  AND EXISTS (
+    SELECT 1 FROM steps s
+    WHERE s.flow_id = f.id
+      AND s.app_key = 'slack'
+      AND s.type = 'action'
+      AND s.deleted_at IS NULL
+  )
+GROUP BY agency
+ORDER BY pipe_count DESC;
+```
+
+Notes:
+- "Published" = `flows.active = true` (see [glossary.md](glossary.md)'s published-vs-active-pipe
+  disambiguation) — not the computed "active pipe" definition.
+- "Owner" = `flows.user_id` joined to `users`, not a collaborator.
+- "Agency" = email domain via `split_part(u.email, '@', 2)`.
+
+## Recipe 3: quarterly active-user retention (Grafana bar chart, fixed trailing window)
+
+**Question**: "What's the quarter-over-quarter retention rate of active users, as a Grafana bar
+chart?" — specifically, retention at 1/2/3/4-quarter gaps (see [glossary.md](glossary.md)'s
+gap-based definition), shown as a fixed trailing window of the last 3 quarters regardless of the
+selected Grafana time range.
+
+```sql
+WITH bounds AS (
+  SELECT
+    date_trunc(
+      'quarter',
+      $__timeFrom()::timestamptz AT TIME ZONE 'Asia/Singapore'
+    ) AS target_quarter
+),
+quarterly_active_users AS (
+  SELECT DISTINCT
+    f.user_id,
+    date_trunc(
+      'quarter',
+      e.created_at AT TIME ZONE 'Asia/Singapore'
+    ) AS quarter
+  FROM executions e
+  JOIN flows f ON f.id = e.flow_id AND f.deleted_at IS NULL
+  JOIN users u ON u.id = f.user_id AND u.deleted_at IS NULL
+  CROSS JOIN bounds b
+  WHERE e.test_run = false
+    AND e.deleted_at IS NULL
+    -- 3 trailing bars, each needing a baseline up to 4 quarters (12 months)
+    -- earlier => pull back (3-1)*3 + 12 = 18 months before target_quarter
+    AND e.created_at >= (b.target_quarter AT TIME ZONE 'Asia/Singapore') - interval '18 months'
+    AND e.created_at < (b.target_quarter AT TIME ZONE 'Asia/Singapore') + interval '3 months'
+),
+quarterly_counts AS (
+  SELECT quarter, COUNT(DISTINCT user_id) AS active_users
+  FROM quarterly_active_users
+  GROUP BY quarter
+),
+retention_1q AS (  -- 1-quarter gap: e.g. Q1 -> Q2
+  SELECT
+    base.quarter + interval '3 months' AS curr_quarter,
+    COUNT(DISTINCT base.user_id) AS base_users,
+    COUNT(DISTINCT ret.user_id) AS retained_users
+  FROM quarterly_active_users base
+  LEFT JOIN quarterly_active_users ret
+    ON ret.user_id = base.user_id AND ret.quarter = base.quarter + interval '3 months'
+  GROUP BY base.quarter
+),
+retention_2q AS (  -- 2-quarter gap: e.g. Q1 -> Q3
+  SELECT
+    base.quarter + interval '6 months' AS curr_quarter,
+    COUNT(DISTINCT base.user_id) AS base_users,
+    COUNT(DISTINCT ret.user_id) AS retained_users
+  FROM quarterly_active_users base
+  LEFT JOIN quarterly_active_users ret
+    ON ret.user_id = base.user_id AND ret.quarter = base.quarter + interval '6 months'
+  GROUP BY base.quarter
+),
+retention_3q AS (  -- 3-quarter gap: e.g. Q1 -> Q4
+  SELECT
+    base.quarter + interval '9 months' AS curr_quarter,
+    COUNT(DISTINCT base.user_id) AS base_users,
+    COUNT(DISTINCT ret.user_id) AS retained_users
+  FROM quarterly_active_users base
+  LEFT JOIN quarterly_active_users ret
+    ON ret.user_id = base.user_id AND ret.quarter = base.quarter + interval '9 months'
+  GROUP BY base.quarter
+),
+retention_4q AS (  -- 4-quarter gap: e.g. Q1 -> Q5
+  SELECT
+    base.quarter + interval '12 months' AS curr_quarter,
+    COUNT(DISTINCT base.user_id) AS base_users,
+    COUNT(DISTINCT ret.user_id) AS retained_users
+  FROM quarterly_active_users base
+  LEFT JOIN quarterly_active_users ret
+    ON ret.user_id = base.user_id AND ret.quarter = base.quarter + interval '12 months'
+  GROUP BY base.quarter
+),
+bars AS (
+  SELECT b.target_quarter - (n * interval '3 months') AS curr_quarter
+  FROM bounds b, generate_series(0, 2) AS n
+)
+SELECT
+  to_char(bar.curr_quarter, '"Q"Q YYYY') AS quarter,
+  qc.active_users,
+
+  r1.base_users AS active_users_1q_ago,
+  r1.retained_users AS retained_1q,
+  ROUND(100.0 * r1.retained_users / NULLIF(r1.base_users, 0), 1) AS retention_1q_pct,
+
+  r2.base_users AS active_users_2q_ago,
+  r2.retained_users AS retained_2q,
+  ROUND(100.0 * r2.retained_users / NULLIF(r2.base_users, 0), 1) AS retention_2q_pct,
+
+  r3.base_users AS active_users_3q_ago,
+  r3.retained_users AS retained_3q,
+  ROUND(100.0 * r3.retained_users / NULLIF(r3.base_users, 0), 1) AS retention_3q_pct,
+
+  r4.base_users AS active_users_4q_ago,
+  r4.retained_users AS retained_4q,
+  ROUND(100.0 * r4.retained_users / NULLIF(r4.base_users, 0), 1) AS retention_4q_pct
+
+FROM bars bar
+LEFT JOIN quarterly_counts qc ON qc.quarter = bar.curr_quarter
+LEFT JOIN retention_1q r1 ON r1.curr_quarter = bar.curr_quarter
+LEFT JOIN retention_2q r2 ON r2.curr_quarter = bar.curr_quarter
+LEFT JOIN retention_3q r3 ON r3.curr_quarter = bar.curr_quarter
+LEFT JOIN retention_4q r4 ON r4.curr_quarter = bar.curr_quarter
+ORDER BY bar.curr_quarter;
+```
+
+Notes:
+- `executions.created_at` is `timestamptz` (confirmed against the live schema — see
+  [gotchas.md](gotchas.md)'s timezone gotcha), so bucketing uses a **single**
+  `e.created_at AT TIME ZONE 'Asia/Singapore'` conversion (not a round-trip through UTC), and the
+  range filter converts `target_quarter` (naive, from the macro-cast `bounds` CTE) back to
+  `timestamptz` once via `AT TIME ZONE 'Asia/Singapore'` before comparing directly against
+  `e.created_at`.
+- Each retention gap is pre-aggregated to one row per quarter in its own CTE before the final join —
+  this avoids a row-multiplying cross join that would happen if the current-quarter set and each
+  gap's base/retained sets were all `LEFT JOIN`ed directly off `bars` in one shot (correct via
+  `COUNT(DISTINCT ...)` either way, but needlessly expensive).
+- Grafana panel config: query format `Table`, visualization `Bar chart`, X-axis = `quarter`,
+  `Percent (0-100)` unit on the `retention_*_pct` columns — see [grafana.md](grafana.md).
+- `bars` is generated explicitly via `generate_series`, anchored only on `$__timeFrom()` (per
+  [grafana.md](grafana.md)'s fixed-trailing-window pattern) — this guarantees exactly 3 bars
+  regardless of the selected Grafana time range, and a quarter with zero activity still renders as a
+  zero bar rather than a missing one.
+- Expect `NULL`s on the higher-gap columns for the earliest displayed bars (e.g. the first bar has no
+  4-quarters-ago baseline within the pulled-back window) — that's `NULLIF` correctly producing no
+  ratio, not a bug.
+- To validate locally, substitute a literal timestamp for `$__timeFrom()` first (see
+  [grafana.md](grafana.md)) — `psql` has no macro expansion.

--- a/.claude/skills/get-metrics-sql/reference/resolving-app-keys.md
+++ b/.claude/skills/get-metrics-sql/reference/resolving-app-keys.md
@@ -1,0 +1,77 @@
+# Resolving app/trigger/action keys
+
+`steps.app_key` + `steps.key` + `steps.type` store opaque string literals (`'slack'` /
+`'sendMessageToChannel'` / `'action'`). The human-readable names only exist in code, under
+[packages/backend/src/apps/](../../../../packages/backend/src/apps/). Whenever a question names an
+app, trigger, or action by its display name, resolve it to keys via the grep procedure below — don't
+guess a key from the display name (see the FormSG example below for why that's unsafe).
+
+## Procedure
+
+1. **App key**: the directory name under `packages/backend/src/apps/<app-key>/` — this is also the
+   value of the top-level `key:` field in `packages/backend/src/apps/<app-key>/index.ts`. The
+   display name is that same file's top-level `name:` field.
+
+   ```ts
+   // packages/backend/src/apps/gathersg/index.ts
+   name: 'Ownself Gather',
+   key: 'gathersg',
+   ```
+
+   The directory/key doesn't always resemble the display name — `gathersg` displays as
+   "Ownself Gather," not "GatherSG." Always read the `name:` field; never infer the app key by
+   abbreviating or transliterating the display name.
+
+2. **Trigger/action key**: grep `name:` and `key:` inside
+   `packages/backend/src/apps/<app-key>/triggers/<trigger-dir>/index.ts` or
+   `packages/backend/src/apps/<app-key>/actions/<action-dir>/index.ts`.
+
+   ```ts
+   // packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+   name: 'Send a message to channel',
+   key: 'sendMessageToChannel',
+   ```
+
+   The kebab-case directory name does not necessarily match the camelCase `key:` value inside
+   (`send-a-message-to-channel` → `sendMessageToChannel`). Read the `key:` field itself — don't infer
+   it from the directory name.
+
+3. **`steps.type`** is the literal string `'trigger'` or `'action'` — not the trigger's own optional
+   `type` field some app definitions have (e.g. FormSG/GatherSG triggers have their own
+   `type: 'webhook'` field, which is an unrelated trigger-subtype flag, not the `steps.type` column
+   value).
+
+## Deviations to watch for when grepping
+
+- **Flat-file triggers/actions**: most apps put each trigger/action in its own
+  `<key-dir>/index.ts`, but at least one app (`databricks`) stores an action directly as
+  `actions/create-row.ts` with no subdirectory. If grepping `actions/*/index.ts` /
+  `triggers/*/index.ts` turns up nothing for an app, also check for loose `actions/*.ts` /
+  `triggers/*.ts` files.
+- **Non-trigger/action helper files**: a `triggers/` or `actions/` directory can contain a helper file
+  that isn't itself a trigger/action (e.g. `scheduler/triggers/get-data-out-metadata.ts`). Confirm a
+  candidate file actually exports an object with its own `key:`/`name:` fields before treating it as a
+  resolvable trigger/action.
+- **Apps with only one of triggers/actions**: normal, not a deviation — e.g. `webhook` has only
+  `triggers/`, `slack` (at time of writing) has only `actions/`.
+- **Display-name collisions across type**: two entries can share a display name. FormSG's trigger
+  `newSubmission` and its hidden action `mrfSubmission` are both labeled "New form response" in code
+  (the action is a hidden MRF-continuation step, `hiddenFromUser: true`, not shown in the builder UI).
+  Resolving by display-name text search alone is ambiguous here — always resolve to the
+  `(app_key, type, key)` triple before writing SQL, and if a display name doesn't uniquely determine
+  `type`, grep both `triggers/` and `actions/` and disambiguate using the question's own phrasing
+  ("the FormSG trigger" vs. "the FormSG action").
+
+## Starter table (confirm via grep — don't treat as exhaustive or stale-proof)
+
+| App display name | `app_key` | Trigger/action display name | `key` | `type` |
+|---|---|---|---|---|
+| FormSG | `formsg` | New form response | `newSubmission` | trigger |
+| FormSG | `formsg` | New form response (hidden MRF continuation) | `mrfSubmission` | action |
+| Ownself Gather | `gathersg` | New instant workflow | `newInstantWorkflow` | trigger |
+| Ownself Gather | `gathersg` | Create case | `createCase` | action |
+
+This table is a starting point for the most commonly-referenced apps, not a substitute for grepping —
+apps get added/renamed over time, so always confirm against the current source in
+[packages/backend/src/apps/](../../../../packages/backend/src/apps/) before finalizing a query, per
+the procedure above.


### PR DESCRIPTION
# Context

I keep having to do this for digging around our product stuff so I added this as a skill

---

Adds `.claude/skills/get-metrics-sql/` — a skill that turns plain-English
business-metrics questions about Plumber's pipes/executions/users into correct,
soft-delete-safe, timezone-correct Postgres SQL, for both one-off questions and
Grafana panels.