### PR TITLE
chore: bump fast-uri, shell-quote, js-yaml, immutable for security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30308,9 +30308,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19721,9 +19721,9 @@
       "license": "ISC"
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20931,10 +20931,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17159,9 +17159,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
     "vite": "6.4.3",
-    "immutable": "4.3.8",
+    "immutable": "4.3.9",
     "picomatch": "4.0.4",
     "shell-quote": "1.9.0",
     "form-data": "4.0.6"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vite": "6.4.3",
     "immutable": "4.3.8",
     "picomatch": "4.0.4",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.9.0",
     "form-data": "4.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## TL;DR

Security-motivated dependency bumps: `fast-uri`, `shell-quote`, `js-yaml`, and `immutable`. All are transitive dependencies (or, for `fast-uri`, sit behind `ajv-formats`) with no first-party call sites in Plumber's own code, so these are low-risk patch/minor bumps.

## What changed?

- **`fast-uri` 3.1.2 → 3.1.5** — fixes host/authority-confusion bugs ([CVE-2026-16221](https://github.com/fastify/fast-uri/security/advisories/GHSA-v2hh-gcrm-f6hx), CVE-2026-18446) where fast-uri parsed a different host than Node's WHATWG URL/`fetch()` for the same backslash-containing string.
- **`shell-quote` 1.8.4 → 1.9.0** — fixes a ReDoS vulnerability ([GHSA-395f-4hp3-45gv](https://github.com/ljharb/shell-quote/security/advisories/GHSA-395f-4hp3-45gv)) and escapes leading tildes in `quote()`. Pinned via the root `overrides` block; pulled in transitively by `@graphql-codegen/cli`, `concurrently`, and `dd-trace`.
- **`js-yaml` 4.1.1 → 4.3.1** — adds DoS guards (`maxDepth`, `maxTotalMergeKeys`) and fixes underscore-number parsing. Transitive dependency of `eslint`/`cosmiconfig` only.
- **`immutable` 4.3.8 → 4.3.9** — fixes two high-severity DoS advisories: GHSA-v56q-mh7h-f735 (List 32-bit trie bounds overflow) and GHSA-xvcm-6775-5m9r (Map/Set hash-collision DoS). Transitive dependency pulled in via `sass` and `relay-compiler` (graphql-codegen) at build/codegen time only.

For each package, confirmed via direct source search that Plumber's own code (`packages/backend`, `packages/frontend`, `packages/types`) has no direct import/call site — so none of the parsing-behavior changes in these releases affect application logic.

## Tests

- [ ] `npm run lint` passes across the monorepo
- [ ] `npm test` passes (frontend, backend unit, backend integration)
- [ ] `npm run build` succeeds (sass/relay-compiler/eslint still parse correctly with bumped `js-yaml`/`immutable`)

## Deploy notes

No runtime behavior change expected — dependency-only bump, no application code touched.