### PR TITLE
PLU-864: retry formsg attachment download if appropriate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,8 +34,9 @@ Do **not** run these yourself unless the user asks — the human runs the dev se
 - **Linting**: before committing, run `npm run lint:fix` (auto-fixes), then `npm run lint` and fix remaining errors. Scope to the workspace you touched: backend-only changes → `npm run -w backend lint:fix`; frontend-only → `npm run -w frontend lint:fix`; otherwise run the root command.
 - **Production monitoring**: after completing a backend/frontend feature, offer to run the `setup-production-monitoring` skill to plan Datadog monitoring for it.
 - **Branches & PRs**: managed via Graphite (`gt`); use the `graphite` skill.
+  - **Branch name prefixes**: `feat/<…>` for features, `fix/<…>` for bugfixes, `chore/<…>` for everything else.
   - **Before `gt submit`** (do both, in this order):
-    1. **Fix the branch name.** If the current branch doesn't match `feat/<…>` or `chore/<…>` (e.g. an auto-generated `claude/<slug>` worktree branch), rename it first: `git branch -m <name>` (works on untracked branches) or `gt rename <name>` (if already tracked). You **MUST** ask the user for the branch name whenever it is at all possible to ask — never auto-pick a name unless asking is genuinely impossible.
+    1. **Fix the branch name.** If the current branch doesn't use one of those prefixes (e.g. an auto-generated `claude/<slug>` worktree branch), rename it first: `git branch -m <name>` (works on untracked branches) or `gt rename <name>` (if already tracked). You **MUST** ask the user for the branch name whenever it is at all possible to ask — never auto-pick a name unless asking is genuinely impossible.
     2. **Track the branch.** Ensure it is tracked onto the branch directly below it in the stack: `gt track --parent <branch-below>`. The parent is the branch immediately beneath it, or the trunk if it sits at the bottom of the stack (note: the trunk is not necessarily named `main`).
 
 ## Skills

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -52,3 +52,4 @@ GraphQL schema and resolvers also live here ([packages/backend/src/graphql/](../
 
 - **Tests**: try to add unit tests (`*.test.ts`) for any new code.
 - **APIs**: prefer adding REST endpoints over new root GraphQL fields (queries/mutations) when exposing new functionality.
+- **Axios errors**: never re-throw or log an axios error. It carries the request URL, request headers and response body, which can hold credentials or other sensitive data. Convert it to a new `Error` naming only the HTTP status code and `error.message`. Do not attach the original as `cause`, since loggers serialise the whole chain. For the pattern, see `sanitiseError` in [packages/backend/src/apps/formsg/auth/download-encrypted-attachment.ts](../../packages/backend/src/apps/formsg/auth/download-encrypted-attachment.ts).

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3-or-v4.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3-or-v4.test.ts
@@ -33,6 +33,10 @@ vi.mock('@/helpers/logger', () => ({
 vi.mock('axios', () => ({
   default: {
     get: mocks.axiosGet,
+    isAxiosError: (error: unknown) =>
+      typeof error === 'object' &&
+      error !== null &&
+      (error as { isAxiosError?: boolean }).isAxiosError === true,
   },
 }))
 
@@ -136,6 +140,24 @@ describe('decrypt form attachments v3', () => {
           FORM_FIELDS,
         ),
       ).rejects.toThrow()
+    })
+
+    it('should retry a transient 503 and still return both attachments', async () => {
+      mocks.axiosGet.mockRejectedValueOnce({
+        isAxiosError: true,
+        message: 'Request failed with status code 503',
+        response: { status: 503 },
+      })
+
+      const result = await decryptFormAttachmentsV3OrV4(
+        formSgSdk,
+        SUBMISSION_SECRET_KEY,
+        $.request.body.data.attachmentDownloadUrls,
+        FORM_FIELDS,
+      )
+
+      expect(Object.keys(result)).toHaveLength(2)
+      expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
     })
 
     it('should throw an error if downloading fails', async () => {

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -218,6 +218,42 @@ describe('decrypt form response - MRF specific', () => {
       )
     })
 
+    it('should return verified: false without downloading when an attachment URL is untrusted', async () => {
+      $.flow.hasFileProcessingActions = true
+      $.request.body.data.attachmentDownloadUrls = {
+        attachField1:
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
+        attachField2: 'https://plumber.svc.cluster.local/a',
+      }
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        submissionSecretKey: 'mock-secret-key',
+        responses: {
+          attachField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({ verified: false, internalId: null })
+      expect(mocks.decryptFormAttachmentsV3OrV4).not.toHaveBeenCalled()
+      expect(mocks.consoleError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'formsg-untrusted-attachment-url',
+          submissionId: 'submissionId',
+          attachmentDownloadUrls: {
+            attachField1:
+              'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
+            attachField2: 'https://plumber.svc.cluster.local/a',
+          },
+        }),
+      )
+    })
+
     it('should return verified: false when decryption fails', async () => {
       mocks.cryptoV3Decrypt.mockReturnValueOnce(null)
 
@@ -245,7 +281,8 @@ describe('decrypt form response - MRF specific', () => {
     it('should not call v3 attachment decryption when hasFileProcessingActions is false', async () => {
       $.flow.hasFileProcessingActions = false
       $.request.body.data.attachmentDownloadUrls = {
-        attachField1: 'https://example.com/download/1',
+        attachField1:
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/download/1',
       }
 
       mocks.cryptoV3Decrypt.mockReturnValueOnce({
@@ -482,7 +519,8 @@ describe('decrypt form response - MRF specific', () => {
         const workflowContent = makeWorkflowContent(2)
         $.request.body.data.workflowContent = workflowContent
         $.request.body.data.attachmentDownloadUrls = {
-          attachmentField1: 'https://example.com/download/1',
+          attachmentField1:
+            'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/download/1',
         }
         $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
 
@@ -515,7 +553,8 @@ describe('decrypt form response - MRF specific', () => {
       it('should not suffix storageId for non-MRF attachments', async () => {
         $.flow.hasFileProcessingActions = true
         $.request.body.data.attachmentDownloadUrls = {
-          attachmentField1: 'https://example.com/download/1',
+          attachmentField1:
+            'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/download/1',
         }
         $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
 

--- a/packages/backend/src/apps/formsg/__tests__/auth/download-encrypted-attachment.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/download-encrypted-attachment.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { downloadEncryptedAttachment } from '../../auth/download-encrypted-attachment'
+
+const mocks = vi.hoisted(() => {
+  return {
+    axiosGet: vi.fn(),
+    consoleError: vi.fn(),
+    consoleWarn: vi.fn(),
+  }
+})
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.consoleError,
+    warn: mocks.consoleWarn,
+  },
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: mocks.axiosGet,
+    isAxiosError: (error: unknown) =>
+      typeof error === 'object' &&
+      error !== null &&
+      (error as { isAxiosError?: boolean }).isAxiosError === true,
+  },
+}))
+
+function axiosErrorWithStatus(status: number) {
+  return {
+    isAxiosError: true,
+    message: `Request failed with status code ${status}`,
+    response: { status },
+  }
+}
+
+const URL = 'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/a'
+
+/**
+ * Freezes the clock and hands back a knob to wind it forward, so tests can
+ * spend the download budget without waiting out real seconds.
+ */
+function useSimulatedClock() {
+  let now = 1_000_000
+  vi.spyOn(Date, 'now').mockImplementation(() => now)
+  return (ms: number) => {
+    now += ms
+  }
+}
+
+describe('downloadEncryptedAttachment', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it.each([429, 500, 502, 503, 504])(
+    'retries a %i and returns the payload from the successful attempt',
+    async (status) => {
+      mocks.axiosGet
+        .mockRejectedValueOnce(axiosErrorWithStatus(status))
+        .mockResolvedValueOnce({ data: { encryptedFile: 'payload' } })
+
+      const result = await downloadEncryptedAttachment(URL)
+
+      expect(result).toEqual({ encryptedFile: 'payload' })
+      expect(mocks.axiosGet).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it.each([404, 409, 501, 505])('does not retry a %i', async (status) => {
+    mocks.axiosGet.mockRejectedValue(axiosErrorWithStatus(status))
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      `Attachment download failed with status ${status}`,
+    )
+
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry an error that did not come from axios', async () => {
+    mocks.axiosGet.mockRejectedValue(new TypeError('Download failed'))
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with TypeError: Download failed',
+    )
+
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('gives up after 3 attempts when the 503 persists', async () => {
+    mocks.axiosGet.mockRejectedValue(axiosErrorWithStatus(503))
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with status 503',
+    )
+
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws a fresh error, so axios never carries the presigned URL or request headers into the logs', async () => {
+    mocks.axiosGet.mockRejectedValue({
+      isAxiosError: true,
+      message: 'Request failed with status code 404',
+      config: {
+        url: `${URL}?X-Amz-Signature=secretsignature`,
+        headers: { authorization: 'secrettoken' },
+      },
+      response: { status: 404, headers: { 'x-amz-id-2': 'secretid' } },
+    })
+
+    const error = await downloadEncryptedAttachment(URL).catch((err) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe(
+      'Attachment download failed with status 404: Request failed with status code 404',
+    )
+    expect(error.cause).toBeUndefined()
+    expect(error).not.toHaveProperty('config')
+    expect(error).not.toHaveProperty('response')
+  })
+
+  it('says so when the request never got a response', async () => {
+    mocks.axiosGet.mockRejectedValue({
+      isAxiosError: true,
+      message: 'timeout of 2000ms exceeded',
+      code: 'ECONNABORTED',
+    })
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with no response: timeout of 2000ms exceeded',
+    )
+  })
+
+  it('names the type when what was thrown is not an error', async () => {
+    mocks.axiosGet.mockRejectedValue('a string holding who knows what')
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with a thrown string',
+    )
+  })
+
+  it('bounds each attempt with a per-attempt timeout', async () => {
+    mocks.axiosGet.mockResolvedValue({ data: {} })
+
+    await downloadEncryptedAttachment(URL)
+
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      URL,
+      expect.objectContaining({ timeout: 2000 }),
+    )
+  })
+
+  it('clamps the last attempt to the budget left before the deadline', async () => {
+    const advanceClock = useSimulatedClock()
+    mocks.axiosGet.mockImplementation(async () => {
+      advanceClock(2000) // Each attempt burns its full per-attempt timeout.
+      throw axiosErrorWithStatus(503)
+    })
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with status 503',
+    )
+
+    const timeouts = mocks.axiosGet.mock.calls.map(
+      ([, config]) => config.timeout,
+    )
+    expect(timeouts).toEqual([2000, 2000, 1000])
+  })
+
+  it('stops retrying once the budget is spent, before hitting the attempt cap', async () => {
+    const advanceClock = useSimulatedClock()
+    mocks.axiosGet.mockImplementation(async () => {
+      advanceClock(2600) // Timeout plus connection overhead.
+      throw axiosErrorWithStatus(503)
+    })
+
+    await expect(downloadEncryptedAttachment(URL)).rejects.toThrow(
+      'Attachment download failed with status 503',
+    )
+
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs each retry so the retries are visible in Datadog', async () => {
+    mocks.axiosGet
+      .mockRejectedValueOnce(axiosErrorWithStatus(503))
+      .mockResolvedValueOnce({ data: {} })
+
+    await downloadEncryptedAttachment(URL)
+
+    expect(mocks.consoleWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'formsg-attachment-download-retry',
+        attempt: 1,
+        status: 503,
+      }),
+    )
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { areAttachmentUrlsTrusted } from '../../auth/trusted-attachment-urls'
+
+const TRUSTED_URL =
+  'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
+
+describe('areAttachmentUrlsTrusted', () => {
+  it('accepts an empty map', () => {
+    expect(areAttachmentUrlsTrusted({})).toBe(true)
+  })
+
+  it('accepts FormSG bucket URLs', () => {
+    expect(
+      areAttachmentUrlsTrusted({
+        attachField1: TRUSTED_URL,
+        attachField2: `${TRUSTED_URL}?X-Amz-Signature=abc`,
+      }),
+    ).toBe(true)
+  })
+
+  it.each([
+    [
+      'plain http',
+      'http://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/a',
+    ],
+    ['the EC2 metadata service', 'http://169.254.169.254/latest/meta-data/'],
+    ['an internal host', 'https://plumber.svc.cluster.local/a'],
+    [
+      'userinfo host confusion',
+      'https://s3.ap-southeast-1.amazonaws.com@evil.test/attachments.form.gov.sg/a',
+    ],
+    [
+      'a host suffix match',
+      'https://s3.ap-southeast-1.amazonaws.com.evil.test/attachments.form.gov.sg/a',
+    ],
+    [
+      'a non-default port',
+      'https://s3.ap-southeast-1.amazonaws.com:8080/attachments.form.gov.sg/a',
+    ],
+    [
+      'another bucket',
+      'https://s3.ap-southeast-1.amazonaws.com/other-bucket/a',
+    ],
+    [
+      'traversal out of the bucket',
+      'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/../other-bucket/a',
+    ],
+    ['a malformed URL', 'not-a-url'],
+    ['an empty string', ''],
+  ])('rejects %s', (_label, untrustedUrl) => {
+    expect(areAttachmentUrlsTrusted({ attachField1: untrustedUrl })).toBe(false)
+  })
+
+  it('rejects the whole map when only one URL is untrusted', () => {
+    expect(
+      areAttachmentUrlsTrusted({
+        attachField1: TRUSTED_URL,
+        attachField2: 'https://plumber.svc.cluster.local/a',
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
@@ -1,10 +1,11 @@
 import { FormField } from '@opengovsg/formsg-sdk'
 import { DecryptedAttachments } from '@opengovsg/formsg-sdk/dist/types'
-import axios from 'axios'
 
 import logger from '@/helpers/logger'
 
 import { getSdk } from '../common/form-env'
+
+import { downloadEncryptedAttachment } from './download-encrypted-attachment'
 
 /**
  * Decrypts form attachments from presigned S3 download URLs.
@@ -12,6 +13,9 @@ import { getSdk } from '../common/form-env'
  * Works for both v3- and v4-shaped MRF submissions: attachments are
  * encrypted the same way in both, with only the decrypted response shape
  * differing (and that is handled upstream by processResponsesV3/V4).
+ *
+ * Callers must vet the URLs with areAttachmentUrlsTrusted first. That happens
+ * in decryptFormResponse, so a forged URL is rejected before we get here.
  *
  * @param formSgSdk - The FormSG SDK instance
  * @param submissionSecretKey - The decrypted submission secret key (base64)
@@ -40,11 +44,7 @@ export async function decryptFormAttachmentsV3OrV4(
   await Promise.all(
     Object.entries(attachmentDownloadUrls).map(async ([fieldId, url]) => {
       try {
-        const {
-          data: { encryptedFile },
-        } = await axios.get(url, {
-          responseType: 'json',
-        })
+        const { encryptedFile } = await downloadEncryptedAttachment(url)
 
         const decryptedBinary = await formSgSdk.cryptoV3.decryptFile(
           submissionSecretKey,
@@ -75,7 +75,7 @@ export async function decryptFormAttachmentsV3OrV4(
           fieldId,
           error: err,
         })
-        throw 'Error downloading or decrypting V3 attachment'
+        throw new Error('Error downloading or decrypting V3 attachment')
       }
     }),
   )

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -20,6 +20,7 @@ import { processResponsesV3 } from './helpers/process-v3-responses'
 import { processResponsesV4 } from './helpers/process-v4-responses'
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
 import { decryptFormAttachmentsV3OrV4 } from './decrypt-form-attachments-v3-or-v4'
+import { areAttachmentUrlsTrusted } from './trusted-attachment-urls'
 
 const NRIC_VERIFIED_FIELDS = new Set(['sgidUinFin', 'uinFin'])
 
@@ -149,6 +150,19 @@ export async function decryptFormResponse(
     // shouldStoreAttachments should only consider steps after the mrf step instead of the whole pipe
     // but leaving it as such for now to avoid complexity
     if (shouldStoreAttachments && data.attachmentDownloadUrls) {
+      // Checked before downloading anything, so a forged URL costs us no
+      // requests. Returning here keeps it on the same 401 path as every other
+      // untrusted payload, instead of surfacing a 500 and a stack trace.
+      if (!areAttachmentUrlsTrusted(data.attachmentDownloadUrls)) {
+        logger.error({
+          event: 'formsg-untrusted-attachment-url',
+          formId: data.formId,
+          submissionId: data.submissionId,
+          attachmentDownloadUrls: data.attachmentDownloadUrls,
+        })
+        return { verified: false, internalId: null }
+      }
+
       attachments = await decryptFormAttachmentsV3OrV4(
         formSgSdk,
         decryptedSubmission.submissionSecretKey,

--- a/packages/backend/src/apps/formsg/auth/download-encrypted-attachment.ts
+++ b/packages/backend/src/apps/formsg/auth/download-encrypted-attachment.ts
@@ -1,0 +1,110 @@
+import axios from 'axios'
+
+import logger from '@/helpers/logger'
+
+const MAX_ATTEMPTS = 3
+const BASE_BACKOFF_MS = 200
+const PER_ATTEMPT_TIMEOUT_MS = 2000
+
+/**
+ * Wall-clock budget for one download, retries included. Attachments download
+ * concurrently, so this bounds the whole download phase too.
+ *
+ * Half of FormSG's 10s webhook timeout. Overshooting is worse than surfacing
+ * the 503: FormSG re-delivers either way, but a timeout says nothing about why.
+ */
+const BUDGET_MS = 5000
+
+/**
+ * The AWS SDK's default retry policy: 429 for throttling, plus the statuses it
+ * treats as transient. Anything else is a real failure that retrying will not
+ * fix.
+ */
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504])
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+interface EncryptedAttachmentPayload {
+  encryptedFile: {
+    submissionPublicKey: string
+    nonce: string
+    binary: string
+  }
+}
+
+/**
+ * Rebuilds the failure as a plain Error carrying only a description of it.
+ *
+ * Callers log whatever we throw. An axios error would drag the presigned URL,
+ * the request headers and the response body along with it, so none of the
+ * original is kept, not even as a cause.
+ */
+function sanitiseError(error: unknown): Error {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status
+    const outcome = status ? `status ${status}` : 'no response'
+
+    return new Error(
+      `Attachment download failed with ${outcome}: ${error.message}`,
+    )
+  }
+
+  if (error instanceof Error) {
+    return new Error(
+      `Attachment download failed with ${error.constructor.name}: ${error.message}`,
+    )
+  }
+
+  return new Error(`Attachment download failed with a thrown ${typeof error}`)
+}
+
+/**
+ * Downloads one encrypted attachment from a FormSG presigned S3 URL, with
+ * retries as needed.
+ */
+export async function downloadEncryptedAttachment(
+  url: string,
+): Promise<EncryptedAttachmentPayload> {
+  const deadline = Date.now() + BUDGET_MS
+
+  for (let attempt = 1; ; attempt += 1) {
+    const timeout = Math.min(
+      PER_ATTEMPT_TIMEOUT_MS,
+      Math.max(1, deadline - Date.now()),
+    )
+
+    try {
+      const { data } = await axios.get<EncryptedAttachmentPayload>(url, {
+        responseType: 'json',
+        timeout,
+      })
+      return data
+    } catch (error) {
+      const status = axios.isAxiosError(error)
+        ? error.response?.status
+        : undefined
+      const isRetryable = status != null && RETRYABLE_STATUSES.has(status)
+
+      if (attempt >= MAX_ATTEMPTS || !isRetryable) {
+        throw sanitiseError(error)
+      }
+
+      // Full jitter, so concurrent attachments don't retry in lockstep.
+      const backoffMs = Math.random() * BASE_BACKOFF_MS * 2 ** (attempt - 1)
+
+      // Never start a retry past the deadline.
+      if (Date.now() + backoffMs >= deadline) {
+        throw sanitiseError(error)
+      }
+
+      logger.warn({
+        event: 'formsg-attachment-download-retry',
+        attempt,
+        status,
+        backoffMs,
+      })
+
+      await sleep(backoffMs)
+    }
+  }
+}

--- a/packages/backend/src/apps/formsg/auth/trusted-attachment-urls.ts
+++ b/packages/backend/src/apps/formsg/auth/trusted-attachment-urls.ts
@@ -1,0 +1,26 @@
+const TRUSTED_ORIGIN = 'https://s3.ap-southeast-1.amazonaws.com'
+const TRUSTED_PATH_PREFIX = '/attachments.form.gov.sg/'
+
+function isTrusted(url: string): boolean {
+  try {
+    const { origin, pathname } = new URL(url)
+
+    return origin === TRUSTED_ORIGIN && pathname.startsWith(TRUSTED_PATH_PREFIX)
+  } catch {
+    // Malformed enough that URL cannot parse it, so it is not FormSG's bucket.
+    return false
+  }
+}
+
+/**
+ * Attachment download URLs arrive in the webhook body, so a forged one could
+ * aim Plumber at an internal service. Only FormSG's bucket is allowed.
+ *
+ * Comparing origin covers scheme, host and port at once. Parsing also
+ * normalises `..`, so traversal cannot climb out of the bucket prefix.
+ */
+export function areAttachmentUrlsTrusted(
+  attachmentDownloadUrls: Record<string, string>,
+): boolean {
+  return Object.values(attachmentDownloadUrls).every(isTrusted)
+}


### PR DESCRIPTION
# Problem

Fetching an attachment from FormSG's presigned S3 URL returned a transient 503, and we exploded.

It turns out 503 is a transient error code from S3, we should have retried.

# Fix

We will follow AWS SDK's retry [guidelines](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-retries.html): retry on 429 and 500, 502, 503, 504.

For MRF forms, we will retry attachment downloads up with fully-jittered exponential backoff up to 5s, so retries stay inside FormSG's 10s webhook timeout.

IMPORTANT: FormSG V1 download retry is out of scope since FormSG is moving off that, lets not invest further.

This also fixes a security issue where formsg attachment URLs could be manipulated to hit arbitrary endpoints.

# Tests

- Check that MRF attachments work, and that we will only download attachments from FormSG S3.
- Remove the security check, manually replace attachment download URL with mock.codes/503, send webhook via postman, and check that we retry.
- [Regression test] Check that MRF / v4 FormSG without attachments still work.
- [Regression test] Check that legacy (non-MRF) forms with attachments still work.