### PR TITLE
chore: simplify column dropdown placeholder and hint typing to create

### DIFF
--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -60,7 +60,7 @@ const createRowAction: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type to create a column',
+          placeholder: 'Select or type',
           key: 'columnName',
           type: 'dropdown' as const,
           required: true,

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -53,7 +53,7 @@ const action: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select or type to create a column',
+          placeholder: 'Select or type',
           key: 'columnId',
           type: 'dropdown' as const,
           required: true,

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -131,6 +131,19 @@ export const SingleSelectProvider = ({
       }
       return [addNewByModalItem, ...allItems]
     }
+    // Inline add-new: show a read-only hint at the bottom while the input is empty
+    if (addNew?.type === 'inline') {
+      const hintLabel = `Type to ${addNew.label.toLowerCase()}`
+      return [
+        ...allItems,
+        {
+          value: hintLabel,
+          label: hintLabel,
+          disabled: true,
+          isHint: true,
+        },
+      ]
+    }
     return allItems
   }, [addNew, allItems])
 

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -6,6 +6,7 @@ import { useSelectContext } from '../../SelectContext'
 import { ComboboxItem } from '../../types'
 import {
   isItemDisabled,
+  isItemHint,
   itemToBadge,
   itemToDescriptionString,
   itemToIcon,
@@ -26,17 +27,36 @@ export const DropdownItem = ({
   const { getItemProps, isItemSelected, inputValue, styles } =
     useSelectContext()
 
-  const { icon, label, description, isDisabled, isActive, badge } = useMemo(
-    () => ({
-      icon: itemToIcon(item),
-      label: itemToLabelString(item),
-      description: itemToDescriptionString(item),
-      isDisabled: isItemDisabled(item),
-      isActive: isItemSelected(item),
-      badge: itemToBadge(item),
-    }),
-    [isItemSelected, item],
-  )
+  const { icon, label, description, isDisabled, isActive, badge, isHint } =
+    useMemo(
+      () => ({
+        icon: itemToIcon(item),
+        label: itemToLabelString(item),
+        description: itemToDescriptionString(item),
+        isDisabled: isItemDisabled(item),
+        isActive: isItemSelected(item),
+        badge: itemToBadge(item),
+        isHint: isItemHint(item),
+      }),
+      [isItemSelected, item],
+    )
+
+  if (isHint) {
+    return (
+      <ListItem
+        {...getItemProps({
+          item,
+          index,
+          disabled: true,
+        })}
+        role="presentation"
+        pointerEvents="none"
+        sx={styles.emptyItem}
+      >
+        {label}
+      </ListItem>
+    )
+  }
 
   return (
     <ListItem

--- a/packages/frontend/src/components/SingleSelect/types.ts
+++ b/packages/frontend/src/components/SingleSelect/types.ts
@@ -21,6 +21,8 @@ export type ComboboxItem<T = string> =
       badge?: JSX.Element
       /** Whether this is an option to add new */
       isAddNew?: boolean
+      /** Read-only hint row (e.g. "Type to create a new column.") */
+      isHint?: boolean
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       [key: string]: any
     }

--- a/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
+++ b/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
@@ -22,6 +22,10 @@ export const isItemAddNew = <Item extends ComboboxItem>(
   return itemIsObject(item) && !!item.isAddNew
 }
 
+export const isItemHint = <Item extends ComboboxItem>(item: Item): boolean => {
+  return itemIsObject(item) && !!item.isHint
+}
+
 export const itemToLabelString = <Item extends ComboboxItem>(
   item?: Item,
 ): string | JSX.Element => {


### PR DESCRIPTION
## Summary
- Shorten create-row column placeholders from "Select or type to create a column" to "Select or type" (Tiles + Databricks)
- Show a read-only "Type to create a new column" hint at the bottom of inline add-new dropdowns when the input is empty, so it's clearer users can type to add columns
<img width="441" height="343" alt="image" src="https://github.com/user-attachments/assets/504a3460-3948-4155-9fba-63325dca296c" />



## Test plan
- [ ] Open a Tiles create-row step and open the column dropdown — placeholder says "Select or type", and the last scrollable row shows the type-to-create hint
- [ ] Start typing — hint disappears and the create-new option appears
- [ ] Repeat for Databricks create-row column dropdown
- [ ] Confirm selecting an existing column still works; Refresh items stays pinned below the list


Made with [Cursor](https://cursor.com)