### PR TITLE
[AI-SETUP-30] feat: reuse email preview modal for rich-text step params

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -32,6 +32,24 @@ export interface VariableInfo {
 
 export type VariableInfoMap = Map<string, VariableInfo>
 
+// Builds a VariableInfoMap from the bare-path-keyed (`step.<id>.<path>`,
+// no braces) label/value maps used outside the live editor, e.g. AI
+// Builder's read-only step preview. No table support: callers needing
+// table-variable rendering should use genVariableInfoMap instead.
+export function buildVariableInfoMapFromPaths(
+  labelsByPath: Map<string, string>,
+  valuesByPath: Map<string, string>,
+): VariableInfoMap {
+  const map: VariableInfoMap = new Map()
+  for (const [path, value] of valuesByPath) {
+    map.set(`{{${path}}}`, {
+      label: labelsByPath.get(path) ?? path,
+      testRunValue: value,
+    })
+  }
+  return map
+}
+
 const HEX_MODIFIER_PATTERN = '[a-fA-F0-9]+'
 
 // Matches step variables with optional hex-encoded modifier

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/FieldPreviewButton.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/FieldPreviewButton.tsx
@@ -1,0 +1,51 @@
+import type { TFieldPreviewType } from '@plumber/types'
+
+import { lazy, Suspense, useState } from 'react'
+import { RiEyeLine } from 'react-icons/ri'
+import { Button } from '@opengovsg/design-system-react'
+
+const LazyViewAsEmailModal = lazy(() => import('@/components/ViewAsEmailModal'))
+
+interface FieldPreviewButtonProps {
+  previewType: TFieldPreviewType
+  html: string
+}
+
+function renderPreviewModal(
+  previewType: TFieldPreviewType,
+  props: { isOpen: boolean; onClose: () => void; html: string },
+) {
+  switch (previewType) {
+    case 'email':
+      return <LazyViewAsEmailModal {...props} title="Preview your email" />
+  }
+}
+
+export default function FieldPreviewButton({
+  previewType,
+  html,
+}: FieldPreviewButtonProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="xs"
+        leftIcon={<RiEyeLine />}
+        onMouseEnter={() => import('@/components/ViewAsEmailModal')}
+        onClick={() => setIsOpen(true)}
+      >
+        Preview
+      </Button>
+      <Suspense fallback={null}>
+        {isOpen &&
+          renderPreviewModal(previewType, {
+            isOpen,
+            onClose: () => setIsOpen(false),
+            html,
+          })}
+      </Suspense>
+    </>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -114,24 +114,30 @@ export default function Step(props: StepProps) {
           flexDir="column"
           alignItems="stretch"
           justifyContent="flex-start"
-          cursor={isConfigured && !isActive ? 'pointer' : 'default'}
-          onClick={
-            isConfigured && !isActive
-              ? () => setIsExpanded((v) => !v)
-              : undefined
-          }
-          // Active: override border + suppress hover background
+          // The header, not this outer card, owns the expand/collapse click —
+          // suppress the container's own hover highlight so only the header
+          // reacts to hover.
+          _hover={{ bg: 'white', cursor: 'default' }}
+          // Active: override border
           {...(isActive && {
             borderColor: 'primary.500',
             boxShadow: '0 0 0 3px var(--chakra-colors-primary-100)',
-            _hover: { bg: 'white', cursor: 'default' },
-          })}
-          // Pending: suppress hover
-          {...(isPending && {
-            _hover: { bg: 'white', cursor: 'default' },
           })}
         >
-          <Flex {...flowStepStyles.topHeader} py={isNested ? 3 : 4}>
+          <Flex
+            {...flowStepStyles.topHeader}
+            py={isNested ? 3 : 4}
+            cursor={isConfigured && !isActive ? 'pointer' : 'default'}
+            onClick={
+              isConfigured && !isActive
+                ? () => setIsExpanded((v) => !v)
+                : undefined
+            }
+            {...(isConfigured &&
+              !isActive && {
+                _hover: { bg: 'interaction.muted.neutral.hover' },
+              })}
+          >
             <StepAppIcon
               isCompleted={isConfigured}
               isNested={isNested}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -11,6 +11,10 @@ import {
 import { useQuery } from '@apollo/client'
 import { Box, Flex, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react'
 
+import {
+  buildVariableInfoMapFromPaths,
+  substituteForPreview,
+} from '@/components/RichTextEditor/utils'
 import { GET_DYNAMIC_DATA } from '@/graphql/queries/get-dynamic-data'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
@@ -30,10 +34,12 @@ import {
   withDynamicOptions,
 } from './helpers/dynamicFieldOptions'
 import {
+  getFieldPreviewType,
   getStepFields,
   resolveDisplayValue,
   resolveFieldLabel,
 } from './helpers/resolveFieldDisplayValue'
+import FieldPreviewButton from './FieldPreviewButton'
 import VariablePill from './VariablePill'
 
 interface DynamicFieldOptionsFetcherProps {
@@ -284,30 +290,51 @@ export default function StepParameterRows({
     [dynamicFields, parameters],
   )
 
+  const variableInfoMap = useMemo(
+    () =>
+      buildVariableInfoMapFromPaths(variableLabelsByPath, variableValuesByPath),
+    [variableLabelsByPath, variableValuesByPath],
+  )
+
   const fieldIndexMap = new Map(stepFields.map((f, i) => [f.key, i]))
   const rows = Object.entries(parameters)
     .filter(([, value]) => value !== '' && value != null)
     .map(([key, value]) => {
       const field = stepFields.find((f) => f.key === key)
       const hasAiLabel = parameterLabels[key] != null
+      // A field with a previewType is always shown via its preview button —
+      // rendering its raw value (e.g. rich-text HTML) as text would be
+      // unreadable, and this must reflect the real value regardless of any
+      // AI-provided summary label for the row.
+      const previewType = getFieldPreviewType(field)
       return {
         key,
         label: resolveFieldLabel(stepFields, key),
+        previewType,
+        previewHtml: previewType
+          ? substituteForPreview(String(value), variableInfoMap)
+          : undefined,
         // AI-provided labels take priority over static option resolution
         // and skip the Column/Value table, since they're already a single
-        // human-readable summary of the whole value.
+        // human-readable summary of the whole value. Preview fields skip
+        // both, since they're rendered via FieldPreviewButton instead.
         displayLines: hasAiLabel
           ? [parameterLabels[key]]
+          : previewType
+          ? []
           : resolveDisplayValue(stepFields, key, value),
-        columnValueRows: hasAiLabel
-          ? null
-          : resolveColumnValueRows(field, value),
+        columnValueRows:
+          hasAiLabel || previewType
+            ? null
+            : resolveColumnValueRows(field, value),
         hiddenIf: field?.hiddenIf,
       }
     })
     .filter(
-      ({ displayLines, columnValueRows, hiddenIf }) =>
-        (displayLines.length > 0 || (columnValueRows?.length ?? 0) > 0) &&
+      ({ displayLines, columnValueRows, hiddenIf, previewType }) =>
+        (previewType ||
+          displayLines.length > 0 ||
+          (columnValueRows?.length ?? 0) > 0) &&
         !isFieldHidden(hiddenIf, parameters),
     )
     .sort((a, b) => {
@@ -347,30 +374,44 @@ export default function StepParameterRows({
             </Text>
           </ParameterRow>
         )}
-        {rows.map(({ key, label, displayLines, columnValueRows }) => (
-          <ParameterRow key={key} label={label}>
-            {columnValueRows && columnValueRows.length > 0 ? (
-              <ColumnValueTable
-                rows={columnValueRows}
-                variableLabelsByPath={variableLabelsByPath}
-                variableValuesByPath={variableValuesByPath}
-                stepNameById={stepNameById}
-              />
-            ) : (
-              <Flex direction="column" gap={1}>
-                {displayLines.map((line, lineIndex) => (
-                  <ParameterValueLine
-                    key={lineIndex}
-                    line={line}
-                    variableLabelsByPath={variableLabelsByPath}
-                    variableValuesByPath={variableValuesByPath}
-                    stepNameById={stepNameById}
-                  />
-                ))}
-              </Flex>
-            )}
-          </ParameterRow>
-        ))}
+        {rows.map(
+          ({
+            key,
+            label,
+            displayLines,
+            columnValueRows,
+            previewType,
+            previewHtml,
+          }) => (
+            <ParameterRow key={key} label={label}>
+              {previewType ? (
+                <FieldPreviewButton
+                  previewType={previewType}
+                  html={previewHtml ?? ''}
+                />
+              ) : columnValueRows && columnValueRows.length > 0 ? (
+                <ColumnValueTable
+                  rows={columnValueRows}
+                  variableLabelsByPath={variableLabelsByPath}
+                  variableValuesByPath={variableValuesByPath}
+                  stepNameById={stepNameById}
+                />
+              ) : (
+                <Flex direction="column" gap={1}>
+                  {displayLines.map((line, lineIndex) => (
+                    <ParameterValueLine
+                      key={lineIndex}
+                      line={line}
+                      variableLabelsByPath={variableLabelsByPath}
+                      variableValuesByPath={variableValuesByPath}
+                      stepNameById={stepNameById}
+                    />
+                  ))}
+                </Flex>
+              )}
+            </ParameterRow>
+          ),
+        )}
       </Box>
     </>
   )

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
@@ -1,4 +1,12 @@
-import type { IApp } from '@plumber/types'
+import type { IApp, IField, TFieldPreviewType } from '@plumber/types'
+
+// Only rich-text fields carry previewType. Narrows the IField union so
+// callers don't need to know which field type it lives on.
+export function getFieldPreviewType(
+  field?: IField,
+): TFieldPreviewType | undefined {
+  return field?.type === 'rich-text' ? field.previewType : undefined
+}
 
 function camelToSentence(key: string): string {
   const words = key.replace(/([A-Z])/g, ' $1').trim()


### PR DESCRIPTION
## TL;DR

Rich-text step parameters that opt into `previewType: 'email'` (e.g. Postman's transactional email `body` field) now show a **Preview** button in the AI Builder step preview, reusing the existing `ViewAsEmailModal` + `substituteForPreview` pipeline already used by the RichTextEditor toolbar's own Preview button — instead of dumping the raw serialized HTML as unreadable text.

## What changed?

- `RichTextEditor/utils.ts`: added `buildVariableInfoMapFromPaths`, which re-keys AI Builder's bare-path (`step.<id>.<path>`) label/value maps into the braced `VariableInfoMap` shape `substituteForPreview` expects.
- `StepsPreview/helpers/resolveFieldDisplayValue.ts`: added `getFieldPreviewType`, narrowing `IField` to read `previewType` off rich-text fields.
- `StepsPreview/FieldPreviewButton.tsx` (new): lazy-loads `ViewAsEmailModal` and switches on `previewType` (currently only `'email'`) to render the right kind-specific preview.
- `StepsPreview/StepParameterRows.tsx`: rows for fields with a `previewType` now render `FieldPreviewButton` instead of raw display lines/Column-Value table, driven purely by field metadata — no app/step-key hardcoding, so any current or future app's field opting into `previewType` gets this for free.
- `StepsPreview/Step.tsx`: moved the step card's expand/collapse click handler and hover highlight from the whole card onto just the header row (icon/name/chevron). Previously any click inside the card body — including the new Preview button — bubbled up and toggled the accordion; now only the header does.

## Tests

- [ ] `npm run -w frontend lint` and `tsc --noEmit` pass (already verified locally).
- [ ] In AI Builder, propose/build a flow with a Postman "Send transactional email" step. Confirm the Body row shows a **Preview** button (not raw HTML), and clicking it opens the email preview with variables substituted.
- [ ] Confirm clicking the Preview button does not collapse/expand the step card, and clicking elsewhere in the header still toggles it.
- [ ] Confirm other parameter rows (plain text, Column/Value table rows) render unchanged.

## Deploy notes

None — frontend-only change, no migrations or config changes. No backend or `packages/types` changes needed since `previewType` already existed on the Postman body field.