### PR TITLE
[AI-BUILDER-FORM-SETUP-5]: add stricter check for mrf

### DIFF
--- a/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
@@ -232,7 +232,10 @@ describe('getFormSchemaService', () => {
 
     it('warns when the form is MRF', async () => {
       vi.mocked(axios.get).mockResolvedValue(
-        mockForm({ responseMode: 'multirespondent' }),
+        mockForm({
+          responseMode: 'multirespondent',
+          workflow: [{ _id: 'step1', edit: [], workflow_type: 'static' }],
+        }),
       )
 
       const result = await getFormSchemaService(FORM_ID)
@@ -240,6 +243,19 @@ describe('getFormSchemaService', () => {
       expect(result).toMatchObject({
         isMrf: true,
         warnings: [expect.stringContaining('multi-respondent')],
+      })
+    })
+
+    it('does not warn when responseMode is multirespondent but the workflow was never set up', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({ responseMode: 'multirespondent', workflow: [] }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({
+        isMrf: false,
+        warnings: [],
       })
     })
   })

--- a/packages/backend/src/services/mcp/get-form-schema.ts
+++ b/packages/backend/src/services/mcp/get-form-schema.ts
@@ -73,6 +73,7 @@ interface PublicFormResponse {
     _id: string
     title: string
     responseMode: string
+    workflow?: unknown[]
     publicKey?: string
     form_fields?: PublicFormField[]
   }
@@ -168,7 +169,12 @@ export async function getFormSchemaService(
   }
 
   const isStorageMode = Boolean(form.publicKey)
-  const isMrf = form.responseMode === 'multirespondent'
+  // A form can be left in 'multirespondent' responseMode without ever having
+  // its workflow set up — Plumber (and the FormSG trigger's own MRF check,
+  // see triggers/new-submission/index.ts) treats that as a single-respondent
+  // form, not an MRF.
+  const isMrf =
+    form.responseMode === 'multirespondent' && (form.workflow?.length ?? 0) > 0
 
   const warnings: string[] = []
   if (!isStorageMode) {


### PR DESCRIPTION
## Problem

New forms in formsg are all MRFs by default

## Solution

Check that workflows is an empty array

## Details
- packages/backend/src/services/mcp/get-form-schema.ts: added workflow?: unknown[] to the PublicFormResponse.form type (previously dropped on the floor despite the API returning it), and changed isMrf to responseMode === 'multirespondent' && (workflow?.length ?? 0) > 0 — matching the correct check already used in the FormSG trigger.
- get-form-schema.test.ts: updated the existing MRF test to include a non-empty workflow, and added a new test asserting isMrf: false / no warnings when responseMode is 'multirespondent' but workflow: [].

