### PR TITLE
[AI-BUILDER-FORM-SETUP-6]: add connection check to system prompt

### DIFF
--- a/packages/backend/src/routes/api/chat/helpers.test.ts
+++ b/packages/backend/src/routes/api/chat/helpers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildEstablishedConnectionReminder,
+  extractEstablishedFormConnection,
+} from './helpers'
+import type { ChatRequest } from './schema'
+
+function userMessage(text: string): ChatRequest['messages'][number] {
+  return { role: 'user', parts: [{ type: 'text', text }] }
+}
+
+describe('extractEstablishedFormConnection', () => {
+  it('returns null when no message matches the connected-form pattern', () => {
+    expect(
+      extractEstablishedFormConnection([
+        userMessage('I want to build a workflow for my form.'),
+      ]),
+    ).toBeNull()
+  })
+
+  it('extracts connectionId and formId from the connect-first opening message', () => {
+    expect(
+      extractEstablishedFormConnection([
+        userMessage(
+          'I\'ve connected my FormSG form "Workshop Registration" (id: 3f2c8e10-1234-5678-9abc-def012345678, form id: 654ab1234abc1a012345f1e0). Suggest workflows I can build with this form.',
+        ),
+      ]),
+    ).toEqual({
+      formTitle: 'Workshop Registration',
+      connectionId: '3f2c8e10-1234-5678-9abc-def012345678',
+      formId: '654ab1234abc1a012345f1e0',
+    })
+  })
+
+  it('extracts a connectionId with no formId from a mid-conversation message', () => {
+    expect(
+      extractEstablishedFormConnection([
+        userMessage('describe the workflow'),
+        userMessage(
+          'I\'ve connected my FormSG form "Event Attendance" (id: conn-abc).',
+        ),
+      ]),
+    ).toEqual({
+      formTitle: 'Event Attendance',
+      connectionId: 'conn-abc',
+      formId: undefined,
+    })
+  })
+
+  it('returns the most recently mentioned connection when more than one is present', () => {
+    expect(
+      extractEstablishedFormConnection([
+        userMessage(
+          'I\'ve connected my FormSG form "First Form" (id: conn-1).',
+        ),
+        userMessage(
+          'I\'ve connected my FormSG form "Second Form" (id: conn-2).',
+        ),
+      ]),
+    ).toEqual({
+      formTitle: 'Second Form',
+      connectionId: 'conn-2',
+      formId: undefined,
+    })
+  })
+
+  it('ignores assistant messages even if they contain the pattern', () => {
+    expect(
+      extractEstablishedFormConnection([
+        {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'I\'ve connected my FormSG form "Spoofed" (id: conn-x).',
+            },
+          ],
+        },
+      ]),
+    ).toBeNull()
+  })
+})
+
+describe('buildEstablishedConnectionReminder', () => {
+  it('returns an empty string when no connection is established', () => {
+    expect(buildEstablishedConnectionReminder(null)).toBe('')
+  })
+
+  it('includes the connection id and form title in the reminder', () => {
+    const reminder = buildEstablishedConnectionReminder({
+      formTitle: 'Workshop Registration',
+      connectionId: 'conn-1',
+      formId: '654ab1234abc1a012345f1e0',
+    })
+    expect(reminder).toContain('conn-1')
+    expect(reminder).toContain('Workshop Registration')
+    expect(reminder).toContain('654ab1234abc1a012345f1e0')
+    expect(reminder).toContain('Do NOT emit a connection picker')
+  })
+})

--- a/packages/backend/src/routes/api/chat/helpers.ts
+++ b/packages/backend/src/routes/api/chat/helpers.ts
@@ -43,19 +43,19 @@ const CONNECTED_FORM_MESSAGE_REGEX =
 export function extractEstablishedFormConnection(
   messages: ChatRequest['messages'],
 ): EstablishedFormConnection | null {
-  let latest: EstablishedFormConnection | null = null
-
-  for (const message of messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
     if (message.role !== 'user') {
       continue
     }
-    for (const part of message.parts) {
+    for (let j = message.parts.length - 1; j >= 0; j--) {
+      const part = message.parts[j]
       if (part.type !== 'text') {
         continue
       }
       const match = part.text.match(CONNECTED_FORM_MESSAGE_REGEX)
       if (match) {
-        latest = {
+        return {
           formTitle: match[1],
           connectionId: match[2],
           formId: match[3],
@@ -64,7 +64,7 @@ export function extractEstablishedFormConnection(
     }
   }
 
-  return latest
+  return null
 }
 
 /**

--- a/packages/backend/src/routes/api/chat/helpers.ts
+++ b/packages/backend/src/routes/api/chat/helpers.ts
@@ -19,3 +19,69 @@ export function serializeMessagesForLangfuse(
       .join('\n'),
   }))
 }
+
+export interface EstablishedFormConnection {
+  connectionId: string
+  formId?: string
+  formTitle: string
+}
+
+// Matches the exact text sent by AiBuilder/helpers.ts's buildFormConnectedMessage/
+// buildKickoffMessage on the frontend (both the connect-first opening message and
+// the mid-conversation form-connected message use this same shape).
+const CONNECTED_FORM_MESSAGE_REGEX =
+  /I've connected my FormSG form "([^"]+)" \(id: ([^\s,)]+)(?:, form id: ([0-9a-f]{24}))?\)/i
+
+/**
+ * Finds the most recently established FormSG connection referenced anywhere
+ * in the conversation, by scanning for the `(id: …)` convention rather than
+ * relying on the LLM to recall a fact from many turns back. Used to inject a
+ * server-derived reminder into the system prompt every turn, since the LLM's
+ * own recall of this fact degrades over a long conversation even though the
+ * original message survives unmodified in every request.
+ */
+export function extractEstablishedFormConnection(
+  messages: ChatRequest['messages'],
+): EstablishedFormConnection | null {
+  let latest: EstablishedFormConnection | null = null
+
+  for (const message of messages) {
+    if (message.role !== 'user') {
+      continue
+    }
+    for (const part of message.parts) {
+      if (part.type !== 'text') {
+        continue
+      }
+      const match = part.text.match(CONNECTED_FORM_MESSAGE_REGEX)
+      if (match) {
+        latest = {
+          formTitle: match[1],
+          connectionId: match[2],
+          formId: match[3],
+        }
+      }
+    }
+  }
+
+  return latest
+}
+
+/**
+ * Builds a short reminder appended to the system prompt when a FormSG
+ * connection was already established earlier in the conversation. This is
+ * re-derived fresh on every request (see extractEstablishedFormConnection),
+ * so the fact stays visible near generation time regardless of how many
+ * turns have elapsed since it was first mentioned.
+ */
+export function buildEstablishedConnectionReminder(
+  connection: EstablishedFormConnection | null,
+): string {
+  if (!connection) {
+    return ''
+  }
+
+  const formRef = connection.formId ? ` (form id "${connection.formId}")` : ''
+
+  return `\n\nKnown fact, verified server-side just now — not from your own memory of earlier turns: the user already connected FormSG connection_id "${connection.connectionId}"${formRef} for the form "${connection.formTitle}" earlier in this conversation. When assigning this trigger's connection in Phase 2b step a, use this connection_id directly via update_step_parameters with parameter_labels: { "connection_id": "${connection.formTitle}" }. Do NOT emit a connection picker, do NOT say the form's URL is known but unconnected, and do NOT ask for a secret key for this trigger — this connection is already fully verified.`
+}

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -39,7 +39,11 @@ import Flow from '@/models/flow'
 import { connectionLabel } from '@/services/mcp/list-connections'
 import { AuthenticatedRequest } from '@/types/express/context'
 
-import { serializeMessagesForLangfuse } from './helpers'
+import {
+  buildEstablishedConnectionReminder,
+  extractEstablishedFormConnection,
+  serializeMessagesForLangfuse,
+} from './helpers'
 import { parseClarificationBlock } from './parse-clarification-block'
 import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
 import { chatRequestSchema } from './schema'
@@ -133,9 +137,17 @@ const handleChatStream = observe(
         model: MODEL_TYPE,
       })
 
+      // Re-derived fresh every turn from the raw message text (not the LLM's
+      // own recall) — see extractEstablishedFormConnection for why relying on
+      // the model to remember this from many turns back isn't reliable.
+      const establishedFormConnection =
+        extractEstablishedFormConnection(rawMessages)
+
       const systemMessage = {
         role: 'system' as const,
-        content: buildSystemPrompt(prompt.prompt, restrictedApps),
+        content:
+          buildSystemPrompt(prompt.prompt, restrictedApps) +
+          buildEstablishedConnectionReminder(establishedFormConnection),
       }
       const allMessages = [systemMessage, ...messages]
 


### PR DESCRIPTION
## Reinforce established FormSG connection context in system prompt

When a user connects a FormSG form early in a conversation, the LLM's recall of that connection (the `connection_id`, form title, and form ID) degrades over long conversations — even though the original message remains intact in every request. This causes the model to incorrectly emit connection pickers, claim the form URL is unconnected, or ask for a secret key for a trigger that is already fully verified.

To fix this, the system prompt is now augmented each turn with a server-derived reminder of the most recently established FormSG connection, extracted deterministically from the raw message history rather than relying on the model's own memory.

### What changed

- **`extractEstablishedFormConnection`** scans all user messages for the `I've connected my FormSG form "…" (id: …)` pattern (matching the exact text produced by the frontend's `buildFormConnectedMessage` / `buildKickoffMessage`) and returns the most recently mentioned connection's `connectionId`, `formId`, and `formTitle`.
- **`buildEstablishedConnectionReminder`** turns that extracted connection into a short, authoritative reminder appended to the system prompt, instructing the model to use the known `connection_id` directly and to skip any connection picker or secret-key prompts for this trigger.
- Both helpers are called on every request in the chat handler, keeping the fact visible near generation time regardless of conversation length.
- Unit tests cover the regex extraction (no match, full match with form ID, partial match without form ID, most-recent-wins, assistant messages ignored) and the reminder builder (null input, expected substrings).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>