### PR TITLE
[AI-SETUP-31] fix: hide advanced/internal fields from the AI Builder chat

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -48,6 +48,10 @@ const trigger: IRawTrigger = {
       required: false,
       variables: false,
       value: NricFilter.None,
+      // Advanced setting; not something the AI Builder should ask about.
+      hiddenFromAiIf: {
+        op: 'always_true',
+      },
       options: [
         {
           label: 'Do nothing',

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
@@ -27,6 +27,10 @@ const trigger: IRawTrigger = {
         'Enter the encryption key for your instant workflow and save it.',
       required: false,
       variables: false,
+      // Secret-like value; not something the AI Builder should ask about.
+      hiddenFromAiIf: {
+        op: 'always_true',
+      },
     },
   ],
 

--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -24,6 +24,13 @@ vi.mock('@/apps', () => ({
               type: 'string',
               required: true,
             },
+            {
+              key: 'nricFilter',
+              label: 'NRIC Filter',
+              type: 'dropdown',
+              required: false,
+              hiddenFromAiIf: { op: 'always_true' },
+            },
           ],
         },
       ],
@@ -131,7 +138,21 @@ vi.mock('@/apps', () => ({
           key: 'ifThen',
           name: 'If/Then',
           description: 'Conditional branching',
-          arguments: [],
+          arguments: [
+            {
+              key: 'branchName',
+              label: 'Branch Name',
+              type: 'string',
+              required: true,
+            },
+            {
+              key: 'depth',
+              label: 'FILE A BUG IF YOU SEE THIS',
+              type: 'string',
+              required: false,
+              hiddenIf: { op: 'always_true' },
+            },
+          ],
         },
       ],
     },
@@ -247,6 +268,25 @@ describe('listAppsService', () => {
       )
       expect(field?.isDynamic).toBeUndefined()
       expect(field?.dynamicDataKey).toBeUndefined()
+    })
+  })
+
+  describe('hidden field filtering', () => {
+    it('omits fields with hiddenFromAiIf always_true', async () => {
+      const apps = await listAppsService(user)
+      const formsg = apps.find((a) => a.key === 'formsg')
+      const fieldKeys = formsg?.triggers[0].fields.map((f) => f.key)
+      expect(fieldKeys).toEqual(['formId'])
+      expect(fieldKeys).not.toContain('nricFilter')
+    })
+
+    it('omits fields with hiddenIf always_true', async () => {
+      mocks.getAllLdFlags.mockResolvedValue({ app_toolbox: true })
+      const apps = await listAppsService(user)
+      const toolbox = apps.find((a) => a.key === 'toolbox')
+      const fieldKeys = toolbox?.actions[0].fields.map((f) => f.key)
+      expect(fieldKeys).toEqual(['branchName'])
+      expect(fieldKeys).not.toContain('depth')
     })
   })
 

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -11,6 +11,21 @@ import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 
 const TOOLBOX_APP_KEY = 'toolbox'
 
+function isHiddenFromAi(
+  field: NonNullable<IRawTrigger['arguments']>[number],
+): boolean {
+  return (
+    field.hiddenIf?.op === 'always_true' ||
+    field.hiddenFromAiIf?.op === 'always_true'
+  )
+}
+
+function serializeFields(
+  fields: NonNullable<IRawTrigger['arguments']>,
+): IMcpAppField[] {
+  return fields.filter((f) => !isHiddenFromAi(f)).map(serializeField)
+}
+
 function serializeField(
   field: NonNullable<IRawTrigger['arguments']>[number],
 ): IMcpAppField {
@@ -49,7 +64,7 @@ function serializeField(
     (field.type === 'multirow' || field.type === 'multirow-multicol') &&
     field.subFields.length
   ) {
-    base.subFields = field.subFields.map(serializeField)
+    base.subFields = serializeFields(field.subFields)
   }
 
   return base
@@ -82,7 +97,7 @@ export async function listAppsService(user: IUser): Promise<IMcpApp[]> {
             key: t.key,
             name: t.name,
             description: t.description,
-            fields: (raw.arguments ?? []).map(serializeField),
+            fields: serializeFields(raw.arguments ?? []),
           }
         }),
       actions: (app.actions ?? [])
@@ -93,7 +108,7 @@ export async function listAppsService(user: IUser): Promise<IMcpApp[]> {
             key: a.key,
             name: a.name,
             description: a.description,
-            fields: (raw.arguments ?? []).map(serializeField),
+            fields: serializeFields(raw.arguments ?? []),
           }
         }),
     }))

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -348,6 +348,14 @@ export interface IBaseField {
    */
   hiddenIf?: IFieldVisibilityCondition
 
+  /**
+   * Allows hiding a field from the AI Builder chat only, while still showing
+   * it in the pipe editor. Shares the same condition shape as `hiddenIf`,
+   * but only `always_true` is currently evaluated by the MCP server (which
+   * has no runtime sibling-field values to check other conditions against).
+   */
+  hiddenFromAiIf?: IFieldVisibilityCondition
+
   // message to show when no variables are available
   noVariablesMessage?: string
 


### PR DESCRIPTION
## Stack Context

This stack (built on `mcp/ai-builder-tile-column-labels` → `mcp/ai-builder-column-value-table` → `mcp/step-preview-email-preview`) improves how the AI Builder chat previews and configures step parameters. This PR is a standalone fix layered on top: it stops the AI Builder from surfacing fields that were never meant to be user/LLM-configurable via chat.

## What?

- Added `hiddenFromAiIf` to `IBaseField` (`packages/types`), mirroring the existing `hiddenIf` editor-visibility condition, but scoped to the AI Builder's MCP schema instead of the pipe editor.
- `packages/backend/src/services/mcp/apps.ts`: `list_apps` now filters out any field (including nested `subFields`) where `hiddenIf.op === 'always_true'` or `hiddenFromAiIf.op === 'always_true'`, instead of passing every field straight through.
- Flagged three fields:
  - FormSG's `nricFilter` (new `hiddenFromAiIf`) — a niche PII-handling toggle with a safe default; not something the AI Builder should proactively ask about.
  - GatherSG's `encryptionKey` (new `hiddenFromAiIf`) — a secret-like value that shouldn't be passed through an LLM chat.
  - Toolbox If-Then's `depth` — already had `hiddenIf: always_true` (internal front-end bookkeeping) but `list_apps` wasn't respecting it at all, so it was leaking into the AI schema regardless.
- Added unit test coverage for the new filtering behavior in `apps.test.ts`.

## Why?

The AI Builder chat was asking users to configure FormSG's NRIC filter — a field that's fine to leave in the human pipe editor but shouldn't be something a non-technical user is interrogated about via chat. Investigating turned up that `list_apps` had no concept of field visibility at all, so any field hidden from the editor (or that should be hidden from just the AI) was still exposed to the LLM. This closes both gaps with one small, generic mechanism rather than a one-off special case for NRIC.

## Tests

- [ ] `npm run -w backend test:unit -- apps.test.ts`
- [ ] Manually verify in the AI Builder chat that a FormSG trigger step no longer prompts for NRIC filter, and that GatherSG's instant workflow trigger no longer prompts for the encryption key
- [ ] Confirm both fields remain configurable as before in the pipe editor UI

## Deploy notes

None — schema-only change, no migrations or infra changes.
