### PR TITLE
PLU-743 [IF-THEN-THEN-V2]: support writing endStepId when creating/updating steps

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveIfThenV1EndStep } from '../../../../actions/if-then/infra/end-step-utils'
+
+type Fixture = {
+  id: string
+  appKey?: string
+  key?: string
+  parameters?: Record<string, any>
+  position: number
+}
+
+const trigger = (position: number): Fixture => ({
+  id: `trigger${position}`,
+  appKey: 'formsg',
+  key: 'newSubmission',
+  position,
+})
+
+const plain = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'postman',
+  key: 'sendTransactionalEmail',
+  position,
+})
+
+const ifThen = (
+  id: string,
+  position: number,
+  extra: Partial<Fixture> = {},
+): Fixture => ({
+  id,
+  appKey: 'toolbox',
+  key: 'ifThen',
+  parameters: { depth: '0' },
+  position,
+  ...extra,
+})
+
+const mrfSubmission = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'formsg',
+  key: 'mrfSubmission',
+  position,
+})
+
+describe('deriveIfThenV1EndStep', () => {
+  it('derives the extent of a 2-branch block up to the step before the next if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const stepA = plain('stepA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const stepB = plain('stepB', 5)
+    const steps = [trigger(1), ifThenA, stepA, ifThenB, stepB]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+  })
+
+  it('derives extents for each branch of a 3-branch block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const ifThenB = ifThen('ifThenB', 4)
+    const ifThenC = ifThen('ifThenC', 6)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      ifThenB,
+      plain('stepB', 5),
+      ifThenC,
+      plain('stepC', 7),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+    expect(deriveIfThenV1EndStep(steps, ifThenC).id).toBe('stepC')
+  })
+
+  it('extends to the end of the flow when there is no following if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      plain('stepB', 4),
+      plain('stepC', 5),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepC')
+  })
+
+  it('returns the if-then itself (self-ref) for an empty block abutting the next if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const ifThenB = ifThen('ifThenB', 3)
+    const steps = [trigger(1), ifThenA, ifThenB, plain('stepB', 4)]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
+  })
+
+  it('treats a following (reject-branch) if-then as an MRF boundary', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const rejectIfThen = ifThen('rejectIfThen', 5, {
+      parameters: { depth: '0' },
+    })
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      mrfSubmission('mrf', 4),
+      rejectIfThen,
+      plain('stepAfter', 6),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mrf')
+  })
+
+  it('does not treat a deeper (nested) if-then as a boundary (mirrors V1 depth scan)', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const nested = ifThen('nested', 4, { parameters: { depth: '1' } })
+    const ifThenB = ifThen('ifThenB', 6)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      nested,
+      plain('stepB', 5),
+      ifThenB,
+      plain('stepC', 7),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepB')
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   BLOCK_END_STEP_ID,
+  isBlockStep,
+  isForEachStep,
   isIfThenStep,
   isIfThenV2,
   isOnlyContinueIfStep,
@@ -54,6 +56,40 @@ describe('toolbox constants', () => {
       { label: 'undefined step', step: undefined },
     ])('is false for $label', ({ step }) => {
       expect(isOnlyContinueIfStep(step)).toBe(false)
+    })
+  })
+
+  describe('isForEachStep', () => {
+    it('is true for a toolbox for-each step', () => {
+      expect(isForEachStep({ appKey: 'toolbox', key: 'forEach' })).toBe(true)
+    })
+
+    it.each([
+      { label: 'if-then', step: { appKey: 'toolbox', key: 'ifThen' } },
+      { label: 'non-toolbox app', step: { appKey: 'formsg', key: 'forEach' } },
+      { label: 'undefined step', step: undefined },
+    ])('is false for $label', ({ step }) => {
+      expect(isForEachStep(step)).toBe(false)
+    })
+  })
+
+  describe('isBlockStep', () => {
+    it.each([
+      { label: 'if-then', step: { appKey: 'toolbox', key: 'ifThen' } },
+      { label: 'for-each', step: { appKey: 'toolbox', key: 'forEach' } },
+    ])('is true for a block step: $label', ({ step }) => {
+      expect(isBlockStep(step)).toBe(true)
+    })
+
+    it.each([
+      {
+        label: 'only-continue-if',
+        step: { appKey: 'toolbox', key: 'onlyContinueIf' },
+      },
+      { label: 'plain action', step: { appKey: 'postman', key: 'sendEmail' } },
+      { label: 'undefined step', step: undefined },
+    ])('is false for a non-block step: $label', ({ step }) => {
+      expect(isBlockStep(step)).toBe(false)
     })
   })
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -1,0 +1,363 @@
+import type { IStepConfig } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import logger from '@/helpers/logger'
+
+import { validateEndStepWrite } from '../../common/validate-end-step'
+
+type Fixture = {
+  id: string
+  appKey?: string
+  key?: string
+  position: number
+  config: IStepConfig
+}
+
+const trigger = (position: number): Fixture => ({
+  id: `trigger${position}`,
+  appKey: 'formsg',
+  key: 'newSubmission',
+  position,
+  config: {},
+})
+
+const plain = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'postman',
+  key: 'sendTransactionalEmail',
+  position,
+  config,
+})
+
+const ifThen = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'toolbox',
+  key: 'ifThen',
+  position,
+  config,
+})
+
+const mrfSubmission = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'formsg',
+  key: 'mrfSubmission',
+  position,
+  config: {},
+})
+
+const FLOW_ID = 'flow1'
+
+const REJECTION_BRANCH = { branch: 'reject', stepId: 'mrf' } as const
+
+describe('validateEndStepWrite', () => {
+  let loggerErrorSpy: MockInstance
+
+  beforeEach(() => {
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+  })
+
+  it('accepts a valid marker over a run of plain steps', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a self-referencing empty block', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts adjacent (non-overlapping) blocks', () => {
+    const blockB = ifThen('blockB', 2)
+    const blockC = ifThen('blockC', 4, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      plain('s3', 3),
+      blockC,
+      plain('s5', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'blockB',
+        endStepId: 's3',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects a target that is not an if-then', () => {
+    const flowSteps = [trigger(1), plain('notIfThen', 2), plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'notIfThen',
+        endStepId: 's3',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'target-not-if-then',
+      }),
+    )
+  })
+
+  it('rejects a target that is missing from the flow', () => {
+    const flowSteps = [trigger(1), ifThen('block', 2)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'ghost',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'target-not-if-then',
+      }),
+    )
+  })
+
+  it('accepts a block confined to one MRF rejection branch', () => {
+    const rejection = { approval: REJECTION_BRANCH }
+    const block = ifThen('block', 3, rejection)
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('child', 4, rejection),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'child',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a rejection-branch block reaching out of its branch', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('child', 4, { approval: REJECTION_BRANCH }),
+      plain('topLevel', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'topLevel',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects a block spanning two different rejection branches', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('otherBranchChild', 4, {
+        approval: { branch: 'reject', stepId: 'otherMrf' },
+      }),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'otherBranchChild',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('accepts an empty (self-referencing) block in a rejection branch', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [trigger(1), mrfSubmission('mrf', 2), block]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an endStep that is not in the flow', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'nowhere',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'end-step-not-in-flow',
+      }),
+    )
+  })
+
+  it('rejects an endStep positioned before the if-then', () => {
+    const block = ifThen('block', 3)
+    const flowSteps = [trigger(1), plain('s2', 2), block]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's2',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'end-step-before-self',
+      }),
+    )
+  })
+
+  it('rejects an mrfSubmission step inside the block region', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [
+      trigger(1),
+      block,
+      mrfSubmission('mrf', 3),
+      plain('s4', 4),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'mrf-step-in-region',
+      }),
+    )
+  })
+
+  it('rejects a top-level block reaching into a rejection branch', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [
+      trigger(1),
+      block,
+      plain('approvalChild', 3, {
+        approval: { branch: 'reject', stepId: 'x' },
+      }),
+      plain('s4', 4),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects overlapping (nested) new-style blocks', () => {
+    const blockB = ifThen('blockB', 2)
+    const blockC = ifThen('blockC', 3, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      blockC,
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'blockB',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'overlapping-blocks',
+      }),
+    )
+  })
+})

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -1,0 +1,42 @@
+import type { IStep } from '@plumber/types'
+
+import { isIfThenStep, type StepLike } from '../../../common/constants'
+
+// Loose enough that unit tests can pass partial plain objects instead of full
+// Step rows.
+type ExtentStep = StepLike &
+  Pick<IStep, 'id' | 'position'> &
+  Partial<Pick<IStep, 'parameters'>>
+
+// Mirrors getIfThenV1StepIdToSkipTo's depth defaulting; nesting never shipped,
+// so this is dead-code defense.
+function parseDepth(step: ExtentStep): number {
+  const depth = parseInt(step.parameters?.depth as string)
+  return isNaN(depth) ? 0 : depth
+}
+
+/**
+ * Computes a V1 if-then block's derived extent (the last step, inclusive).
+ *
+ * IMPORTANT: this is a plain positional scan with no MRF awareness, so it can
+ * derive an extent that crosses an mrfSubmission or a rejection-branch
+ * boundary — region-confinement write validation is the safety net that
+ * refuses to pin one that does.
+ */
+export function deriveIfThenV1EndStep<T extends ExtentStep>(
+  flowSteps: T[],
+  ifThenStep: T,
+): T {
+  const startIndex = flowSteps.findIndex((step) => step.id === ifThenStep.id)
+  const currDepth = parseDepth(ifThenStep)
+
+  const nextBoundaryIndex = flowSteps.findIndex(
+    (step, index) =>
+      index > startIndex && isIfThenStep(step) && parseDepth(step) <= currDepth,
+  )
+
+  if (nextBoundaryIndex === -1) {
+    return flowSteps[flowSteps.length - 1]
+  }
+  return flowSteps[nextBoundaryIndex - 1]
+}

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -23,8 +23,9 @@ export enum TOOLBOX_ACTIONS {
 export const BLOCK_END_STEP_ID = 'endStepId'
 
 // Not IStep itself: the execution context's $.step is trimmed (no config), and
-// unit-test fixtures pass partials — neither is a full IStep.
-type StepLike = Partial<Pick<IStep, 'appKey' | 'key' | 'config'>>
+// unit-test fixtures pass partials — neither is a full IStep. Also reused as
+// a base for the slightly wider shapes elsewhere in the toolbox.
+export type StepLike = Partial<Pick<IStep, 'appKey' | 'key' | 'config'>>
 
 export function isIfThenStep(step: StepLike | null | undefined): boolean {
   return (
@@ -39,6 +40,16 @@ export function isOnlyContinueIfStep(
     step?.appKey === TOOLBOX_APP_KEY &&
     step?.key === TOOLBOX_ACTIONS.ONLY_CONTINUE_IF
   )
+}
+
+export function isForEachStep(step: StepLike | null | undefined): boolean {
+  return (
+    step?.appKey === TOOLBOX_APP_KEY && step?.key === TOOLBOX_ACTIONS.FOR_EACH
+  )
+}
+
+export function isBlockStep(step: StepLike | null | undefined): boolean {
+  return isIfThenStep(step) || isForEachStep(step)
 }
 
 // IMPORTANT: presence (Object.hasOwn), not value, distinguishes an if-then V2

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -1,0 +1,286 @@
+import type { IStep } from '@plumber/types'
+
+import { raw, Transaction } from 'objection'
+
+import { deriveIfThenV1EndStep } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+
+import {
+  BLOCK_END_STEP_ID,
+  isBlockStep,
+  isIfThenStep,
+  isIfThenV2,
+  type StepLike,
+} from './constants'
+
+// Loose enough for unit tests to pass partial objects instead of full Step
+// rows.
+type ValidationStep = StepLike & Pick<IStep, 'id' | 'position'>
+
+interface EndStepWriteValidationArgs {
+  // IMPORTANT: must already reflect the mutation's own insert/patch, ordered
+  // by position ascending.
+  flowSteps: ValidationStep[]
+  ifThenStepId: string
+  endStepId: string
+  flowId: string
+}
+
+/**
+ * IMPORTANT: throws a plain Error, not BadUserInputError — these violations
+ * are prevented by the frontend, so hitting one means a bug, not bad input.
+ */
+function rejectEndStepWrite(
+  reason: string,
+  details: Record<string, unknown>,
+): never {
+  logger.error({ event: 'end-step-write-rejected', reason, ...details })
+  throw new Error(`endStepId write rejected: ${reason}`)
+}
+
+function isMrfSubmissionStep(step: ValidationStep): boolean {
+  return step.appKey === 'formsg' && step.key === 'mrfSubmission'
+}
+
+/**
+ * Which MRF rejection branch a step belongs to, or null for the main flow.
+ * `config.approval` is only ever written for rejection branches (its `branch`
+ * is typed `'reject'`), so its `stepId` — the approval step the branch hangs
+ * off — identifies the branch on its own.
+ */
+function getRejectionBranchId(step: ValidationStep): string | null {
+  return step.config?.approval?.stepId ?? null
+}
+
+/**
+ * Enforces every endStepId write invariant; throws and logs
+ * `end-step-write-rejected` on violation, rolling back the mutation.
+ *
+ * Exported for unit coverage — mutations should go through
+ * `validateEndStepOn{Create,Update}Step` below instead.
+ */
+export function validateEndStepWrite({
+  flowSteps,
+  ifThenStepId,
+  endStepId,
+  flowId,
+}: EndStepWriteValidationArgs): void {
+  const ifThenStep = flowSteps.find((step) => step.id === ifThenStepId)
+
+  // Target must be a toolbox/ifThen present in this flow.
+  if (!ifThenStep || !isIfThenStep(ifThenStep)) {
+    rejectEndStepWrite('target-not-if-then', { ifThenStepId, flowId })
+  }
+
+  // endStep must exist in the same flow.
+  const endStep = flowSteps.find((step) => step.id === endStepId)
+  if (!endStep) {
+    rejectEndStepWrite('end-step-not-in-flow', {
+      ifThenStepId,
+      endStepId,
+      flowId,
+    })
+  }
+
+  // endStep must be at or after the if-then (self-ref is the empty block).
+  if (endStep.position < ifThenStep.position) {
+    rejectEndStepWrite('end-step-before-self', {
+      ifThenStepId,
+      endStepId,
+      endStepPosition: endStep.position,
+      ifThenPosition: ifThenStep.position,
+      flowId,
+    })
+  }
+
+  // IMPORTANT: a block that crosses this boundary would jump execution into
+  // or out of a branch on FALSE.
+  const blockRejectionBranchId = getRejectionBranchId(ifThenStep)
+  for (const step of flowSteps) {
+    if (
+      step.position <= ifThenStep.position ||
+      step.position > endStep.position
+    ) {
+      continue
+    }
+    if (isMrfSubmissionStep(step)) {
+      rejectEndStepWrite('mrf-step-in-region', {
+        ifThenStepId,
+        endStepId,
+        offendingStepId: step.id,
+        flowId,
+      })
+    }
+    if (getRejectionBranchId(step) !== blockRejectionBranchId) {
+      rejectEndStepWrite('approval-branch-crossed', {
+        ifThenStepId,
+        endStepId,
+        offendingStepId: step.id,
+        blockRejectionBranchId,
+        offendingRejectionBranchId: getRejectionBranchId(step),
+        flowId,
+      })
+    }
+  }
+
+  // Nesting is never legitimate (depth === 0), so no two ranges may overlap.
+  for (const other of flowSteps) {
+    if (other.id === ifThenStepId || !isIfThenV2(other)) {
+      continue
+    }
+    const otherEnd = flowSteps.find(
+      (step) => step.id === other.config?.[BLOCK_END_STEP_ID],
+    )
+    // Skip pre-existing dangling markers — out of scope for this write.
+    if (!otherEnd) {
+      continue
+    }
+    const overlaps =
+      ifThenStep.position <= otherEnd.position &&
+      other.position <= endStep.position
+    if (overlaps) {
+      rejectEndStepWrite('overlapping-blocks', {
+        ifThenStepId,
+        endStepId,
+        otherIfThenStepId: other.id,
+        flowId,
+      })
+    }
+  }
+}
+
+// Uses jsonb_set so this only touches endStepId, not the rest of config.
+async function pinEndStep(
+  trx: Transaction,
+  ifThenStepId: string,
+  endStepId: string,
+): Promise<void> {
+  await Step.query(trx)
+    .findById(ifThenStepId)
+    .patch({
+      config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+        JSON.stringify(endStepId),
+      ]),
+    })
+}
+
+/**
+ * Maintains if-then endStepId markers when a step is created, in the same
+ * transaction as the insert.
+ *
+ * IMPORTANT: throws on any violation, rolling back the whole creation.
+ */
+export async function validateEndStepOnCreateStep({
+  trx,
+  flow,
+  previousBlockId,
+  previousStep,
+  newStep,
+}: {
+  trx: Transaction
+  flow: Flow
+  previousBlockId: string | null | undefined
+  previousStep: Step
+  newStep: Step
+}): Promise<void> {
+  const flowId = flow.id
+  const flowSteps = await flow
+    .$relatedQuery('steps', trx)
+    .orderBy('position', 'asc')
+
+  if (previousBlockId != null) {
+    const blockStep = flowSteps.find((step) => step.id === previousBlockId)
+    if (!blockStep || !isIfThenStep(blockStep)) {
+      rejectEndStepWrite('previous-block-not-if-then', {
+        previousBlockId,
+        flowId,
+      })
+    }
+
+    // Already marked: nothing to pin here, this check is just a bug tripwire.
+    if (isIfThenV2(blockStep)) {
+      const explicitEndStepId = blockStep.config[BLOCK_END_STEP_ID]
+      if (previousStep.id !== explicitEndStepId) {
+        rejectEndStepWrite('previous-step-not-block-end', {
+          previousBlockId,
+          previousStepId: previousStep.id,
+          endStepId: explicitEndStepId,
+          flowId,
+        })
+      }
+      return
+    }
+
+    // Excludes the new step from the extent scan so a plain add-after isn't
+    // absorbed into the block.
+    const preInsertSteps = flowSteps.filter((step) => step.id !== newStep.id)
+    const preBlockStep = preInsertSteps.find(
+      (step) => step.id === previousBlockId,
+    )
+    const derivedEndStep = deriveIfThenV1EndStep(preInsertSteps, preBlockStep)
+    if (previousStep.id !== derivedEndStep.id) {
+      rejectEndStepWrite('previous-step-not-block-end', {
+        previousBlockId,
+        previousStepId: previousStep.id,
+        endStepId: derivedEndStep.id,
+        flowId,
+      })
+    }
+    validateEndStepWrite({
+      flowSteps,
+      ifThenStepId: blockStep.id,
+      endStepId: derivedEndStep.id,
+      flowId,
+    })
+    await pinEndStep(trx, blockStep.id, derivedEndStep.id)
+    return
+  }
+
+  if (!isBlockStep(newStep)) {
+    const blockToExtend = flowSteps.find(
+      (step) =>
+        isIfThenV2(step) && step.config[BLOCK_END_STEP_ID] === previousStep.id,
+    )
+    if (blockToExtend) {
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: blockToExtend.id,
+        endStepId: newStep.id,
+        flowId,
+      })
+      await pinEndStep(trx, blockToExtend.id, newStep.id)
+    }
+  }
+}
+
+/**
+ * Validates a client-supplied config.endStepId on updateStep.
+ *
+ * Accepted only when the key is present — an absent key is preserved by the
+ * caller's config spread. Throws (rolling back the transaction) on an invalid
+ * target.
+ */
+export async function validateEndStepOnUpdateStep({
+  trx,
+  step,
+  inputConfig,
+  flowId,
+}: {
+  trx: Transaction
+  step: Step
+  inputConfig: { [BLOCK_END_STEP_ID]?: string | null } | null | undefined
+  flowId: string
+}): Promise<{ [BLOCK_END_STEP_ID]?: string }> {
+  if (!inputConfig || !Object.hasOwn(inputConfig, BLOCK_END_STEP_ID)) {
+    return {}
+  }
+
+  const endStepId = inputConfig[BLOCK_END_STEP_ID] as string
+  const flowSteps = await Step.query(trx)
+    .where('flow_id', flowId)
+    .orderBy('position', 'asc')
+  validateEndStepWrite({ flowSteps, ifThenStepId: step.id, endStepId, flowId })
+  return { [BLOCK_END_STEP_ID]: endStepId }
+}

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -638,3 +638,436 @@ describe('createStep mutation integration tests', async () => {
     })
   })
 })
+
+describe('createStep endStepId write rules', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let flowTimestamp: string
+
+  const flowInput = () => ({ id: testFlow.id, updatedAt: flowTimestamp })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    await FlowConnections.query().delete()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'endStep Test Flow',
+      updatedBy: owner.id,
+    })
+    flowTimestamp = String(new Date(testFlow.updatedAt).getTime())
+
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      ...testFlow,
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('rule 1: pins a legacy block when adding after it (lazy upgrade)', async () => {
+    const [, ifThenA, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((newStep as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 1: adds after an explicit block without changing its marker', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, other] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((await reload(other.id)).position).toBe(newStep.position + 1)
+  })
+
+  it('rule 1: rolls back when previousStep is not the block endStep', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, other] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: other.id },
+            previousBlockId: ifThenA.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(4)
+  })
+
+  it('rule 1: rolls back when the block would reach out of its rejection branch', async () => {
+    // The derived extent runs past the branch boundary to the end of the flow,
+    // so the write must be rejected.
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      {
+        key: 'ifThen',
+        appKey: 'toolbox',
+        type: 'action',
+        config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenApproval, stepA] = seeded
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: stepA.id },
+            previousBlockId: ifThenApproval.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(3)
+  })
+
+  it('rule 1: pins a rejection-branch block when adding after it', async () => {
+    // ifThenB bounds ifThenA's derived extent to stepA, keeping it inside the
+    // branch.
+    const rejection = {
+      approval: { branch: 'reject' as const, stepId: 'someApprovalStep' },
+    }
+    const [, , ifThenA, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'mrfSubmission', appKey: 'formsg', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+      {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        type: 'action',
+        config: rejection,
+      },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+          config: rejection,
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((newStep as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 2: extends an explicit block on a plain tail-add', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(newStep.id)
+  })
+
+  it('rule 2: extends an empty (self-ref) block on the first inside-add', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: ifThenA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThenA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(newStep.id)
+  })
+
+  it('rule 2: extends an empty block inside a rejection branch', async () => {
+    // Simulates the if-then V2 initializer's empty-block-then-first-child
+    // sequence inside a rejection branch.
+    const rejection = {
+      approval: { branch: 'reject' as const, stepId: 'someApprovalStep' },
+    }
+    const [, , ifThenA, existing] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'mrfSubmission', appKey: 'formsg', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+      {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        type: 'action',
+        config: rejection,
+      },
+    ])
+    await ifThenA.$query().patch({
+      config: { ...rejection, endStepId: ifThenA.id },
+    })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThenA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+          config: rejection,
+        },
+      },
+      context,
+    )
+
+    const block = await reload(ifThenA.id)
+    expect(block.config.endStepId).toBe(newStep.id)
+    // IMPORTANT: preserves the approval marker and doesn't swallow the
+    // pre-existing step during the pin.
+    expect(block.config.approval).toEqual(rejection.approval)
+    expect(newStep.position).toBeLessThan((await reload(existing.id)).position)
+  })
+
+  it('rule 2: does NOT extend when the new step is an if-then', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newIfThen = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'ifThen',
+          appKey: 'toolbox',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect((newIfThen as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 2: no-op for a mid-range insert (endStep stays last by id)', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, stepB] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepB.id } })
+
+    await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepB.id)
+  })
+
+  it('rule 3: no-op inside-add on a legacy block (stays lazy)', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, , stepA] = seeded
+
+    await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps.every((step) => step.config.endStepId === undefined)).toBe(
+      true,
+    )
+  })
+
+  it('strips a client-supplied config.endStepId on create', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, existing] = seeded
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: existing.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+          config: { endStepId: 'client-supplied-id', stepName: 'kept' },
+        },
+      },
+      context,
+    )
+
+    expect((newStep as any).config.endStepId).toBeUndefined()
+    expect((newStep as any).config.stepName).toBe('kept')
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -858,3 +858,179 @@ describe('updateStep mutation', () => {
     })
   })
 })
+
+// Real-DB integration tests, kept separate from the mock-based suite above so
+// writes hit real flow steps and can actually roll back.
+describe('updateStep endStepId config merge', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let flowTimestamp: string
+
+  const flowInput = () => ({ id: testFlow.id, updatedAt: flowTimestamp })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'endStep Update Flow',
+      updatedBy: owner.id,
+    })
+    flowTimestamp = String(new Date(testFlow.updatedAt).getTime())
+
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      ...testFlow,
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('writes a self-referencing endStepId onto a new-style if-then', async () => {
+    const [, ifThen] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+    ])
+
+    await updateStep(
+      null,
+      {
+        input: {
+          id: ifThen.id,
+          flow: flowInput(),
+          key: 'ifThen',
+          appKey: 'toolbox',
+          connection: {},
+          parameters: {},
+          config: { endStepId: ifThen.id },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(ifThen.id)
+  })
+
+  it('preserves an existing marker through a condition edit (merge)', async () => {
+    const [, ifThen, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({
+      config: { endStepId: stepA.id, stepName: 'orig' },
+    })
+
+    await updateStep(
+      null,
+      {
+        input: {
+          id: ifThen.id,
+          flow: flowInput(),
+          key: 'ifThen',
+          appKey: 'toolbox',
+          connection: {},
+          parameters: { conditions: [{ rows: [] }] },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(stepA.id)
+  })
+
+  it('rolls back an endStepId write on a non-if-then step', async () => {
+    const [, postmanStep] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await expect(
+      updateStep(
+        null,
+        {
+          input: {
+            id: postmanStep.id,
+            flow: flowInput(),
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            connection: {},
+            parameters: {},
+            config: { endStepId: postmanStep.id },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    expect((await reload(postmanStep.id)).config.endStepId).toBeUndefined()
+  })
+
+  it('rolls back an endStepId write on an approval-bearing if-then', async () => {
+    const [, ifThen, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      {
+        key: 'ifThen',
+        appKey: 'toolbox',
+        type: 'action',
+        config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await expect(
+      updateStep(
+        null,
+        {
+          input: {
+            id: ifThen.id,
+            flow: flowInput(),
+            key: 'ifThen',
+            appKey: 'toolbox',
+            connection: {},
+            parameters: {},
+            config: { endStepId: stepA.id },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const reloaded = await reload(ifThen.id)
+    expect(reloaded.config.endStepId).toBeUndefined()
+    expect(reloaded.config.approval).toEqual({
+      branch: 'reject',
+      stepId: 'someApprovalStep',
+    })
+  })
+})

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,6 +2,8 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import { BLOCK_END_STEP_ID } from '@/apps/toolbox/common/constants'
+import { validateEndStepOnCreateStep } from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
@@ -12,6 +14,20 @@ import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
+
+// endStepId is maintained by the endStep write rules and duplicateBranch's
+// remap, never accepted directly from the client.
+const SERVER_OWNED_CONFIG_KEYS = [BLOCK_END_STEP_ID] as const
+
+function sanitizeServerSideConfig(
+  config: IStepConfig | null | undefined,
+): IStepConfig {
+  const sanitized = { ...(config ?? {}) }
+  for (const key of SERVER_OWNED_CONFIG_KEYS) {
+    delete sanitized[key]
+  }
+  return sanitized
+}
 
 const createStep: MutationResolvers['createStep'] = async (
   _parent,
@@ -82,8 +98,10 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .throwIfNotFound()
 
+    const newStepConfig = sanitizeServerSideConfig(input.config as IStepConfig)
+
     const validationResult = await validateApprovalConfig(
-      input.config as IStepConfig,
+      newStepConfig,
       previousStep,
     )
     if (!validationResult.isApprovalConfigValid) {
@@ -106,8 +124,18 @@ const createStep: MutationResolvers['createStep'] = async (
       position: validationResult.newStepPosition,
       parameters: input.parameters,
       connectionId: input.connection?.id,
-      config: input.config as IStepConfig,
+      config: newStepConfig,
       version,
+    })
+
+    // IMPORTANT: throws (and rolls back the whole creation) on any marker
+    // violation.
+    await validateEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: input.previousBlockId,
+      previousStep,
+      newStep: step,
     })
 
     // NOTE: add flow connection to the flow_connections table

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,5 +1,6 @@
 import { IAction } from '@/../../types'
 import apps from '@/apps'
+import { validateEndStepOnUpdateStep } from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import {
   addFlowConnection,
@@ -84,6 +85,15 @@ const updateStep: MutationResolvers['updateStep'] = async (
     const stepName = input?.config?.stepName ?? step?.config?.stepName
     const existingConfig = step?.config ?? {}
 
+    // Returns {} when absent so the config spread below preserves any existing
+    // marker; throws (rolls back) on an invalid target.
+    const endStepConfig = await validateEndStepOnUpdateStep({
+      trx,
+      step,
+      inputConfig: input.config,
+      flowId: input.flow.id,
+    })
+
     let parameters = input.parameters
     let version = step.version
 
@@ -113,6 +123,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
           ...existingConfig,
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
           ...(stepName !== undefined ? { stepName } : {}),
+          ...endStepConfig,
         },
       })
       .withGraphFetched({

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -691,6 +691,9 @@ input CreateStepInput {
   parameters: JSONObject
   previousStep: PreviousStepInput
   config: StepConfigInput
+  # The if-then block the new step is being added after.
+  # IMPORTANT: presence triggers a server-side lazy upgrade / marker pin.
+  previousBlockId: ID
 }
 
 input StepApprovalConfigInput {
@@ -706,6 +709,10 @@ input StepConfigInput {
   stepName: String
   approval: StepApprovalConfigInput
   templateConfig: StepTemplateConfigInput
+  # System-owned marker: id of the last step (inclusive) inside a block
+  # (if-then V2 today, possibly for-each later). Only the if-then initializer
+  # writes it, via updateStep.
+  endStepId: String
 }
 
 input UpdateStepInput {
@@ -826,6 +833,7 @@ type StepConfig {
   templateConfig: StepTemplateConfig
   stepName: String
   approval: StepApprovalConfig
+  endStepId: String
 }
 
 type StepTemplateConfig {


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end. 
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Adds mutations and validations to support writing to `endStepId`when creating a If-Then V2 block.

### Creation

This adds a new parameter - `previousBlockId` - to the `createStep` mutation. This is meant to support adding steps _after_ an If-Then block (both V1 and V2), and must contain the step ID of the If-Then step which begins that block.

Technically, the `config` param is also updated to accept a new param - `endStepId`, but this is not used in the create path.

### 

# Tests

See top of stack. 