### PR TITLE
PLU-743 [IF-THEN-THEN-V2] Support updating endStepId on reorder

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -1,6 +1,16 @@
+import type { IStepConfig } from '@plumber/types'
+
 import { describe, expect, it } from 'vitest'
 
-import { deriveIfThenV1EndStep } from '../../../../actions/if-then/infra/end-step-utils'
+import {
+  deriveIfThenV1EndStep,
+  expandIfThenBlockDeletions,
+  findBlankPlaceholderMemberIds,
+  reassignIfThenEndStepsOnDelete,
+  reassignIfThenEndStepsOnReorder,
+  remapIfThenEndStepIdsOnDuplicate,
+  remapIfThenEndStepIdsOnDuplicateBranch,
+} from '../../../../actions/if-then/infra/end-step-utils'
 
 type Fixture = {
   id: string
@@ -8,6 +18,7 @@ type Fixture = {
   key?: string
   parameters?: Record<string, any>
   position: number
+  config?: IStepConfig
 }
 
 const trigger = (position: number): Fixture => ({
@@ -41,6 +52,12 @@ const mrfSubmission = (id: string, position: number): Fixture => ({
   id,
   appKey: 'formsg',
   key: 'mrfSubmission',
+  position,
+})
+
+// A leftover blank child from the V1 branch initializer: neither field set.
+const blank = (id: string, position: number): Fixture => ({
+  id,
   position,
 })
 
@@ -135,5 +152,486 @@ describe('deriveIfThenV1EndStep', () => {
 
     // depth-1 nested if-then is skipped; extent runs to the step before ifThenB.
     expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepB')
+  })
+})
+
+describe('findBlankPlaceholderMemberIds', () => {
+  it('finds a lone blank child that is the whole block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const child = blank('child', 3)
+    const steps = [trigger(1), ifThenA, child]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, child)).toEqual([
+      'child',
+    ])
+  })
+
+  it('finds a blank member alongside real ones, ignoring the real ones', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const child = blank('child', 4)
+    const steps = [trigger(1), ifThenA, real, child]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, child)).toEqual([
+      'child',
+    ])
+  })
+
+  it('returns every blank member when there are more than one', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const firstBlank = blank('firstBlank', 3)
+    const real = plain('real', 4)
+    const secondBlank = blank('secondBlank', 5)
+    const steps = [trigger(1), ifThenA, firstBlank, real, secondBlank]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, secondBlank)).toEqual([
+      'firstBlank',
+      'secondBlank',
+    ])
+  })
+
+  it('returns an empty array for a fully-configured block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const steps = [trigger(1), ifThenA, real]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, real)).toEqual([])
+  })
+
+  it('returns an empty array for an empty (self-referencing) block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const steps = [trigger(1), ifThenA]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, ifThenA)).toEqual([])
+  })
+
+  it('ignores a blank step outside the block range', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const outsideBlank = blank('outsideBlank', 4)
+    const steps = [trigger(1), ifThenA, real, outsideBlank]
+
+    // endStep is `real`, so outsideBlank (position 4) sits outside the range.
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, real)).toEqual([])
+  })
+})
+
+// A new-style (marked) if-then carrying its block endStep marker in config.
+const markedIfThen = (
+  id: string,
+  position: number,
+  endStepId: string,
+): Fixture => ifThen(id, position, { config: { endStepId } })
+
+describe('reassignIfThenEndStepsOnDelete', () => {
+  it('repoints a block whose endStep (tail) was deleted to the new highest survivor', () => {
+    // block A = [A, s3, s4], endStep s4; delete the tail s4.
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 's3' },
+    ])
+  })
+
+  it('repoints to the highest surviving member when the tail run is deleted', () => {
+    // block A = [A, s3, s4, s5], endStep s5; delete s4 and s5.
+    const block = markedIfThen('A', 2, 's5')
+    const steps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4', 's5'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 's3' },
+    ])
+  })
+
+  it('empties a block to self-reference when every member is deleted', () => {
+    // block A = [A, s3, s4], endStep s4; delete both members.
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3', 's4'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 'A' },
+    ])
+  })
+
+  it('leaves a block untouched when a mid-block member is deleted but the endStep survives', () => {
+    // block A = [A, s3, s4, s5], endStep s5; delete only the interior s4.
+    const block = markedIfThen('A', 2, 's5')
+    const steps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4'])).toEqual([])
+  })
+
+  it('does not repair a block whose own if-then is deleted', () => {
+    // block A = [A, s3]; delete the if-then and its member together.
+    const block = markedIfThen('A', 2, 's3')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['A', 's3'])).toEqual([])
+  })
+
+  it('leaves a surviving empty (self-referencing) block untouched', () => {
+    // block A is empty (endStep === A); delete an unrelated later step.
+    const block = markedIfThen('A', 2, 'A')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3'])).toEqual([])
+  })
+
+  it('repairs multiple blocks in a single batch', () => {
+    // block A = [A, a3], endStep a3; block B = [B, b5], endStep b5.
+    const blockA = markedIfThen('A', 2, 'a3')
+    const blockB = markedIfThen('B', 4, 'b5')
+    const steps = [trigger(1), blockA, plain('a3', 3), blockB, plain('b5', 5)]
+
+    // Delete both endSteps; each block empties to self-reference.
+    expect(reassignIfThenEndStepsOnDelete(steps, ['a3', 'b5'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 'A' },
+      { ifThenStepId: 'B', endStepId: 'B' },
+    ])
+  })
+
+  it('never repairs a legacy (marker-less) if-then', () => {
+    // Legacy if-then with no endStepId marker; its derived tail is deleted.
+    const legacy = ifThen('L', 2)
+    const steps = [trigger(1), legacy, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3'])).toEqual([])
+  })
+})
+
+describe('expandIfThenBlockDeletions', () => {
+  const ids = (set: Set<string>) => [...set].sort()
+
+  it('expands a single marked if-then id to its whole block range', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A', 's3', 's4'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('is a no-op when the full range is already requested', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds } = expandIfThenBlockDeletions(steps, ['A', 's3', 's4'])
+    expect(ids(expandedIds)).toEqual(['A', 's3', 's4'])
+  })
+
+  it('never expands a legacy (marker-less) if-then', () => {
+    const legacy = ifThen('L', 2)
+    const steps = [trigger(1), legacy, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['L'],
+    )
+    expect(ids(expandedIds)).toEqual(['L'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('expands an empty (self-referencing) block to just its if-then', () => {
+    const block = markedIfThen('A', 2, 'A')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('does not expand a block with a dangling marker and reports it', () => {
+    const block = markedIfThen('A', 2, 'ghost')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual(['A'])
+  })
+
+  it('treats a marker pointing before the if-then as dangling', () => {
+    const block = markedIfThen('A', 4, 's2')
+    const steps = [trigger(1), plain('s2', 2), plain('s3', 3), block]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual(['A'])
+  })
+
+  it('passes plain-step deletions through unchanged', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    // Deleting an interior member (not the if-then) does not expand.
+    const { expandedIds } = expandIfThenBlockDeletions(steps, ['s3'])
+    expect(ids(expandedIds)).toEqual(['s3'])
+  })
+})
+
+describe('reassignIfThenEndStepsOnReorder', () => {
+  it('moves the endStep to the member that now sits at the highest position', () => {
+    // block A = [A, s3, s4, s5], endStep s5. Reorder the interior to
+    // [s5, s3, s4] so the old endStep s5 is no longer last.
+    const block = markedIfThen('A', 2, 's5')
+    const preSteps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+    const newPositions = [
+      { id: 's5', position: 3 },
+      { id: 's3', position: 4 },
+      { id: 's4', position: 5 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([
+      { ifThenStepId: 'A', endStepId: 's4' },
+    ])
+  })
+
+  it('is a no-op when the reorder does not touch a block', () => {
+    // block A = [A, s3]; reorder two later, unrelated steps.
+    const block = markedIfThen('A', 2, 's3')
+    const preSteps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('a4', 4),
+      plain('a5', 5),
+    ]
+    const newPositions = [
+      { id: 'a5', position: 4 },
+      { id: 'a4', position: 5 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('preserves membership when a whole block moves as a unit', () => {
+    // block A = [A, s4, s5] preceded by a plain step; move the block up so it
+    // starts one position earlier (members keep their relative order).
+    const before = plain('before', 2)
+    const block = markedIfThen('A', 3, 's5')
+    const preSteps = [trigger(1), before, block, plain('s4', 4), plain('s5', 5)]
+    const newPositions = [
+      { id: 'A', position: 2 },
+      { id: 's4', position: 3 },
+      { id: 's5', position: 4 },
+      { id: 'before', position: 5 },
+    ]
+
+    // s5 is still the highest-positioned member, so nothing changes.
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('leaves an empty (self-referencing) block untouched', () => {
+    const block = markedIfThen('A', 2, 'A')
+    const preSteps = [trigger(1), block, plain('a3', 3), plain('a4', 4)]
+    const newPositions = [
+      { id: 'a3', position: 4 },
+      { id: 'a4', position: 3 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('leaves a block with a dangling marker untouched', () => {
+    const block = markedIfThen('A', 2, 'ghost')
+    const preSteps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+    const newPositions = [
+      { id: 's3', position: 4 },
+      { id: 's4', position: 3 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('repairs only the block whose interior was reordered', () => {
+    // Two blocks; reorder the interior of the second only.
+    const blockA = markedIfThen('A', 2, 'a4')
+    const blockB = markedIfThen('B', 5, 'b7')
+    const preSteps = [
+      trigger(1),
+      blockA,
+      plain('a3', 3),
+      plain('a4', 4),
+      blockB,
+      plain('b6', 6),
+      plain('b7', 7),
+    ]
+    const newPositions = [
+      { id: 'b7', position: 6 },
+      { id: 'b6', position: 7 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([
+      { ifThenStepId: 'B', endStepId: 'b6' },
+    ])
+  })
+})
+
+describe('remapIfThenEndStepIdsOnDuplicate', () => {
+  it('remaps a marker to the copied endStep id', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 's3'), plain('s3', 3)]
+    const map = { trigger1: 'newTrigger', A: 'newA', s3: 'newS3' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [{ ifThenStepId: 'newA', endStepId: 'newS3' }],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('remaps a self-referencing (empty) block to the new self id', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 'A')]
+    const map = { trigger1: 'newTrigger', A: 'newA' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [{ ifThenStepId: 'newA', endStepId: 'newA' }],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('reports a source marker that does not resolve to a copied step', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 'ghost')]
+    const map = { trigger1: 'newTrigger', A: 'newA' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [],
+      danglingSourceStepIds: ['A'],
+    })
+  })
+
+  it('ignores legacy (marker-less) if-thens', () => {
+    const sourceSteps = [trigger(1), ifThen('L', 2), plain('s3', 3)]
+    const map = { trigger1: 'newTrigger', L: 'newL', s3: 'newS3' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('remaps multiple blocks', () => {
+    const sourceSteps = [
+      trigger(1),
+      markedIfThen('A', 2, 'a3'),
+      plain('a3', 3),
+      markedIfThen('B', 4, 'b5'),
+      plain('b5', 5),
+    ]
+    const map = {
+      trigger1: 'nt',
+      A: 'nA',
+      a3: 'na3',
+      B: 'nB',
+      b5: 'nb5',
+    }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [
+        { ifThenStepId: 'nA', endStepId: 'na3' },
+        { ifThenStepId: 'nB', endStepId: 'nb5' },
+      ],
+      danglingSourceStepIds: [],
+    })
+  })
+})
+
+describe('remapIfThenEndStepIdsOnDuplicateBranch', () => {
+  it('remaps an intra-selection marker to the ordinal counterpart copy', () => {
+    // Selection [A, s2]; A's endStep is s2 (index 1). Copies: nA, ns2.
+    const sourceSelection = [markedIfThen('A', 2, 's2'), plain('s2', 3)]
+    const newStepIds = ['nA', 'ns2']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [{ ifThenStepId: 'nA', endStepId: 'ns2' }],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('remaps a self-referencing (empty) block to its own copy', () => {
+    const sourceSelection = [markedIfThen('A', 2, 'A')]
+    const newStepIds = ['nA']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [{ ifThenStepId: 'nA', endStepId: 'nA' }],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('leaves the copy marker-less and reports when the marker points outside the selection', () => {
+    // A's endStep points at a step not in the duplicated selection.
+    const sourceSelection = [markedIfThen('A', 2, 'outsider'), plain('s3', 3)]
+    const newStepIds = ['nA', 'ns3']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [],
+      strippedSourceStepIds: ['A'],
+    })
+  })
+
+  it('ignores legacy (marker-less) if-thens in the selection', () => {
+    const sourceSelection = [ifThen('L', 2), plain('s3', 3)]
+    const newStepIds = ['nL', 'ns3']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('remaps multiple intra-selection blocks by ordinal position', () => {
+    const sourceSelection = [
+      markedIfThen('A', 2, 'a2'),
+      plain('a2', 3),
+      markedIfThen('B', 4, 'b2'),
+      plain('b2', 5),
+    ]
+    const newStepIds = ['nA', 'na2', 'nB', 'nb2']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [
+        { ifThenStepId: 'nA', endStepId: 'na2' },
+        { ifThenStepId: 'nB', endStepId: 'nb2' },
+      ],
+      strippedSourceStepIds: [],
+    })
   })
 })

--- a/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   BLOCK_END_STEP_ID,
+  isBlankPlaceholderStep,
   isBlockStep,
   isForEachStep,
   isIfThenStep,
@@ -90,6 +91,34 @@ describe('toolbox constants', () => {
       { label: 'undefined step', step: undefined },
     ])('is false for a non-block step: $label', ({ step }) => {
       expect(isBlockStep(step)).toBe(false)
+    })
+  })
+
+  describe('isBlankPlaceholderStep', () => {
+    it('is true when both appKey and key are missing', () => {
+      expect(isBlankPlaceholderStep({})).toBe(true)
+    })
+
+    it('is true when both appKey and key are null', () => {
+      expect(isBlankPlaceholderStep({ appKey: null, key: null })).toBe(true)
+    })
+
+    it.each([
+      { label: 'undefined step', step: undefined },
+      { label: 'null step', step: null },
+    ])('is true for $label', ({ step }) => {
+      expect(isBlankPlaceholderStep(step)).toBe(true)
+    })
+
+    it.each([
+      {
+        label: 'a fully-configured step',
+        step: { appKey: 'toolbox', key: 'ifThen' },
+      },
+      { label: 'appKey set but key missing', step: { appKey: 'toolbox' } },
+      { label: 'key set but appKey missing', step: { key: 'ifThen' } },
+    ])('is false for $label', ({ step }) => {
+      expect(isBlankPlaceholderStep(step)).toBe(false)
     })
   })
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -1,10 +1,46 @@
 import type { IStepConfig } from '@plumber/types'
 
+import { raw, Transaction } from 'objection'
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
+import type Flow from '@/models/flow'
+import type Step from '@/models/step'
 
-import { validateEndStepWrite } from '../../common/validate-end-step'
+import { BLOCK_END_STEP_ID } from '../../common/constants'
+import {
+  upgradeIfThenV1BlocksIfEnabled,
+  validateEndStepOnCreateStep,
+  validateEndStepWrite,
+  validateFlowBlocks,
+} from '../../common/validate-end-step'
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+const stepPatchMocks = vi.hoisted(() => ({
+  patchCalls: [] as { id: string; patch: unknown }[],
+  deleteCalls: [] as string[],
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: (id: string) => ({
+        patch: (patch: unknown) => {
+          stepPatchMocks.patchCalls.push({ id, patch })
+          return Promise.resolve()
+        },
+        delete: () => {
+          stepPatchMocks.deleteCalls.push(id)
+          return Promise.resolve()
+        },
+      }),
+    }),
+  },
+}))
 
 type Fixture = {
   id: string
@@ -364,5 +400,527 @@ describe('validateEndStepWrite', () => {
         reason: 'overlapping-blocks',
       }),
     )
+  })
+})
+
+describe('validateFlowBlocks', () => {
+  let loggerWarnSpy: MockInstance
+
+  beforeEach(() => {
+    loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => null)
+  })
+
+  it('passes a flow whose blocks are all valid and non-empty', () => {
+    const blockB = ifThen('blockB', 2, { endStepId: 's3' })
+    const blockC = ifThen('blockC', 4, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      plain('s3', 3),
+      blockC,
+      plain('s5', 5),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores legacy (marker-less) if-thens', () => {
+    const flowSteps = [trigger(1), ifThen('legacy', 2), plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty (self-referencing) block', () => {
+    const block = ifThen('block', 2, { endStepId: 'block' })
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'empty-block',
+      }),
+    )
+  })
+
+  it('rejects a dangling marker', () => {
+    const block = ifThen('block', 2, { endStepId: 'ghost' })
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'end-step-not-in-flow',
+      }),
+    )
+  })
+
+  it('rejects a marker pointing before the if-then', () => {
+    const block = ifThen('block', 3, { endStepId: 's2' })
+    const flowSteps = [trigger(1), plain('s2', 2), block]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'end-step-before-self',
+      }),
+    )
+  })
+
+  it('accepts a block confined to one MRF rejection branch', () => {
+    const rejection = { approval: REJECTION_BRANCH }
+    const block = ifThen('block', 3, { ...rejection, endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('s4', 4, rejection),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a marked if-then whose block leaves its rejection branch', () => {
+    const block = ifThen('block', 3, {
+      approval: REJECTION_BRANCH,
+      endStepId: 's4',
+    })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects a block whose region contains an mrfSubmission step', () => {
+    const block = ifThen('block', 2, { endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      block,
+      mrfSubmission('mrf', 3),
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'mrf-step-in-region',
+      }),
+    )
+  })
+
+  it('rejects a top-level block whose region reaches into a rejection branch', () => {
+    const block = ifThen('block', 2, { endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      block,
+      plain('approvalChild', 3, {
+        approval: { branch: 'reject', stepId: 'x' },
+      }),
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects overlapping (nested) new-style blocks', () => {
+    const blockB = ifThen('blockB', 2, { endStepId: 's4' })
+    const blockC = ifThen('blockC', 3, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      blockC,
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'overlapping-blocks',
+      }),
+    )
+  })
+})
+
+describe('upgradeIfThenV1BlocksIfEnabled', () => {
+  const getLdFlagValueMock = vi.mocked(getLdFlagValue)
+  const trx = {} as Transaction
+
+  const flowPositionPatchMocks = {
+    patchCalls: [] as { threshold: number; patch: unknown }[],
+  }
+
+  // `stepsAfterBlankRemoval` stands in for what a real DB re-fetch would
+  // return once the blank-cleanup deletes + compacts positions — only
+  // consulted by tests that actually trigger a cleanup.
+  function fakeFlow(
+    ownerEmail: string,
+    stepsAfterBlankRemoval: Fixture[] = [],
+  ): Flow {
+    return {
+      id: FLOW_ID,
+      $relatedQuery: vi.fn((relation: string) => {
+        if (relation === 'user') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            throwIfNotFound: vi.fn().mockResolvedValue({ email: ownerEmail }),
+          }
+        }
+        return {
+          orderBy: vi.fn().mockResolvedValue(stepsAfterBlankRemoval),
+          where: vi.fn((_column: string, _operator: string, value: number) => ({
+            patch: vi.fn((patch: unknown) => {
+              flowPositionPatchMocks.patchCalls.push({
+                threshold: value,
+                patch,
+              })
+              return Promise.resolve()
+            }),
+          })),
+        }
+      }),
+    } as unknown as Flow
+  }
+
+  const pinPatch = (endStepId: string) => ({
+    config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+      JSON.stringify(endStepId),
+    ]),
+  })
+
+  const shiftPatch = () => ({ position: raw('position - 1') })
+
+  // A leftover blank child from the V1 branch initializer: neither field set.
+  const blank = (id: string, position: number): Fixture => ({
+    id,
+    position,
+    config: {},
+  })
+
+  beforeEach(() => {
+    getLdFlagValueMock.mockReset()
+    stepPatchMocks.patchCalls.length = 0
+    stepPatchMocks.deleteCalls.length = 0
+    flowPositionPatchMocks.patchCalls.length = 0
+  })
+
+  it('returns before checking the flag when there are no V1 if-thens', async () => {
+    const flowSteps = [trigger(1), plain('s2', 2)]
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(getLdFlagValueMock).not.toHaveBeenCalled()
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('does nothing when the flag is off for the pipe owner', async () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+    getLdFlagValueMock.mockResolvedValue(false)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(getLdFlagValueMock).toHaveBeenCalledWith(
+      'feature_if_then_then',
+      'owner@example.com',
+      false,
+    )
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('pins every V1 if-then block to its own independently-derived endStep', async () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const childA = plain('childA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const childB = plain('childB', 5)
+    const trailing = plain('trailing', 6)
+    const flowSteps = [trigger(1), ifThenA, childA, ifThenB, childB, trailing]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'ifThenA', patch: pinPatch('childA') },
+      { id: 'ifThenB', patch: pinPatch('trailing') },
+    ])
+  })
+
+  it('excludes steps about to be deleted from consideration', async () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+      new Set(['block']),
+    )
+
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('throws end-step-write-rejected when a derived extent violates region confinement', async () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('topLevel', 4),
+    ]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await expect(
+      upgradeIfThenV1BlocksIfEnabled(
+        trx,
+        fakeFlow('owner@example.com'),
+        flowSteps,
+      ),
+    ).rejects.toThrow()
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('deletes a lone blank member and self-references the emptied block', async () => {
+    const block = ifThen('block', 2)
+    const child = blank('child', 3)
+    const flowSteps = [trigger(1), block, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [trigger(1), block])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['child'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('block') },
+    ])
+  })
+
+  it('deletes a blank member and pins to the surviving real step', async () => {
+    const block = ifThen('block', 2)
+    const real = plain('real', 3)
+    const child = blank('child', 4)
+    const flowSteps = [trigger(1), block, real, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [trigger(1), block, real])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['child'])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
+  })
+
+  it('deletes multiple blank members in the same block, highest position first', async () => {
+    const block = ifThen('block', 2)
+    const firstBlank = blank('firstBlank', 3)
+    const real = plain('real', 4)
+    const secondBlank = blank('secondBlank', 5)
+    const flowSteps = [trigger(1), block, firstBlank, real, secondBlank]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [
+      trigger(1),
+      block,
+      { ...real, position: 3 },
+    ])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['secondBlank', 'firstBlank'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 5, patch: shiftPatch() },
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
+  })
+
+  it('does not delete a blank member the caller already excluded', async () => {
+    const block = ifThen('block', 2)
+    const child = blank('child', 3)
+    const flowSteps = [trigger(1), block, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com')
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      flow,
+      flowSteps,
+      new Set(['child']),
+    )
+
+    expect(stepPatchMocks.deleteCalls).toEqual([])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('child') },
+    ])
+  })
+
+  it('re-derives a later block correctly after an earlier blank removal shifts positions', async () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const blankA = blank('blankA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const childB = plain('childB', 5)
+    const flowSteps = [trigger(1), ifThenA, blankA, ifThenB, childB]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [
+      trigger(1),
+      ifThenA,
+      { ...ifThenB, position: 3 },
+      { ...childB, position: 4 },
+    ])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['blankA'])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'ifThenA', patch: pinPatch('ifThenA') },
+      { id: 'ifThenB', patch: pinPatch('childB') },
+    ])
+  })
+})
+
+describe('validateEndStepOnCreateStep', () => {
+  const trx = {} as Transaction
+
+  const flowPositionPatchMocks = {
+    patchCalls: [] as { threshold: number; patch: unknown }[],
+  }
+
+  // `stepsAfterBlankRemoval` stands in for what a real DB re-fetch would
+  // return once the blank-cleanup deletes + compacts positions — the mock
+  // returns `initialSteps` for the function's first `steps` fetch (its
+  // pre-cleanup view) and this for every fetch after.
+  function fakeFlow(
+    initialSteps: Fixture[],
+    stepsAfterBlankRemoval: Fixture[] = initialSteps,
+  ): Flow {
+    const orderByMock = vi
+      .fn()
+      .mockResolvedValueOnce(initialSteps)
+      .mockResolvedValue(stepsAfterBlankRemoval)
+    return {
+      id: FLOW_ID,
+      $relatedQuery: vi.fn(() => ({
+        orderBy: orderByMock,
+        where: vi.fn((_column: string, _operator: string, value: number) => ({
+          patch: vi.fn((patch: unknown) => {
+            flowPositionPatchMocks.patchCalls.push({
+              threshold: value,
+              patch,
+            })
+            return Promise.resolve()
+          }),
+        })),
+      })),
+    } as unknown as Flow
+  }
+
+  const pinPatch = (endStepId: string) => ({
+    config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+      JSON.stringify(endStepId),
+    ]),
+  })
+
+  const shiftPatch = () => ({ position: raw('position - 1') })
+
+  // A leftover blank child from the V1 branch initializer: neither field set.
+  const blank = (id: string, position: number): Fixture => ({
+    id,
+    position,
+    config: {},
+  })
+
+  beforeEach(() => {
+    stepPatchMocks.patchCalls.length = 0
+    stepPatchMocks.deleteCalls.length = 0
+    flowPositionPatchMocks.patchCalls.length = 0
+  })
+
+  it('deletes a leftover V1 blank placeholder before pinning a block reached via add-after-block', async () => {
+    const block = ifThen('block', 2)
+    const blankChild = blank('blankChild', 3)
+    const newStep = plain('newStep', 4)
+    const flow = fakeFlow(
+      [trigger(1), block, blankChild, newStep],
+      [trigger(1), block, { ...newStep, position: 3 }],
+    )
+
+    await validateEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: 'block',
+      previousStep: { id: 'blankChild' } as unknown as Step,
+      newStep: { id: 'newStep' } as unknown as Step,
+    })
+
+    // The placeholder is deleted and positions close up around it...
+    expect(stepPatchMocks.deleteCalls).toEqual(['blankChild'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    // ...so the block, left with no other member, self-references (an empty
+    // V2 block) instead of the deleted placeholder becoming its endStep.
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('block') },
+    ])
+  })
+
+  it('pins directly to a real last member, with no cleanup, when there is no blank placeholder', async () => {
+    const block = ifThen('block', 2)
+    const real = plain('real', 3)
+    const newStep = plain('newStep', 4)
+    const flow = fakeFlow([trigger(1), block, real, newStep])
+
+    await validateEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: 'block',
+      previousStep: { id: 'real' } as unknown as Step,
+      newStep: { id: 'newStep' } as unknown as Step,
+    })
+
+    expect(stepPatchMocks.deleteCalls).toEqual([])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -1,6 +1,12 @@
 import type { IStep } from '@plumber/types'
 
-import { isIfThenStep, type StepLike } from '../../../common/constants'
+import {
+  BLOCK_END_STEP_ID,
+  isBlankPlaceholderStep,
+  isIfThenStep,
+  isIfThenV2,
+  type StepLike,
+} from '../../../common/constants'
 
 // StepLike (appKey/key/config, all optional) plus the fields the extent scan
 // needs directly: id/position (used unconditionally) and parameters (depth,
@@ -9,6 +15,17 @@ import { isIfThenStep, type StepLike } from '../../../common/constants'
 type ExtentStep = StepLike &
   Pick<IStep, 'id' | 'position'> &
   Partial<Pick<IStep, 'parameters'>>
+
+// The minimal step shape the structural-repair helpers read: id/position plus
+// config (for the marker). Real Objection `Step` rows satisfy it; unit tests
+// pass partial plain objects. Callers pass steps ordered by position ascending.
+type RepairStep = StepLike & Pick<IStep, 'id' | 'position'>
+
+// A single marker reassignment: pin `ifThenStepId`'s block endStep to `endStepId`.
+export interface EndStepPatch {
+  ifThenStepId: string
+  endStepId: string
+}
 
 // Mirrors the depth handling in getIfThenV1StepIdToSkipTo: a missing/garbled
 // depth defaults to 0 (nesting never shipped, so this is inert defense).
@@ -46,4 +63,250 @@ export function deriveIfThenV1EndStep<T extends ExtentStep>(
     return flowSteps[flowSteps.length - 1]
   }
   return flowSteps[nextBoundaryIndex - 1]
+}
+
+/**
+ * Finds the ids of any blank placeholder steps (see `isBlankPlaceholderStep`)
+ * inside a V1 if-then block's derived range `(ifThenStep, endStep]`. Used by
+ * the V1 -> V2 opportunistic upgrade to drop these leftover stubs rather than
+ * pin them into the block's initial V2 membership: V2 blocks start empty and
+ * never grow one on their own, so a survivor here is purely a V1-era
+ * artifact from the (now-superseded) branch initializer.
+ */
+export function findBlankPlaceholderMemberIds<T extends ExtentStep>(
+  flowSteps: T[],
+  ifThenStep: T,
+  endStep: T,
+): string[] {
+  return flowSteps
+    .filter(
+      (step) =>
+        step.position > ifThenStep.position &&
+        step.position <= endStep.position &&
+        isBlankPlaceholderStep(step),
+    )
+    .map((step) => step.id)
+}
+
+/**
+ * Computes the marker reassignments needed to keep new-style if-then blocks
+ * correct after a delete. For each surviving new-style block whose endStep was
+ * among the deleted steps, the block repoints to the highest-positioned
+ * surviving member within its old range `(ifThen, oldEnd]`, or to the if-then
+ * itself when every member is gone (empty block => self-reference).
+ *
+ * A block whose own if-then was deleted needs no repair (block-expansion
+ * removes such a block whole), and a block whose endStep survived is left
+ * alone. Legacy (marker-less) if-thens are never touched. `stepsBeforeDelete`
+ * must be ordered by position ascending and reflect the pre-delete positions.
+ */
+export function reassignIfThenEndStepsOnDelete<T extends RepairStep>(
+  stepsBeforeDelete: T[],
+  deletedIds: string[],
+): EndStepPatch[] {
+  const deleted = new Set(deletedIds)
+  const patches: EndStepPatch[] = []
+
+  for (const step of stepsBeforeDelete) {
+    if (!isIfThenV2(step) || deleted.has(step.id)) {
+      continue
+    }
+    const oldEndStepId = step.config?.[BLOCK_END_STEP_ID]
+    // endStep survived, or the marker was already dangling — nothing to repair.
+    if (oldEndStepId === undefined || !deleted.has(oldEndStepId)) {
+      continue
+    }
+    const oldEnd = stepsBeforeDelete.find((s) => s.id === oldEndStepId)
+    if (!oldEnd) {
+      continue
+    }
+
+    let endStepId = step.id
+    let endPosition = step.position
+    for (const candidate of stepsBeforeDelete) {
+      if (
+        !deleted.has(candidate.id) &&
+        candidate.position > step.position &&
+        candidate.position <= oldEnd.position &&
+        candidate.position > endPosition
+      ) {
+        endStepId = candidate.id
+        endPosition = candidate.position
+      }
+    }
+    patches.push({ ifThenStepId: step.id, endStepId })
+  }
+
+  return patches
+}
+
+/**
+ * Expands a requested delete set so that deleting a new-style if-then also
+ * deletes its whole block range `[ifThen … endStep]`. A client that already
+ * sent the full range (e.g. an old-UI branch delete) is a no-op via the set
+ * union. Legacy (marker-less) if-thens keep old-client single-id semantics and
+ * are never expanded; a new-style if-then with a dangling / behind-self marker
+ * is reported (so the caller can log it) and its block is left un-expanded —
+ * only what was asked is deleted. `flowSteps` must be ordered by position
+ * ascending.
+ */
+export function expandIfThenBlockDeletions<T extends RepairStep>(
+  flowSteps: T[],
+  requestedIds: string[],
+): { expandedIds: Set<string>; danglingIfThenIds: string[] } {
+  const requested = new Set(requestedIds)
+  const expandedIds = new Set(requestedIds)
+  const danglingIfThenIds: string[] = []
+
+  for (const step of flowSteps) {
+    if (!requested.has(step.id) || !isIfThenV2(step)) {
+      continue
+    }
+    const endStepId = step.config?.[BLOCK_END_STEP_ID]
+    const endStep = flowSteps.find((s) => s.id === endStepId)
+    if (!endStep || endStep.position < step.position) {
+      danglingIfThenIds.push(step.id)
+      continue
+    }
+    for (const member of flowSteps) {
+      if (
+        member.position >= step.position &&
+        member.position <= endStep.position
+      ) {
+        expandedIds.add(member.id)
+      }
+    }
+  }
+
+  return { expandedIds, danglingIfThenIds }
+}
+
+/**
+ * Computes the marker reassignments needed to keep new-style if-then blocks
+ * correct after a reorder. Each block's membership is fixed by the pre-reorder
+ * positions (the steps in `(ifThen, oldEnd]`); its endStep becomes whichever
+ * member now sits at the highest position. Only markers that actually changed
+ * are returned. A reorder never changes membership, so blocks moved as a unit —
+ * and blocks the reorder never touched — produce no patch. Empty
+ * (self-referencing) blocks and blocks with a pre-existing dangling marker are
+ * left alone. `preSteps` must be ordered by position ascending; `newPositions`
+ * gives the post-reorder position of every moved step (unmoved steps keep their
+ * pre-reorder position).
+ */
+export function reassignIfThenEndStepsOnReorder<T extends RepairStep>(
+  preSteps: T[],
+  newPositions: { id: string; position: number }[],
+): EndStepPatch[] {
+  const newPositionById = new Map(
+    newPositions.map(({ id, position }) => [id, position]),
+  )
+  const positionOf = (step: T): number =>
+    newPositionById.get(step.id) ?? step.position
+
+  const patches: EndStepPatch[] = []
+
+  for (const step of preSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const oldEndStepId = step.config?.[BLOCK_END_STEP_ID]
+    const oldEnd = preSteps.find((s) => s.id === oldEndStepId)
+    // Dangling marker — out of scope for reorder repair.
+    if (!oldEnd) {
+      continue
+    }
+    // Members are fixed by pre-reorder position: the steps in (ifThen, oldEnd].
+    const members = preSteps.filter(
+      (s) => s.position > step.position && s.position <= oldEnd.position,
+    )
+    // Empty block (self-reference) — nothing to reassign.
+    if (members.length === 0) {
+      continue
+    }
+
+    let newEnd = members[0]
+    for (const member of members) {
+      if (positionOf(member) > positionOf(newEnd)) {
+        newEnd = member
+      }
+    }
+    if (newEnd.id !== oldEndStepId) {
+      patches.push({ ifThenStepId: step.id, endStepId: newEnd.id })
+    }
+  }
+
+  return patches
+}
+
+/**
+ * Remaps new-style if-then markers when a whole flow is duplicated. `endStepId`
+ * is a forward reference, so it can only be resolved once every step has a
+ * copy: this runs as a post-pass over the source steps and the old→new id map.
+ * Each source block yields a patch pinning the COPIED if-then to the COPIED
+ * endStep; self-references remap for free. A source marker that does not
+ * resolve to a copied step (a pre-existing dangling marker) is reported so the
+ * caller can fail the whole duplication. Legacy (marker-less) if-thens are
+ * ignored. Returned patch ids are the NEW (copied) step ids.
+ */
+export function remapIfThenEndStepIdsOnDuplicate<T extends RepairStep>(
+  sourceSteps: T[],
+  oldToNewStepIds: Record<string, string>,
+): { patches: EndStepPatch[]; danglingSourceStepIds: string[] } {
+  const patches: EndStepPatch[] = []
+  const danglingSourceStepIds: string[] = []
+
+  for (const step of sourceSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const newIfThenId = oldToNewStepIds[step.id]
+    const newEndStepId = oldToNewStepIds[step.config?.[BLOCK_END_STEP_ID] ?? '']
+    if (newIfThenId === undefined) {
+      continue
+    }
+    if (newEndStepId === undefined) {
+      danglingSourceStepIds.push(step.id)
+      continue
+    }
+    patches.push({ ifThenStepId: newIfThenId, endStepId: newEndStepId })
+  }
+
+  return { patches, danglingSourceStepIds }
+}
+
+/**
+ * Remaps new-style if-then markers when a branch (a contiguous selection of
+ * steps) is duplicated. The source selection is DB-derived and correlated to
+ * the copies ordinally: `sourceSelection[i]` was copied to `newStepIds[i]`.
+ * Markers are read from the source rows, never from client-copied values. A
+ * source block whose endStep is within the selection yields a patch pinning the
+ * copy to the ordinal counterpart's copy (self-references included); a marker
+ * pointing outside the selection is reported so the caller can log it and leave
+ * the copy marker-less (a graceful legacy copy with a correct derived extent).
+ */
+export function remapIfThenEndStepIdsOnDuplicateBranch<T extends RepairStep>(
+  sourceSelection: T[],
+  newStepIds: string[],
+): { patches: EndStepPatch[]; strippedSourceStepIds: string[] } {
+  const patches: EndStepPatch[] = []
+  const strippedSourceStepIds: string[] = []
+
+  for (let i = 0; i < sourceSelection.length; i++) {
+    const sourceStep = sourceSelection[i]
+    if (!isIfThenV2(sourceStep)) {
+      continue
+    }
+    const oldEndStepId = sourceStep.config?.[BLOCK_END_STEP_ID]
+    const endIndex = sourceSelection.findIndex((s) => s.id === oldEndStepId)
+    if (endIndex === -1) {
+      strippedSourceStepIds.push(sourceStep.id)
+      continue
+    }
+    patches.push({
+      ifThenStepId: newStepIds[i],
+      endStepId: newStepIds[endIndex],
+    })
+  }
+
+  return { patches, strippedSourceStepIds }
 }

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -58,6 +58,17 @@ export function isBlockStep(step: StepLike | null | undefined): boolean {
   return isIfThenStep(step) || isForEachStep(step)
 }
 
+// A step created with neither an app nor an event. The only legitimate way
+// this happens is the if-then V1 branch initializer, which stubs a blank
+// child so users see where to add their first action — createStep otherwise
+// requires both fields together, so a step is never mid-configuration with
+// just one of them unset.
+export function isBlankPlaceholderStep(
+  step: StepLike | null | undefined,
+): boolean {
+  return !step?.appKey && !step?.key
+}
+
 // A new-style ("v2") if-then carries the block endStep marker in config;
 // presence (Object.hasOwn) — not value — distinguishes it from a legacy one.
 export function isIfThenV2(step: StepLike | null | undefined): boolean {

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -1,8 +1,16 @@
-import type { IStep } from '@plumber/types'
+import type { IStep, IStepConfig } from '@plumber/types'
 
 import { raw, Transaction } from 'objection'
 
-import { deriveIfThenV1EndStep } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import {
+  deriveIfThenV1EndStep,
+  findBlankPlaceholderMemberIds,
+  reassignIfThenEndStepsOnDelete,
+  reassignIfThenEndStepsOnReorder,
+  remapIfThenEndStepIdsOnDuplicate,
+  remapIfThenEndStepIdsOnDuplicateBranch,
+} from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
@@ -31,6 +39,25 @@ interface EndStepWriteValidationArgs {
   flowId: string
 }
 
+// Config keys the server owns; a client must never set them directly. endStepId
+// is maintained entirely by the endStep write rules and the duplication remaps.
+const SERVER_OWNED_CONFIG_KEYS = [BLOCK_END_STEP_ID] as const
+
+/**
+ * Strips server-owned keys from a client-supplied config so a mutation only
+ * persists the marker via its own server-side rules. Used by create-step and
+ * duplicate-branch.
+ */
+export function sanitizeServerSideConfig(
+  config: IStepConfig | null | undefined,
+): IStepConfig {
+  const sanitized = { ...(config ?? {}) }
+  for (const key of SERVER_OWNED_CONFIG_KEYS) {
+    delete sanitized[key]
+  }
+  return sanitized
+}
+
 /**
  * Logs a structured rejection and throws a plain Error so the enclosing
  * transaction rolls back. These states are prevented by the frontend, so a
@@ -45,8 +72,31 @@ function rejectEndStepWrite(
   throw new Error(`endStepId write rejected: ${reason}`)
 }
 
+/**
+ * Logs a structured publish rejection and throws a user-facing error. Unlike a
+ * write rejection (a should-never-happen bug), publish is the one place a user
+ * can trip a bad marker — most notably an empty block — so the message is
+ * actionable and the log level is warn.
+ */
+function rejectPublishEndStep(
+  reason: string,
+  details: Record<string, unknown>,
+): never {
+  logger.warn({ event: 'publish-invalid-end-step', reason, ...details })
+  throw new Error(
+    reason === 'empty-block'
+      ? 'Cannot publish: an If-then block has no steps. Add a step inside it or remove the block.'
+      : 'Cannot publish: an If-then block is misconfigured. Refresh the page and try again.',
+  )
+}
+
 function isMrfSubmissionStep(step: ValidationStep): boolean {
   return step.appKey === 'formsg' && step.key === 'mrfSubmission'
+}
+
+interface EndStepViolation {
+  reason: string
+  details: Record<string, unknown>
 }
 
 /**
@@ -60,47 +110,50 @@ function getRejectionBranchId(step: ValidationStep): string | null {
 }
 
 /**
- * Enforces every invariant an if-then V2 endStepId write must satisfy: the
- * target is a toolbox/ifThen in this flow; the endStep exists and sits at/after
- * it; the block region `(ifThen, end]` holds no mrfSubmission and stays within
- * the if-then's own MRF region (the main flow, or one rejection branch); and the
- * block does not overlap another if-then V2 block. Violations log
- * `end-step-write-rejected` and throw, rolling back the mutation. Exported for
- * unit coverage; mutations should call the `validateEndStepOn{Create,Update}Step`
- * helpers below.
+ * Pure invariant check for a single if-then V2 endStepId: the target is a
+ * toolbox/ifThen in this flow; the endStep exists and sits at/after it; the
+ * block region `(ifThen, end]` holds no mrfSubmission and stays within the
+ * if-then's own MRF region (the main flow, or one rejection branch); and the
+ * block does not overlap another if-then V2 block. Returns the first violation
+ * (reason + details) or null when the write is valid. Shared by the write path
+ * (which throws) and the publish validator (which warns) so the invariant lives
+ * in one place. A self-referencing (empty) block passes here; only publish
+ * rejects it.
  */
-export function validateEndStepWrite({
+function checkEndStepWrite({
   flowSteps,
   ifThenStepId,
   endStepId,
   flowId,
-}: EndStepWriteValidationArgs): void {
+}: EndStepWriteValidationArgs): EndStepViolation | null {
   const ifThenStep = flowSteps.find((step) => step.id === ifThenStepId)
 
   // Target must be a toolbox/ifThen present in this flow.
   if (!ifThenStep || !isIfThenStep(ifThenStep)) {
-    rejectEndStepWrite('target-not-if-then', { ifThenStepId, flowId })
+    return { reason: 'target-not-if-then', details: { ifThenStepId, flowId } }
   }
 
   // endStep must exist in the same flow.
   const endStep = flowSteps.find((step) => step.id === endStepId)
   if (!endStep) {
-    rejectEndStepWrite('end-step-not-in-flow', {
-      ifThenStepId,
-      endStepId,
-      flowId,
-    })
+    return {
+      reason: 'end-step-not-in-flow',
+      details: { ifThenStepId, endStepId, flowId },
+    }
   }
 
   // endStep must be at or after the if-then (self-ref is the empty block).
   if (endStep.position < ifThenStep.position) {
-    rejectEndStepWrite('end-step-before-self', {
-      ifThenStepId,
-      endStepId,
-      endStepPosition: endStep.position,
-      ifThenPosition: ifThenStep.position,
-      flowId,
-    })
+    return {
+      reason: 'end-step-before-self',
+      details: {
+        ifThenStepId,
+        endStepId,
+        endStepPosition: endStep.position,
+        ifThenPosition: ifThenStep.position,
+        flowId,
+      },
+    }
   }
 
   // Region confinement: the block must live inside one MRF region. It may hold
@@ -117,22 +170,23 @@ export function validateEndStepWrite({
       continue
     }
     if (isMrfSubmissionStep(step)) {
-      rejectEndStepWrite('mrf-step-in-region', {
-        ifThenStepId,
-        endStepId,
-        offendingStepId: step.id,
-        flowId,
-      })
+      return {
+        reason: 'mrf-step-in-region',
+        details: { ifThenStepId, endStepId, offendingStepId: step.id, flowId },
+      }
     }
     if (getRejectionBranchId(step) !== blockRejectionBranchId) {
-      rejectEndStepWrite('approval-branch-crossed', {
-        ifThenStepId,
-        endStepId,
-        offendingStepId: step.id,
-        blockRejectionBranchId,
-        offendingRejectionBranchId: getRejectionBranchId(step),
-        flowId,
-      })
+      return {
+        reason: 'approval-branch-crossed',
+        details: {
+          ifThenStepId,
+          endStepId,
+          offendingStepId: step.id,
+          blockRejectionBranchId,
+          offendingRejectionBranchId: getRejectionBranchId(step),
+          flowId,
+        },
+      }
     }
   }
 
@@ -153,12 +207,68 @@ export function validateEndStepWrite({
       ifThenStep.position <= otherEnd.position &&
       other.position <= endStep.position
     if (overlaps) {
-      rejectEndStepWrite('overlapping-blocks', {
-        ifThenStepId,
-        endStepId,
-        otherIfThenStepId: other.id,
-        flowId,
-      })
+      return {
+        reason: 'overlapping-blocks',
+        details: {
+          ifThenStepId,
+          endStepId,
+          otherIfThenStepId: other.id,
+          flowId,
+        },
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Enforces every invariant an if-then V2 endStepId write must satisfy (see
+ * `checkEndStepWrite`). Violations log `end-step-write-rejected` and throw,
+ * rolling back the mutation. Exported for unit coverage; mutations should call
+ * the `validateEndStepOn{Create,Update}Step` helpers below.
+ */
+export function validateEndStepWrite(args: EndStepWriteValidationArgs): void {
+  const violation = checkEndStepWrite(args)
+  if (violation) {
+    rejectEndStepWrite(violation.reason, violation.details)
+  }
+}
+
+/**
+ * Publish-time tripwire over a whole flow's blocks (a step carrying an endStepId
+ * marker is, by definition, a block), so the runtime fail-loud path stays rare.
+ * Every new-style if-then block must satisfy the write invariant (via
+ * checkEndStepWrite: resolves, at/after self, region-confined, disjoint) AND
+ * must not be empty. An empty (self-referencing) block is valid mid-edit —
+ * delete/reorder repair to self-ref — but is rejected here: unlike the old UI's
+ * auto-created empty step, it has no incomplete child to block publish. Any
+ * violation logs `publish-invalid-end-step` and throws a user-facing error.
+ * `flowSteps` must be ordered by position ascending.
+ */
+export function validateFlowBlocks(
+  flowSteps: ValidationStep[],
+  flowId: string,
+): void {
+  for (const step of flowSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const endStepId = step.config?.[BLOCK_END_STEP_ID] ?? ''
+
+    // Empty (self-referencing) block: allowed mid-edit, not publishable.
+    if (endStepId === step.id) {
+      rejectPublishEndStep('empty-block', { ifThenStepId: step.id, flowId })
+    }
+
+    const violation = checkEndStepWrite({
+      flowSteps,
+      ifThenStepId: step.id,
+      endStepId,
+      flowId,
+    })
+    if (violation) {
+      rejectPublishEndStep(violation.reason, violation.details)
     }
   }
 }
@@ -178,6 +288,160 @@ async function pinEndStep(
     })
 }
 
+// Mirrors packages/frontend/src/config/flags.ts's IF_THEN_THEN_FEATURE_FLAG.
+const IF_THEN_THEN_LD_FLAG_KEY = 'feature_if_then_then'
+
+/**
+ * Deletes a V1 block's leftover blank placeholder members and closes the
+ * position gaps they leave, highest position first so each target's own
+ * recorded position stays valid for the ones still to come. DB-only; the
+ * caller re-derives its own view of the flow afterward.
+ */
+async function deleteBlankPlaceholderMembers(
+  trx: Transaction,
+  flow: Flow,
+  currentSteps: ValidationStep[],
+  blankMemberIds: string[],
+): Promise<void> {
+  const targets = currentSteps
+    .filter((step) => blankMemberIds.includes(step.id))
+    .sort((a, b) => b.position - a.position)
+
+  for (const target of targets) {
+    await Step.query(trx).findById(target.id).delete()
+    await flow
+      .$relatedQuery('steps', trx)
+      .where('position', '>', target.position)
+      .patch({ position: raw('position - 1') })
+  }
+}
+
+/**
+ * Derives `ifThenStep`'s current V1 extent, deleting any leftover blank
+ * placeholder member(s) first (see `isBlankPlaceholderStep`) rather than
+ * sweeping them into the block's initial V2 membership: a V1 block can carry
+ * one from the (now-superseded) branch initializer, but a V2 block has no
+ * equivalent concept and starts empty, so a survivor here would render
+ * inconsistently with a native V2 block's own empty/populated conventions.
+ * `excludeStepIds` is kept out of both the derivation and the blank-member
+ * scan — e.g. create-step's own just-inserted step, so a plain add-after
+ * isn't absorbed into a block whose true end has shifted underneath it from
+ * a deletion here.
+ *
+ * Deleting a member shifts every later step's position, so cleanup re-derives
+ * off a freshly re-fetched, complete step list rather than patching
+ * `currentSteps` in place. Returns whether that happened — exactly when the
+ * caller's own copy of the flow's steps is now stale, position-wise.
+ */
+async function deriveV1EndStepDroppingBlankMembers(
+  trx: Transaction,
+  flow: Flow,
+  currentSteps: ValidationStep[],
+  ifThenStep: ValidationStep,
+  excludeStepIds: Set<string>,
+): Promise<{ endStep: ValidationStep; cleaned: boolean }> {
+  const endStep = deriveIfThenV1EndStep(currentSteps, ifThenStep)
+
+  const blankMemberIds = findBlankPlaceholderMemberIds(
+    currentSteps,
+    ifThenStep,
+    endStep,
+  ).filter((id) => !excludeStepIds.has(id))
+
+  if (blankMemberIds.length === 0) {
+    return { endStep, cleaned: false }
+  }
+
+  await deleteBlankPlaceholderMembers(trx, flow, currentSteps, blankMemberIds)
+  logger.info({
+    event: 'if-then-v1-blank-members-removed',
+    ifThenStepId: ifThenStep.id,
+    removedStepIds: blankMemberIds,
+    flowId: flow.id,
+  })
+
+  const refetchedSteps = (
+    await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+  ).filter((step) => !excludeStepIds.has(step.id))
+  return {
+    endStep: deriveIfThenV1EndStep(
+      refetchedSteps,
+      refetchedSteps.find((step) => step.id === ifThenStep.id),
+    ),
+    cleaned: true,
+  }
+}
+
+/**
+ * Opportunistically pins every legacy (V1) if-then block in a flow to its
+ * current derived extent, when the if-then-then flag is on for the flow
+ * owner. Once pinned, a block is protected forever after by the existing V2
+ * repair logic (`repairEndStepsOnReorder`/`repairEndStepsOnDeleteStep`) — this
+ * only ever needs to run the initial pin. Called opportunistically from
+ * create-step, delete-step, and update-step-positions so a block's extent
+ * gets locked in before a structural mutation can silently change it.
+ *
+ * A region-confinement violation on a pre-existing block throws exactly like
+ * the create-step pin path does (see `validateEndStepWrite`) — a background
+ * pass over a never-before-validated block can trip this on an edit unrelated
+ * to that block; this is an accepted risk, not a bug to defend against here.
+ */
+export async function upgradeIfThenV1BlocksIfEnabled(
+  trx: Transaction,
+  flow: Flow,
+  flowSteps: ValidationStep[],
+  excludeStepIds: Set<string> = new Set(),
+): Promise<void> {
+  const v1IfThens = flowSteps.filter(
+    (step) =>
+      isIfThenStep(step) && !isIfThenV2(step) && !excludeStepIds.has(step.id),
+  )
+  if (v1IfThens.length === 0) {
+    return
+  }
+
+  const owner = await flow
+    .$relatedQuery('user', trx)
+    .select('email')
+    .throwIfNotFound()
+  const isEnabled = await getLdFlagValue(
+    IF_THEN_THEN_LD_FLAG_KEY,
+    owner.email,
+    false,
+  )
+  if (!isEnabled) {
+    return
+  }
+
+  let currentSteps = flowSteps
+
+  for (const ifThenStep of v1IfThens) {
+    const liveIfThenStep = currentSteps.find(
+      (step) => step.id === ifThenStep.id,
+    )
+    const { endStep, cleaned } = await deriveV1EndStepDroppingBlankMembers(
+      trx,
+      flow,
+      currentSteps,
+      liveIfThenStep,
+      excludeStepIds,
+    )
+    if (cleaned) {
+      currentSteps = await flow
+        .$relatedQuery('steps', trx)
+        .orderBy('position', 'asc')
+    }
+
+    validateEndStepWrite({
+      flowSteps: currentSteps,
+      ifThenStepId: ifThenStep.id,
+      endStepId: endStep.id,
+      flowId: flow.id,
+    })
+    await pinEndStep(trx, ifThenStep.id, endStep.id)
+  }
+}
+
 /**
  * Maintains if-then endStepId markers when a step is created, in the same
  * transaction as the insert. A new step is placed either AFTER a block (the
@@ -185,7 +449,9 @@ async function pinEndStep(
  *
  *   - Added AFTER a block (previousBlockId set): the block's endStep must be the
  *     step the new one follows. A marker-less (V1) block is lazily upgraded by
- *     pinning it to its derived extent so the new step lands outside; an already
+ *     pinning it to its derived extent so the new step lands outside — dropping
+ *     any leftover blank placeholder member first, same as the opportunistic
+ *     upgrade pass (see `deriveV1EndStepDroppingBlankMembers`); an already
  *     marked block needs no write (the check is just a bug tripwire).
  *   - A plain step added at a marked block's tail (previousBlockId absent):
  *     extend that block to include it — this also covers first-add into an empty
@@ -250,13 +516,31 @@ export async function validateEndStepOnCreateStep({
         flowId,
       })
     }
+
+    // Drop the block's own leftover V1 blank placeholder member(s), if any,
+    // before pinning — same as the opportunistic upgrade pass — so a block
+    // lazily upgraded via an add-after-block insert never carries one into
+    // its initial V2 membership either. The new step is excluded from the
+    // re-derivation for the same reason it was excluded above.
+    const { endStep: finalEndStep, cleaned } =
+      await deriveV1EndStepDroppingBlankMembers(
+        trx,
+        flow,
+        preInsertSteps,
+        preBlockStep,
+        new Set([newStep.id]),
+      )
+    const finalFlowSteps = cleaned
+      ? await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+      : flowSteps
+
     validateEndStepWrite({
-      flowSteps,
+      flowSteps: finalFlowSteps,
       ifThenStepId: blockStep.id,
-      endStepId: derivedEndStep.id,
+      endStepId: finalEndStep.id,
       flowId,
     })
-    await pinEndStep(trx, blockStep.id, derivedEndStep.id)
+    await pinEndStep(trx, blockStep.id, finalEndStep.id)
     return
   }
 
@@ -306,4 +590,183 @@ export async function validateEndStepOnUpdateStep({
     .orderBy('position', 'asc')
   validateEndStepWrite({ flowSteps, ifThenStepId: step.id, endStepId, flowId })
   return { [BLOCK_END_STEP_ID]: endStepId }
+}
+
+/**
+ * Repairs new-style if-then markers after a deleteStep, in the same transaction
+ * as the delete. Any surviving block whose endStep was deleted repoints to its
+ * highest surviving member (empties to self-reference). Runs over the surviving
+ * step set, so it covers both the normal action-step delete and the
+ * trigger/MRF branch (which deletes via removeMrfSteps). A repaired marker only
+ * ever shrinks its block, so it stays valid by construction — structural
+ * mutations repair, never reject, and never add new restrictions.
+ */
+export async function repairEndStepsOnDeleteStep({
+  trx,
+  flow,
+  stepsBeforeDelete,
+}: {
+  trx: Transaction
+  flow: Flow
+  stepsBeforeDelete: Step[]
+}): Promise<void> {
+  const survivingSteps = await flow.$relatedQuery('steps', trx)
+  const survivingIds = new Set(survivingSteps.map((step) => step.id))
+  const deletedIds = stepsBeforeDelete
+    .map((step) => step.id)
+    .filter((id) => !survivingIds.has(id))
+
+  const patches = reassignIfThenEndStepsOnDelete(stepsBeforeDelete, deletedIds)
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+    logger.info({
+      event: 'end-step-repaired',
+      mutation: 'deleteStep',
+      ifThenStepId,
+      endStepId,
+      flowId: flow.id,
+    })
+  }
+}
+
+/**
+ * Repairs new-style if-then markers after an updateStepPositions, in the same
+ * transaction as the position patches. Each block keeps its membership; its
+ * endStep becomes the member now at the highest position. Only changed markers
+ * are patched. A repaired marker still points at a block member, so it stays
+ * valid by construction — structural mutations repair, never reject.
+ */
+export async function repairEndStepsOnReorder({
+  trx,
+  flow,
+  preSteps,
+  newPositions,
+}: {
+  trx: Transaction
+  flow: Flow
+  preSteps: Step[]
+  newPositions: { id: string; position: number }[]
+}): Promise<void> {
+  const patches = reassignIfThenEndStepsOnReorder(preSteps, newPositions)
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+    logger.info({
+      event: 'end-step-repaired',
+      mutation: 'updateStepPositions',
+      ifThenStepId,
+      endStepId,
+      flowId: flow.id,
+    })
+  }
+}
+
+/**
+ * Remaps new-style if-then markers after a whole flow is duplicated, in the
+ * same transaction as the copy. `endStepId` is a forward reference, so this
+ * runs as a post-pass once every step has a copy: each copied block is pinned
+ * to its copied endStep (self-references remap for free). A source marker that
+ * does not resolve to a copied step means the source flow itself was corrupt —
+ * logged and thrown so the whole duplication rolls back.
+ */
+export async function remapEndStepIdsOnDuplicateFlow({
+  trx,
+  originalFlowId,
+  duplicatedFlowId,
+  sourceSteps,
+  oldToNewStepIds,
+}: {
+  trx: Transaction
+  originalFlowId: string
+  duplicatedFlowId: string
+  sourceSteps: Step[]
+  oldToNewStepIds: Record<string, string>
+}): Promise<void> {
+  const { patches, danglingSourceStepIds } = remapIfThenEndStepIdsOnDuplicate(
+    sourceSteps,
+    oldToNewStepIds,
+  )
+
+  if (danglingSourceStepIds.length > 0) {
+    logger.error({
+      event: 'duplicate-flow-dangling-end-step',
+      originalFlowId,
+      duplicatedFlowId,
+      danglingSourceStepIds,
+    })
+    throw new Error('duplicateFlow: dangling endStepId marker in source flow')
+  }
+
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+  }
+}
+
+/**
+ * Remaps new-style if-then markers after a branch is duplicated, in the same
+ * transaction as the copy. The source selection is derived from the DB — the
+ * `newSteps.length` steps ending at `previousStep`, correlated to the copies
+ * ordinally — rather than read from the client-copied config: a copied marker
+ * still references the SOURCE step ids (not the new copies), and older editor
+ * bundles do not even fetch `config.endStepId`, so its value is wrong or
+ * absent. A block whose endStep is within the selection is pinned onto its
+ * copy; a marker pointing outside the selection leaves the copy marker-less (a
+ * graceful legacy copy) and is logged.
+ *
+ * Called after the insertion loop: the copies land after `previousStep`, and
+ * every position shift touches only later positions, so the source rows keep
+ * their positions and can be re-derived here.
+ */
+export async function remapEndStepIdsOnDuplicateBranch({
+  trx,
+  flow,
+  previousStepId,
+  newSteps,
+}: {
+  trx: Transaction
+  flow: Flow
+  previousStepId: string
+  newSteps: Step[]
+}): Promise<void> {
+  const previousStep = await flow
+    .$relatedQuery('steps', trx)
+    .findOne({ id: previousStepId })
+    .throwIfNotFound()
+  const sourceSelection = await flow
+    .$relatedQuery('steps', trx)
+    .where('position', '>=', previousStep.position - newSteps.length + 1)
+    .andWhere('position', '<=', previousStep.position)
+    .orderBy('position', 'asc')
+
+  // Ordinal correlation is only valid when the derived source rows align 1:1
+  // with the copies. A mismatch means the derivation invariant (previousStep is
+  // the selection's last step) did not hold — degrade to marker-less copies
+  // rather than risk a wrong remap.
+  if (sourceSelection.length !== newSteps.length) {
+    logger.warn({
+      event: 'duplicate-branch-stripped-end-step',
+      reason: 'source-selection-size-mismatch',
+      flowId: flow.id,
+      sourceCount: sourceSelection.length,
+      copyCount: newSteps.length,
+    })
+    return
+  }
+
+  const { patches, strippedSourceStepIds } =
+    remapIfThenEndStepIdsOnDuplicateBranch(
+      sourceSelection,
+      newSteps.map((step) => step.id),
+    )
+
+  for (const sourceStepId of strippedSourceStepIds) {
+    logger.info({
+      event: 'duplicate-branch-stripped-end-step',
+      flowId: flow.id,
+      sourceStepId,
+    })
+  }
+
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+  }
 }

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -16,6 +16,16 @@ import { generateMockCollaborator, generateMockUser } from './flow.mock'
 const REFRESH_PIPE_MESSAGE =
   'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.'
 
+// Defaults to false in every beforeEach below so pre-existing tests here stay
+// byte-identical; the opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
 describe('createStep mutation integration tests', async () => {
   let testFlow: Flow
   let existingSteps: Step[]
@@ -39,6 +49,7 @@ describe('createStep mutation integration tests', async () => {
   // Clean up (and seed) database before each test.
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Clear out all rows. Adjust deletion order if using foreign keys.
     await FlowConnections.query().delete()
@@ -674,6 +685,7 @@ describe('createStep endStepId write rules', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
     await FlowConnections.query().delete()
     await Step.query().delete()
     await Flow.query().delete()
@@ -728,6 +740,51 @@ describe('createStep endStepId write rules', () => {
     // ...and the new step lands OUTSIDE the block (right after stepA).
     expect(newStep.position).toBe(stepA.position + 1)
     expect((newStep as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 1: deletes a leftover V1 blank placeholder before pinning a block reached via add-after-block', async () => {
+    // trigger, ifThenA, blankChild — the branch initializer's placeholder,
+    // never configured, still the block's only (and thus last) member.
+    const [, ifThenA, blankChild] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: null, appKey: null, type: 'action' },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: blankChild.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    // The placeholder is gone rather than surviving inside the pinned block...
+    await expect(reload(blankChild.id)).rejects.toThrow()
+    // ...so the block, having no other member left, self-references (an
+    // empty V2 block) instead of absorbing the placeholder as its endStep...
+    const reloadedIfThenA = await reload(ifThenA.id)
+    expect(reloadedIfThenA.config.endStepId).toBe(ifThenA.id)
+    // ...and the new step lands right after it, with positions closed up.
+    // (Reloaded, not the mutation's own return value: the cleanup's position
+    // shift runs after the insert this resolver's response was captured
+    // from, so the response's own `position` is stale by one.)
+    const reloadedNewStep = await reload((newStep as any).id)
+    expect(reloadedNewStep.position).toBe(reloadedIfThenA.position + 1)
+
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+    expect(steps.map((step) => step.position)).toEqual(
+      steps.map((_step, index) => index + 1),
+    )
   })
 
   it('rule 1: adds after an explicit block without changing its marker', async () => {
@@ -1086,5 +1143,215 @@ describe('createStep endStepId write rules', () => {
     expect((newStep as any).config.endStepId).toBeUndefined()
     // Other config keys survive the strip.
     expect((newStep as any).config.stepName).toBe('kept')
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    it('pins unrelated V1 if-then blocks elsewhere in the flow when the flag is on', async () => {
+      // trigger, ifThenA, childA, ifThenB, childB — both if-thens are
+      // legacy. The new step lands right after the trigger, before either
+      // block, so neither rule 1 nor rule 2 has any reason to touch them —
+      // any pin on them comes only from the general opportunistic pass.
+      // (A plain tail-add at the flow's actual end can't play this role: a
+      // trailing, unbounded V1 if-then's derived extent runs to whatever the
+      // current last step is, so appending one there always doubles as a
+      // rule 2 tail-add on that block — see "composes with rule 2" below.)
+      const [trigger, ifThenA, childA, ifThenB, childB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: trigger.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(childA.id)
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(childB.id)
+    })
+
+    it('composes with rule 1: upgrades other blocks in the same pass as the adjacent pin', async () => {
+      // Same fixture as the "rule 1: pins a legacy block when adding after it"
+      // test above, but with the flag on: rule 1 pins ifThenA (adjacent to the
+      // new step) as before, and this pass separately pins the unrelated
+      // ifThenB, which rule 1 never touches.
+      const [, ifThenA, stepA, ifThenB, stepB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: stepA.id },
+            previousBlockId: ifThenA.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // rule 1's own adjacent pin, unchanged.
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+      // the opportunistic pass pins the other, unrelated block too.
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(stepB.id)
+    })
+
+    it('composes with rule 2: extends a still-legacy block on a plain tail-add', async () => {
+      // Same shape as "rule 2: extends an explicit block on a plain
+      // tail-add" above, but ifThenA starts marker-less (V1) instead of
+      // being pre-patched to V2: the opportunistic pin has to land before
+      // rule 2's tail-extend check runs, or rule 2 sees an unmarked block,
+      // skips, and the pin (once it does land) locks onto the pre-insert
+      // extent — stranding the new step outside.
+      const [, ifThenA, stepA, ifThenB, stepB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            // No previousBlockId -> inside-tail add, same as rule 2's own
+            // test above.
+            previousStep: { id: stepA.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // ifThenA extends to include the new step rather than staying pinned
+      // to its pre-insert extent (stepA).
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(
+        (newStep as any).id,
+      )
+      // The unrelated block still gets pinned by the same opportunistic pass.
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(stepB.id)
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      const [, ifThenA, , ifThenB, , trailing] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: trailing.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBeUndefined()
+      expect((await reload(ifThenB.id)).config.endStepId).toBeUndefined()
+    })
+
+    it('deletes a leftover V1 blank placeholder member when a real step is added ahead of it', async () => {
+      // The V1 branch initializer leaves a blank child (no appKey/key) as the
+      // block's only member; inserting a real step between the if-then and
+      // that blank is exactly the reported bug shape.
+      const [, ifThenStep, blankChild] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: null, appKey: null, type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: ifThenStep.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // The blank placeholder is gone, and the block is pinned to the real
+      // step instead of surviving as a second (phantom) member.
+      await expect(reload(blankChild.id)).rejects.toThrow()
+      expect((await reload(ifThenStep.id)).config.endStepId).toBe(
+        (newStep as any).id,
+      )
+
+      // Positions stay contiguous after the delete + compaction.
+      const steps = await testFlow
+        .$relatedQuery('steps')
+        .orderBy('position', 'asc')
+      expect(steps.map((step) => step.position)).toEqual(
+        steps.map((_step, index) => index + 1),
+      )
+    })
+
+    it('keeps a leftover V1 blank placeholder member when the flag is off', async () => {
+      const [, ifThenStep, blankChild] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: null, appKey: null, type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: ifThenStep.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(blankChild.id)).id).toBe(blankChild.id)
+      expect((await reload(ifThenStep.id)).config.endStepId).toBeUndefined()
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -1,7 +1,8 @@
 import { NotFoundError } from 'objection'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import deleteStep from '@/graphql/mutations/delete-step'
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import User from '@/models/user'
@@ -13,6 +14,16 @@ import {
   generateMockStep,
   generateMockUser,
 } from './flow.mock'
+
+// Defaults to false in beforeEach below so pre-existing tests here stay
+// byte-identical; the opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
 
 describe('deleteStep mutation', () => {
   let context: Context
@@ -27,6 +38,7 @@ describe('deleteStep mutation', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Mock the patchLastUpdated method
     vi.spyOn(Flow.prototype, 'patchLastUpdated').mockImplementation(
@@ -281,5 +293,295 @@ describe('deleteStep mutation', () => {
         context,
       ),
     ).rejects.toThrow(NotFoundError)
+  })
+
+  describe('new-style if-then block expansion and marker repair', () => {
+    let blockFlow: Flow
+    let blockFlowInput: { flow: { updatedAt: string } }
+    let loggerErrorSpy: MockInstance
+
+    const addTrigger = (
+      key: 'catchRawWebhook' | 'newSubmission',
+      appKey: 'custom-api' | 'formsg',
+    ) =>
+      generateMockStep(context, key, appKey, 'trigger', blockFlow.id, 1, {}, {})
+
+    const addIfThen = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        blockFlow.id,
+        position,
+        { depth: '0' },
+        config,
+      )
+
+    const addPlain = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        blockFlow.id,
+        position,
+        { email: 'test@example.com' },
+        config,
+      )
+
+    const currentSteps = () =>
+      blockFlow.$relatedQuery('steps').orderBy('position', 'asc')
+
+    beforeEach(async () => {
+      loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+      blockFlow = await owner.$relatedQuery('flows').insertAndFetch({
+        name: 'Block Flow',
+      })
+      blockFlowInput = { flow: { updatedAt: blockFlow.updatedAt } }
+    })
+
+    it('deletes the whole block when only the marked if-then id is sent', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+      await addPlain(3) // s3, a block member
+      const after = await addPlain(5)
+
+      await deleteStep(
+        null,
+        { input: { ids: [ifThen.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([
+        steps[0].id, // trigger
+        after.id,
+      ])
+      expect(steps[1].position).toBe(2)
+    })
+
+    it('is a no-op double-delete when the full range is sent (old-UI branch delete)', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+      const after = await addPlain(5)
+
+      await deleteStep(
+        null,
+        {
+          input: { ids: [ifThen.id, s3.id, s4.id], ...blockFlowInput },
+        },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, after.id])
+    })
+
+    it('never expands a legacy (marker-less) if-then', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const legacy = await addIfThen(2) // no endStepId marker
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+
+      await deleteStep(
+        null,
+        { input: { ids: [legacy.id], ...blockFlowInput } },
+        context,
+      )
+
+      // Only the if-then is deleted; the following steps keep old-client
+      // single-id delete semantics.
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, s3.id, s4.id])
+    })
+
+    it('repoints a surviving block to its new highest member when the endStep is deleted', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+
+      await deleteStep(
+        null,
+        { input: { ids: [s4.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(s3.id)
+    })
+
+    it('empties a block to self-reference when its only member is deleted', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: s3.id })
+
+      await deleteStep(
+        null,
+        { input: { ids: [s3.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(ifThen.id)
+    })
+
+    it('does not expand a dangling marker and logs it', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: 'does-not-exist' })
+
+      await deleteStep(
+        null,
+        { input: { ids: [ifThen.id], ...blockFlowInput } },
+        context,
+      )
+
+      // Only the if-then is deleted; its member survives.
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, s3.id])
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'if-then-dangling-end-step',
+          mutation: 'deleteStep',
+          ifThenStepId: ifThen.id,
+        }),
+      )
+    })
+
+    it('preserves an intact block marker when the trigger (MRF) branch is deleted', async () => {
+      const trigger = await addTrigger('newSubmission', 'formsg')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: s3.id })
+      // An MRF submission step outside the block — removed by removeMrfSteps.
+      await generateMockStep(
+        context,
+        'mrfSubmission',
+        'formsg',
+        'action',
+        blockFlow.id,
+        4,
+        {},
+        {},
+      )
+
+      await deleteStep(
+        null,
+        { input: { ids: [trigger.id], ...blockFlowInput } },
+        context,
+      )
+
+      // removeMrfSteps drops the mrfSubmission step; the block's marker is
+      // repaired over the survivor set and stays intact (endStep survived).
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(s3.id)
+      expect(steps.some((s) => s.key === 'mrfSubmission')).toBe(false)
+    })
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    let blockFlow: Flow
+    let blockFlowInput: { flow: { updatedAt: string } }
+
+    const addTrigger = (
+      key: 'catchRawWebhook' | 'newSubmission',
+      appKey: 'custom-api' | 'formsg',
+    ) =>
+      generateMockStep(context, key, appKey, 'trigger', blockFlow.id, 1, {}, {})
+
+    const addIfThen = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        blockFlow.id,
+        position,
+        { depth: '0' },
+        config,
+      )
+
+    const addPlain = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        blockFlow.id,
+        position,
+        { email: 'test@example.com' },
+        config,
+      )
+
+    const currentSteps = () =>
+      blockFlow.$relatedQuery('steps').orderBy('position', 'asc')
+
+    beforeEach(async () => {
+      blockFlow = await owner.$relatedQuery('flows').insertAndFetch({
+        name: 'Upgrade Flow',
+      })
+      blockFlowInput = { flow: { updatedAt: blockFlow.updatedAt } }
+    })
+
+    it('pins other legacy if-then blocks when deleting an unrelated step, and composes with repair', async () => {
+      // trigger, ifThenA, childA, ifThenB, childB, unrelated — both if-thens
+      // are legacy; `unrelated` (the step being deleted) is the last step in
+      // the flow, so it is derived as part of ifThenB's V1 extent right up
+      // until the delete removes it — the same reported-bug shape, but here
+      // the subsequent repair (already unmodified) re-points ifThenB back to
+      // childB once `unrelated` is gone.
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const ifThenA = await addIfThen(2)
+      const childA = await addPlain(3)
+      const ifThenB = await addIfThen(4)
+      const childB = await addPlain(5)
+      const unrelated = await addPlain(6)
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await deleteStep(
+        null,
+        { input: { ids: [unrelated.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.find((s) => s.id === ifThenA.id)?.config.endStepId).toBe(
+        childA.id,
+      )
+      expect(steps.find((s) => s.id === ifThenB.id)?.config.endStepId).toBe(
+        childB.id,
+      )
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const ifThenA = await addIfThen(2)
+      await addPlain(3)
+      const ifThenB = await addIfThen(4)
+      await addPlain(5)
+      const unrelated = await addPlain(6)
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await deleteStep(
+        null,
+        { input: { ids: [unrelated.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(
+        steps.find((s) => s.id === ifThenA.id)?.config.endStepId,
+      ).toBeUndefined()
+      expect(
+        steps.find((s) => s.id === ifThenB.id)?.config.endStepId,
+      ).toBeUndefined()
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import duplicateBranch from '@/graphql/mutations/duplicate-branch'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+// Real-DB integration tests for the DB-derived endStepId remap when a branch
+// (contiguous selection) is duplicated. Markers are read from the source rows,
+// never from the client-sent config.
+describe('duplicateBranch endStepId remap', () => {
+  let owner: User
+  let context: Context
+  let testFlow: Flow
+  let loggerInfoSpy: MockInstance
+
+  const flowInput = () => ({
+    id: testFlow.id,
+    updatedAt: new Date(testFlow.updatedAt).getTime().toString(),
+  })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Branch Flow',
+      updatedBy: owner.id,
+    })
+
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => null)
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('remaps an intra-selection marker DB-derived, ignoring the client-sent value', async () => {
+    // Block [ifThen, member], endStep = member; a trailing step follows.
+    const [, ifThen, member] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: member.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: member.id },
+          steps: [
+            {
+              key: 'ifThen',
+              appKey: 'toolbox',
+              parameters: {},
+              // A bogus client-sent marker that must be ignored.
+              config: { endStepId: 'client-bogus' },
+            },
+            {
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              parameters: {},
+            },
+          ],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen, copiedMember] = result.steps
+    const reloaded = await reload(copiedIfThen.id)
+    expect(reloaded.config.endStepId).toBe(copiedMember.id)
+    expect(reloaded.config.endStepId).not.toBe('client-bogus')
+    expect(reloaded.config.endStepId).not.toBe(member.id)
+  })
+
+  it('remaps a self-referencing (empty) block to its own copy', async () => {
+    const [, ifThen] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThen.id },
+          steps: [{ key: 'ifThen', appKey: 'toolbox', parameters: {} }],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen] = result.steps
+    expect((await reload(copiedIfThen.id)).config.endStepId).toBe(
+      copiedIfThen.id,
+    )
+  })
+
+  it('leaves the copy marker-less and logs when the source marker points outside the selection', async () => {
+    // Block spans [ifThen, member, tail]; duplicating only [ifThen, member]
+    // leaves the endStep (tail) outside the selection.
+    const [, ifThen, member, tail] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: tail.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: member.id },
+          steps: [
+            { key: 'ifThen', appKey: 'toolbox', parameters: {} },
+            {
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              parameters: {},
+            },
+          ],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen] = result.steps
+    expect((await reload(copiedIfThen.id)).config.endStepId).toBeUndefined()
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'duplicate-branch-stripped-end-step',
+        sourceStepId: ifThen.id,
+      }),
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import duplicateFlow from '@/graphql/mutations/duplicate-flow'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+// Real-DB integration tests for the endStepId forward-reference remap when a
+// whole flow is duplicated.
+describe('duplicateFlow endStepId remap', () => {
+  let owner: User
+  let context: Context
+  let loggerErrorSpy: MockInstance
+
+  async function seedFlow(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+    }>,
+  ): Promise<{ flow: Flow; steps: Step[] }> {
+    const flow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Source Flow',
+      updatedBy: owner.id,
+    })
+    const steps = (await flow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: {},
+        config: spec.config ?? {},
+      })),
+    )) as unknown as Step[]
+    return { flow, steps }
+  }
+
+  const copiedSteps = async (): Promise<Step[]> => {
+    const copy = await Flow.query()
+      .where('name', '[COPY] Source Flow')
+      .first()
+      .throwIfNotFound()
+    return copy.$relatedQuery('steps').orderBy('position', 'asc')
+  }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+  })
+
+  it('remaps a block marker to the copied endStep id', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen, s3] = steps
+    await ifThen.$query().patch({ config: { endStepId: s3.id } })
+
+    await duplicateFlow(null, { input: { id: flow.id } }, context)
+
+    const copies = await copiedSteps()
+    const copiedIfThen = copies[1]
+    const copiedS3 = copies[2]
+    // The copy points at the copied endStep, not the original.
+    expect(copiedIfThen.config.endStepId).toBe(copiedS3.id)
+    expect(copiedIfThen.config.endStepId).not.toBe(s3.id)
+  })
+
+  it('remaps a self-referencing (empty) block to the new self id', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen] = steps
+    await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
+
+    await duplicateFlow(null, { input: { id: flow.id } }, context)
+
+    const copies = await copiedSteps()
+    const copiedIfThen = copies[1]
+    expect(copiedIfThen.config.endStepId).toBe(copiedIfThen.id)
+    expect(copiedIfThen.config.endStepId).not.toBe(ifThen.id)
+  })
+
+  it('rolls back the whole duplication when a source marker is dangling', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen] = steps
+    await ifThen.$query().patch({ config: { endStepId: 'does-not-exist' } })
+
+    await expect(
+      duplicateFlow(null, { input: { id: flow.id } }, context),
+    ).rejects.toThrow(/dangling endStepId/)
+
+    // Rollback: no copied flow persisted, original duplicateCount untouched.
+    const copy = await Flow.query().where('name', '[COPY] Source Flow').first()
+    expect(copy).toBeUndefined()
+    const original = await Flow.query().findById(flow.id)
+    expect(original.config?.duplicateCount).toBeUndefined()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'duplicate-flow-dangling-end-step',
+        danglingSourceStepIds: [ifThen.id],
+      }),
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -194,6 +194,63 @@ describe('updateFlowStatus', () => {
     ).resolves.not.toThrow()
   })
 
+  it('throws when publishing a flow with an empty (self-referencing) if-then block', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 'block' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow('If-then block has no steps')
+  })
+
+  it('throws when publishing a flow with a dangling if-then marker', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 'ghost' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow('If-then block is misconfigured')
+  })
+
+  it('publishes a flow with a valid non-empty if-then block', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 's3' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).resolves.not.toThrow()
+  })
+
   it('activates the flow and enqueues a job for non-webhook triggers', async () => {
     // Starting state where the flow is inactive and input sets it to active.
     fakeFlow.active = false

--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -1,8 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStepPositions from '@/graphql/mutations/update-step-positions'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+// Defaults to false in beforeEach below so pre-existing tests here stay
+// byte-identical; the opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
 
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
 
@@ -65,6 +79,7 @@ describe('updateStepPositions mutation', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Set up flow patch and fetch spy first
     flowPatchAndFetchSpy = vi.fn().mockReturnValue({
@@ -82,6 +97,11 @@ describe('updateStepPositions mutation', () => {
       active: false,
       $query: vi.fn().mockReturnValue({
         patchAndFetch: flowPatchAndFetchSpy,
+      }),
+      // Used by upgradeIfThenV1BlocksIfEnabled's re-fetch; MOCK_STEPS has no
+      // if-then steps, so it's a no-op regardless of what this returns.
+      $relatedQuery: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockResolvedValue(MOCK_STEPS),
       }),
       assertNotUpdatedSince: vi.fn(),
     }
@@ -106,6 +126,8 @@ describe('updateStepPositions mutation', () => {
     })
     vi.spyOn(Step, 'query').mockReturnValue({
       findById: stepFindByIdSpy,
+      // Subquery builder used to scope the step load to the flow.
+      select: vi.fn().mockReturnValue({ whereIn: vi.fn() }),
     } as any)
 
     // Fake the chained query methods on context.currentUser.$relatedQuery('steps')
@@ -322,5 +344,220 @@ describe('updateStepPositions mutation', () => {
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
       'Failed to update: steps were not found',
     )
+  })
+})
+
+// Real-DB integration tests for reorder marker repair. Kept separate from the
+// mock-based suite above (which stubs Step.query/transaction) so the repair
+// runs against real flow steps.
+describe('updateStepPositions endStepId repair', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let loggerInfoSpy: MockInstance
+
+  const flowInput = () => ({
+    updatedAt: new Date(testFlow.updatedAt).getTime().toString(),
+  })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  const wasRepaired = () =>
+    loggerInfoSpy.mock.calls.some(
+      ([arg]) =>
+        arg?.event === 'end-step-repaired' &&
+        arg?.mutation === 'updateStepPositions',
+    )
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Reorder Flow',
+      updatedBy: owner.id,
+    })
+
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => null)
+  })
+
+  it('moves the endStep marker to the new highest member after an interior reorder', async () => {
+    const [, ifThen, s3, s4, s5] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: s5.id } })
+
+    // Reorder the block interior [s3, s4, s5] -> [s5, s3, s4].
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: s5.id, position: 3, type: 'action' as const },
+            { id: s3.id, position: 4, type: 'action' as const },
+            { id: s4.id, position: 5, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(s4.id)
+    expect(wasRepaired()).toBe(true)
+  })
+
+  it('leaves the marker untouched when the reorder does not touch the block', async () => {
+    const [, ifThen, s3, a4, a5] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: s3.id } })
+
+    // Reorder two later steps that sit outside the block.
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: a5.id, position: 4, type: 'action' as const },
+            { id: a4.id, position: 5, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(s3.id)
+    expect(wasRepaired()).toBe(false)
+  })
+
+  it('reorders a legacy (marker-less) flow without writing any marker', async () => {
+    const [, legacy, s3, s4] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: s4.id, position: 3, type: 'action' as const },
+            { id: s3.id, position: 4, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(legacy.id)).config.endStepId).toBeUndefined()
+    expect(wasRepaired()).toBe(false)
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    // trigger, ifThenA, childA, ifThenB, childB, trailing — both if-thens are
+    // legacy. Dragging ifThenB's block to before ifThenA's is the exact
+    // reported-bug shape: without pinning ifThenA's extent BEFORE the drag,
+    // re-deriving it afterwards (once it's the last if-then) would silently
+    // balloon to include `trailing`.
+    async function seedTwoBlockFlow() {
+      return seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+    }
+
+    const swapBlocksInput = (
+      ifThenB: Step,
+      childB: Step,
+      ifThenA: Step,
+      childA: Step,
+    ) => ({
+      stepPositions: [
+        { id: ifThenB.id, position: 2, type: 'action' as const },
+        { id: childB.id, position: 3, type: 'action' as const },
+        { id: ifThenA.id, position: 4, type: 'action' as const },
+        { id: childA.id, position: 5, type: 'action' as const },
+      ],
+      flow: flowInput(),
+    })
+
+    it('pins both legacy blocks to their pre-reorder extents so the drag does not absorb the trailing step', async () => {
+      const [, ifThenA, childA, ifThenB, childB, trailing] =
+        await seedTwoBlockFlow()
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await updateStepPositions(
+        null,
+        { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
+        context,
+      )
+
+      // ifThenA's block stays pinned to just childA — `trailing` is not
+      // absorbed into it, even though ifThenA is now the last if-then.
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(childA.id)
+      expect((await reload(ifThenB.id)).config.endStepId).toBeDefined()
+      expect((await reload(trailing.id)).config.endStepId).toBeUndefined()
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      const [, ifThenA, childA, ifThenB, childB] = await seedTwoBlockFlow()
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await updateStepPositions(
+        null,
+        { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBeUndefined()
+      expect((await reload(ifThenB.id)).config.endStepId).toBeUndefined()
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,8 +2,11 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
-import { BLOCK_END_STEP_ID } from '@/apps/toolbox/common/constants'
-import { validateEndStepOnCreateStep } from '@/apps/toolbox/common/validate-end-step'
+import {
+  sanitizeServerSideConfig,
+  upgradeIfThenV1BlocksIfEnabled,
+  validateEndStepOnCreateStep,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
@@ -14,21 +17,6 @@ import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
-
-// Config keys the server owns; a client must never set them directly on create.
-// endStepId is maintained entirely by the endStep write rules (and
-// duplicateBranch's DB-derived remap).
-const SERVER_OWNED_CONFIG_KEYS = [BLOCK_END_STEP_ID] as const
-
-function sanitizeServerSideConfig(
-  config: IStepConfig | null | undefined,
-): IStepConfig {
-  const sanitized = { ...(config ?? {}) }
-  for (const key of SERVER_OWNED_CONFIG_KEYS) {
-    delete sanitized[key]
-  }
-  return sanitized
-}
 
 const createStep: MutationResolvers['createStep'] = async (
   _parent,
@@ -128,6 +116,17 @@ const createStep: MutationResolvers['createStep'] = async (
       config: newStepConfig,
       version,
     })
+
+    // Opportunistically pin any other legacy if-then block in the flow to its
+    // current extent, if the if-then-then flag is on for the pipe owner. Runs
+    // BEFORE validateEndStepOnCreateStep: its rule 2 (tail-extend) only
+    // recognises a block as extendable once it's explicit V2, so pinning
+    // first is what lets a still-legacy block being tail-added to see its own
+    // fresh pin and extend, instead of staying unmarked and getting skipped.
+    const preInsertSteps = (
+      await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+    ).filter((flowStep) => flowStep.id !== step.id)
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, preInsertSteps)
 
     // Maintain if-then endStep markers for the new step, in-transaction. Any
     // violation throws and rolls back the whole creation.

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -1,7 +1,13 @@
 import { raw } from 'objection'
 
 import { removeMrfSteps } from '@/apps/formsg/triggers/new-submission/remove-mrf-steps'
+import { expandIfThenBlockDeletions } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import {
+  repairEndStepsOnDeleteStep,
+  upgradeIfThenV1BlocksIfEnabled,
+} from '@/apps/toolbox/common/validate-end-step'
 import { hasStepReference } from '@/helpers/check-step-parameters'
+import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -29,30 +35,80 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
   return await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
     // Include SELECTs in transaction too just in case there's concurrent modification.
-    const steps = await context.currentUser
+    // Load the whole flow's steps in one access-checked query (scoped to the
+    // flow that input.ids belong to), then narrow to the requested steps. The
+    // full set drives the integrity logic — expanding a marked if-then to its
+    // block range and repairing surviving blocks after the delete — while the
+    // requested subset feeds the existing deletion code.
+    let stepsBeforeDelete = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', input.ids)
+      .whereIn(
+        'steps.flow_id',
+        Step.query(trx).select('flow_id').whereIn('id', input.ids),
+      )
       .orderBy('steps.position', 'asc')
       .throwIfNotFound({
         message: 'Step not found. Refresh the page and try again.',
       })
 
-    const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
+    const steps = stepsBeforeDelete.filter((step) =>
+      input.ids.includes(step.id),
+    )
 
+    // Confirm the request is single-pipe before deriving the flow, so
+    // `steps[0].flow` is unambiguous (stepsBeforeDelete may span pipes if the
+    // request mixed them).
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
     }
+
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
+
+    // Opportunistically pin any other legacy if-then block in the flow to its
+    // current extent, if the if-then-then flag is on for the pipe owner.
+    // Runs before the delete so derivation reflects the true pre-delete
+    // state; steps about to be deleted are excluded from consideration.
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      flow,
+      stepsBeforeDelete,
+      new Set(input.ids),
+    )
+    // Re-read so any block just pinned above is reflected as V2 below —
+    // otherwise the repair pass wouldn't see its own freshly-written marker.
+    stepsBeforeDelete = await flow
+      .$relatedQuery('steps', trx)
+      .orderBy('position', 'asc')
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      stepsBeforeDelete,
+      input.ids,
+    )
+    for (const ifThenStepId of danglingIfThenIds) {
+      logger.error({
+        event: 'if-then-dangling-end-step',
+        mutation: 'deleteStep',
+        ifThenStepId,
+        flowId: flow.id,
+      })
+    }
+    const stepsToDelete = stepsBeforeDelete.filter((step) =>
+      expandedIds.has(step.id),
+    )
 
     //
     // ** IMPORTANT NOTE **
     // We only support deleting single trigger steps or contiguous action steps.
     //
-    if (steps.length === 1 && steps[0].type === 'trigger') {
-      const deletedStepId = steps[0].id
+    if (stepsToDelete.length === 1 && stepsToDelete[0].type === 'trigger') {
+      const deletedStepId = stepsToDelete[0].id
 
-      if (steps[0].appKey === 'formsg' && steps[0].key === 'newSubmission') {
+      if (
+        stepsToDelete[0].appKey === 'formsg' &&
+        stepsToDelete[0].key === 'newSubmission'
+      ) {
         await removeMrfSteps(flow.id, trx)
       }
 
@@ -82,16 +138,17 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
     } else {
       if (
-        !steps.every(
+        !stepsToDelete.every(
           (step, index) =>
-            (index === 0 || step.position === steps[index - 1].position + 1) &&
+            (index === 0 ||
+              step.position === stepsToDelete[index - 1].position + 1) &&
             step.type === 'action',
         )
       ) {
         throw new Error('Must delete contiguous action steps!')
       }
 
-      const stepIds = steps.map((step) => step.id)
+      const stepIds = stepsToDelete.map((step) => step.id)
 
       // check for steps whose parameters reference the deletedStepId
       const allSteps = await flow
@@ -115,9 +172,16 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
 
       await flow
         .$relatedQuery('steps', trx)
-        .where('position', '>', steps[steps.length - 1].position)
-        .patch({ position: raw(`position - ${steps.length}`) })
+        .where(
+          'position',
+          '>',
+          stepsToDelete[stepsToDelete.length - 1].position,
+        )
+        .patch({ position: raw(`position - ${stepsToDelete.length}`) })
     }
+
+    // Repair any surviving new-style if-then block whose endStep was deleted.
+    await repairEndStepsOnDeleteStep({ trx, flow, stepsBeforeDelete })
 
     await flow.patchLastUpdated({
       flowId: flow.id,

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -2,6 +2,10 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import {
+  remapEndStepIdsOnDuplicateBranch,
+  sanitizeServerSideConfig,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import Step from '@/models/step'
@@ -74,6 +78,11 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
         })
         .where('position', '>=', previousStep.position + 1)
 
+      // A copied endStepId still points at the SOURCE step, not this new copy,
+      // so strip it and let the DB-derived post-pass remap set the correct
+      // copied id (leaving it marker-less if the endStep wasn't in the selection).
+      const sanitizedConfig = sanitizeServerSideConfig(config as IStepConfig)
+
       const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
         key,
         appKey,
@@ -81,7 +90,7 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
         position: previousStep.position + 1,
         parameters,
         connectionId: connection?.id,
-        config: config as IStepConfig,
+        config: sanitizedConfig,
         version: getStepVersion(appKey, key),
       })
 
@@ -93,6 +102,15 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       // as the connection would have already been added when the step
       // was created in the original branch
     }
+
+    // Remap intra-selection endStepId markers onto the copies (DB-derived);
+    // markers pointing outside the selection leave the copy marker-less.
+    await remapEndStepIdsOnDuplicateBranch({
+      trx,
+      flow,
+      previousStepId: input.previousStep.id,
+      newSteps,
+    })
 
     const updatedFlow = await flow.patchLastUpdated({
       flowId: flow.id,

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 
+import { remapEndStepIdsOnDuplicateFlow } from '@/apps/toolbox/common/validate-end-step'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
 import { updateStepVariables } from '@/helpers/update-duplicated-steps'
@@ -88,6 +89,15 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
         })
       oldToNewStepIdsMap[oldStep.id] = duplicatedStep.id // update map after duplicating step
     }
+
+    // endStepId is a forward reference, so remap it once every step has a copy.
+    await remapEndStepIdsOnDuplicateFlow({
+      trx,
+      originalFlowId: oldFlowId,
+      duplicatedFlowId: duplicatedFlow.id,
+      sourceSteps: flow.steps,
+      oldToNewStepIds: oldToNewStepIdsMap,
+    })
 
     logger.info('Duplicate flow details', {
       event: 'duplicate-flow-request',

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -2,6 +2,7 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
+import { validateFlowBlocks } from '@/apps/toolbox/common/validate-end-step'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
@@ -56,6 +57,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
 
   if (params.input.active) {
     validateFlowSteps(flow.steps)
+    validateFlowBlocks(flow.steps, flow.id)
   }
 
   await flow.$query().patch({

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -2,6 +2,10 @@ import { IStep } from '@plumber/types'
 
 import { PartialModelObject, raw } from 'objection'
 
+import {
+  repairEndStepsOnReorder,
+  upgradeIfThenV1BlocksIfEnabled,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
@@ -39,23 +43,44 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
   const updatedPositions = await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
-    const steps = await context.currentUser
+    // Query all steps of the impacted flow (scoped via the reordered ids' flow)
+    // so block end steps can be repaired after the reorder; the steps named in
+    // the request params drive the position update itself.
+    let allSteps = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', stepIds)
+      .whereIn(
+        'steps.flow_id',
+        Step.query(trx).select('flow_id').whereIn('id', stepIds),
+      )
       .orderBy('steps.position', 'asc')
       .throwIfNotFound()
 
-    if (steps[0].flow.active) {
+    const stepsFromParams = allSteps.filter((step) => stepIds.includes(step.id))
+
+    // Confirm the request is single-pipe before deriving the flow, so
+    // `stepsFromParams[0].flow` is unambiguous (allSteps may span pipes if the
+    // request mixed them).
+    if (
+      !stepsFromParams.every(
+        (step) => step.flowId === stepsFromParams[0].flowId,
+      )
+    ) {
+      throw new BadUserInputError(
+        'Failed to update: steps must be from the same pipe!',
+      )
+    }
+
+    const flow = stepsFromParams[0].flow
+    if (flow.active) {
       throw new BadUserInputError(
         'Pipe is active. Cannot update step in active pipe!',
       )
     }
 
-    const flow = steps[0].flow
     flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
-    const foundStepIds = steps.map((step) => step.id)
+    const foundStepIds = stepsFromParams.map((step) => step.id)
     const missingStepIds = stepIds.filter(
       (id: string) => !foundStepIds.includes(id),
     )
@@ -67,8 +92,8 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     // since we are only updating actions based on their groups
     // e.g., non grouped steps, or actions within an if-then branch
     // validate that the step positions are not out of bounds
-    const minPosition = steps[0].position
-    const maxPosition = steps[steps.length - 1].position
+    const minPosition = stepsFromParams[0].position
+    const maxPosition = stepsFromParams[stepsFromParams.length - 1].position
     if (
       stepPositions.some((obj) => obj.position > maxPosition) ||
       stepPositions.some((obj) => obj.position < minPosition)
@@ -77,6 +102,15 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
         'Failed to update: step positions are out of bounds.',
       )
     }
+
+    // Opportunistically pin any legacy if-then block in the flow to its
+    // current extent, if the if-then-then flag is on for the pipe owner, so
+    // its extent gets locked in before this reorder can silently change it.
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, allSteps)
+    // Re-read (positions are still pre-patch) so any block just pinned above
+    // is reflected as V2 below — otherwise the repair pass wouldn't see its
+    // own freshly-written marker.
+    allSteps = await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
 
     // Patch each step individually with its new position
     for (const stepPosition of stepPositions) {
@@ -92,6 +126,15 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       }
       await Step.query(trx).findById(stepPosition.id).patch(patchData)
     }
+
+    // Repair any new-style if-then block whose endStep is no longer its
+    // highest-positioned member after the reorder.
+    await repairEndStepsOnReorder({
+      trx,
+      flow,
+      preSteps: allSteps,
+      newPositions: stepPositions,
+    })
 
     // Update the flow's lastUpdatedAt timestamp
     const updatedFlow = await flow


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end. 
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates 

# Tests

See top of stack. 

