### PR TITLE
PLU-743: [IF-THEN-THEN-V2-11] Support rendering If-Then V2 blocks in frontend

### DIFF
--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -1,0 +1,517 @@
+import type { IStep } from '@plumber/types'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildStepsList,
+  deriveIfThenV1EndStep,
+  isStepInsideForEachBody,
+  isStepInsideIfThenBlock,
+} from '../steps-utils'
+
+//
+// Fixtures. buildStepsList and its companions operate on the MRF-filtered
+// action-step list (the trigger already removed), ordered by position, so these
+// fixtures never include a trigger.
+//
+
+const plain = (id: string): IStep =>
+  ({ id, appKey: 'postman', key: 'sendTransactionalEmail' } as IStep)
+
+const ifThen = (id: string, extra: Partial<IStep> = {}): IStep =>
+  ({
+    id,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    parameters: { depth: '0' },
+    ...extra,
+  } as IStep)
+
+const markedIfThen = (id: string, endStepId: string): IStep =>
+  ifThen(id, { config: { endStepId } })
+
+// A marker-less if-then exactly as GraphQL delivers one: a response carries
+// every field the query selected, so the key is present and null. IStepConfig
+// describes the backend's own DB shape, where the key is simply absent, hence
+// the cast.
+const nullMarkerIfThen = (id: string): IStep =>
+  ifThen(id, { config: { endStepId: null } as unknown as IStep['config'] })
+
+const forEach = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'forEach' } as IStep)
+
+const mrfSubmission = (id: string): IStep =>
+  ({ id, appKey: 'formsg', key: 'mrfSubmission' } as IStep)
+
+// The set of grouping actions (`groupsLaterSteps`) is exactly if-then and
+// for-each today.
+const GROUPING_ACTIONS = new Set(['toolbox-ifThen', 'toolbox-forEach'])
+
+describe('deriveIfThenV1EndStep', () => {
+  it('derives a 2-branch block up to the step before the next if-then', () => {
+    const ifThenA = ifThen('ifThenA')
+    const ifThenB = ifThen('ifThenB')
+    const steps = [ifThenA, plain('stepA'), ifThenB, plain('stepB')]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+  })
+
+  it('derives extents for each branch of a 3-branch block', () => {
+    const ifThenA = ifThen('ifThenA')
+    const ifThenB = ifThen('ifThenB')
+    const ifThenC = ifThen('ifThenC')
+    const steps = [
+      ifThenA,
+      plain('stepA'),
+      ifThenB,
+      plain('stepB'),
+      ifThenC,
+      plain('stepC'),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+    expect(deriveIfThenV1EndStep(steps, ifThenC).id).toBe('stepC')
+  })
+
+  it('runs to the end of the list when there is no following if-then', () => {
+    const ifThenA = ifThen('ifThenA')
+    const steps = [ifThenA, plain('stepA'), plain('stepB'), plain('stepC')]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepC')
+  })
+
+  it('returns the if-then itself (self-ref) for an empty block abutting the next if-then', () => {
+    const ifThenA = ifThen('ifThenA')
+    const steps = [ifThenA, ifThen('ifThenB'), plain('stepB')]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
+  })
+
+  it('treats a following if-then as a boundary across an MRF submission step', () => {
+    const ifThenA = ifThen('ifThenA')
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'ifThenA' } },
+    })
+    const steps = [
+      ifThenA,
+      plain('stepA'),
+      mrfSubmission('mrf'),
+      rejectIfThen,
+      plain('stepAfter'),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mrf')
+  })
+
+  it('skips a deeper (nested) if-then when scanning for the boundary', () => {
+    const ifThenA = ifThen('ifThenA')
+    const nested = ifThen('nested', { parameters: { depth: '1' } })
+    const ifThenB = ifThen('ifThenB')
+    const steps = [
+      ifThenA,
+      plain('stepA'),
+      nested,
+      plain('stepB'),
+      ifThenB,
+      plain('stepC'),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepB')
+  })
+})
+
+describe('buildStepsList', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns plain steps as single-step items', () => {
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+
+    expect(buildStepsList([s1, s2], GROUPING_ACTIONS)).toEqual([
+      { type: 'step', step: s1 },
+      { type: 'step', step: s2 },
+    ])
+  })
+
+  it('builds an explicit if-then V2 block over a run of plain steps', () => {
+    const block = markedIfThen('block', 's3')
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+    const s4 = plain('s4')
+
+    expect(buildStepsList([block, s2, s3, s4], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: block,
+        children: [s2, s3],
+        endStepId: 's3',
+        endStep: s3,
+        isExplicit: true,
+        isDangling: false,
+      },
+      { type: 'step', step: s4 },
+    ])
+  })
+
+  it('treats a null marker as marker-less: GraphQL always sends the key', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    // A null marker means if-then V1, not a corrupt if-then V2, so no
+    // warning is expected.
+    const ifThenA = nullMarkerIfThen('ifThenA')
+    const s2 = plain('s2')
+    const ifThenB = nullMarkerIfThen('ifThenB')
+    const s4 = plain('s4')
+
+    expect(
+      buildStepsList([ifThenA, s2, ifThenB, s4], GROUPING_ACTIONS),
+    ).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenA,
+        children: [s2],
+        endStepId: 's2',
+        endStep: s2,
+        isExplicit: false,
+        isDangling: false,
+      },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenB,
+        children: [s4],
+        endStepId: 's4',
+        endStep: s4,
+        isExplicit: false,
+        isDangling: false,
+      },
+    ])
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('builds an empty explicit block (self-referencing marker)', () => {
+    const block = markedIfThen('block', 'block')
+    const s2 = plain('s2')
+
+    expect(buildStepsList([block, s2], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: block,
+        children: [],
+        endStepId: 'block',
+        endStep: block,
+        isExplicit: true,
+        isDangling: false,
+      },
+      { type: 'step', step: s2 },
+    ])
+  })
+
+  it('flags a marker pointing at a missing step as dangling and falls back to the derived extent', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const block = markedIfThen('block', 'ghost')
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+
+    // No following if-then, so the derived extent runs to the end of the list.
+    expect(buildStepsList([block, s2, s3], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: block,
+        children: [s2, s3],
+        endStepId: 's3',
+        endStep: s3,
+        isExplicit: false,
+        isDangling: true,
+      },
+    ])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('flags a marker pointing before the if-then as dangling and falls back to the derived extent', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const s1 = plain('s1')
+    const block = markedIfThen('block', 's1')
+
+    // No following if-then, so the derived extent self-references as an
+    // empty block.
+    expect(buildStepsList([s1, block], GROUPING_ACTIONS)).toEqual([
+      { type: 'step', step: s1 },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: block,
+        children: [],
+        endStepId: 'block',
+        endStep: block,
+        isExplicit: false,
+        isDangling: true,
+      },
+    ])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('builds if-then V1 (marker-less) blocks with parity to the derived extent', () => {
+    const ifThenA = ifThen('ifThenA')
+    const sA = plain('sA')
+    const ifThenB = ifThen('ifThenB')
+    const sB = plain('sB')
+
+    expect(
+      buildStepsList([ifThenA, sA, ifThenB, sB], GROUPING_ACTIONS),
+    ).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenA,
+        children: [sA],
+        endStepId: 'sA',
+        endStep: sA,
+        isExplicit: false,
+        isDangling: false,
+      },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenB,
+        children: [sB],
+        endStepId: 'sB',
+        endStep: sB,
+        isExplicit: false,
+        isDangling: false,
+      },
+    ])
+  })
+
+  it('builds an empty if-then V1 block abutting the next if-then', () => {
+    const ifThenA = ifThen('ifThenA')
+    const ifThenB = ifThen('ifThenB')
+    const sB = plain('sB')
+
+    const result = buildStepsList([ifThenA, ifThenB, sB], GROUPING_ACTIONS)
+
+    expect(result).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenA,
+        children: [],
+        endStepId: 'ifThenA',
+        endStep: ifThenA,
+        isExplicit: false,
+        isDangling: false,
+      },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: ifThenB,
+        children: [sB],
+        endStepId: 'sB',
+        endStep: sB,
+        isExplicit: false,
+        isDangling: false,
+      },
+    ])
+  })
+
+  it('interleaves plain steps with if-then V1 and V2 blocks', () => {
+    const p0 = plain('p0')
+    const v1If = ifThen('v1If')
+    const l1 = plain('l1')
+    const v2If = markedIfThen('v2If', 'n2')
+    const n1 = plain('n1')
+    const n2 = plain('n2')
+    const pAfter = plain('pAfter')
+
+    expect(
+      buildStepsList([p0, v1If, l1, v2If, n1, n2, pAfter], GROUPING_ACTIONS),
+    ).toEqual([
+      { type: 'step', step: p0 },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: v1If,
+        children: [l1],
+        endStepId: 'l1',
+        endStep: l1,
+        isExplicit: false,
+        isDangling: false,
+      },
+      {
+        type: 'ifThenBlock',
+        ifThenStep: v2If,
+        children: [n1, n2],
+        endStepId: 'n2',
+        endStep: n2,
+        isExplicit: true,
+        isDangling: false,
+      },
+      { type: 'step', step: pAfter },
+    ])
+  })
+
+  it('honours the marker on an if-then inside an MRF rejection branch', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    // A block inside a rejection branch is an ordinary if-then V2 block,
+    // with no special-casing.
+    const approvalIf = ifThen('approvalIf', {
+      config: {
+        approval: { branch: 'reject', stepId: 'someApprovalStep' },
+        endStepId: 's2',
+      },
+    })
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+
+    expect(buildStepsList([approvalIf, s2, s3], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: approvalIf,
+        children: [s2],
+        endStepId: 's2',
+        endStep: s2,
+        isExplicit: true,
+        isDangling: false,
+      },
+      { type: 'step', step: s3 },
+    ])
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('still derives the extent of a marker-less if-then in a rejection branch', () => {
+    // Existing if-then V1 blocks inside rejection branches keep working.
+    const approvalIf = ifThen('approvalIf', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+
+    expect(buildStepsList([approvalIf, s2, s3], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'ifThenBlock',
+        ifThenStep: approvalIf,
+        children: [s2, s3],
+        endStepId: 's3',
+        endStep: s3,
+        isExplicit: false,
+        isDangling: false,
+      },
+    ])
+  })
+
+  it('lets a for-each block swallow all later steps', () => {
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+
+    expect(buildStepsList([forEachStep, s1, s2], GROUPING_ACTIONS)).toEqual([
+      {
+        type: 'forEachBlock',
+        forEachStep,
+        children: [
+          { type: 'step', step: s1 },
+          { type: 'step', step: s2 },
+        ],
+      },
+    ])
+  })
+
+  it('recurses into a for-each body so if-then blocks render inside it', () => {
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const v2If = markedIfThen('v2If', 'n2')
+    const n1 = plain('n1')
+    const n2 = plain('n2')
+
+    expect(
+      buildStepsList([forEachStep, s1, v2If, n1, n2], GROUPING_ACTIONS),
+    ).toEqual([
+      {
+        type: 'forEachBlock',
+        forEachStep,
+        children: [
+          { type: 'step', step: s1 },
+          {
+            type: 'ifThenBlock',
+            ifThenStep: v2If,
+            children: [n1, n2],
+            endStepId: 'n2',
+            endStep: n2,
+            isExplicit: true,
+            isDangling: false,
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe('isStepInsideIfThenBlock', () => {
+  it('is true for a member of an if-then block, including its endStep', () => {
+    const p0 = plain('p0')
+    const block = markedIfThen('block', 'b2')
+    const b1 = plain('b1')
+    const b2 = plain('b2')
+    const pAfter = plain('pAfter')
+    const steps = [p0, block, b1, b2, pAfter]
+
+    expect(isStepInsideIfThenBlock(b1, steps, GROUPING_ACTIONS)).toBe(true)
+    expect(isStepInsideIfThenBlock(b2, steps, GROUPING_ACTIONS)).toBe(true)
+  })
+
+  it('is false for the if-then step itself and for steps outside any block', () => {
+    const p0 = plain('p0')
+    const block = markedIfThen('block', 'b2')
+    const b1 = plain('b1')
+    const b2 = plain('b2')
+    const pAfter = plain('pAfter')
+    const steps = [p0, block, b1, b2, pAfter]
+
+    expect(isStepInsideIfThenBlock(block, steps, GROUPING_ACTIONS)).toBe(false)
+    expect(isStepInsideIfThenBlock(p0, steps, GROUPING_ACTIONS)).toBe(false)
+    expect(isStepInsideIfThenBlock(pAfter, steps, GROUPING_ACTIONS)).toBe(false)
+  })
+
+  it('is true for a member of an if-then block nested in a for-each body', () => {
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const v2If = markedIfThen('v2If', 'n2')
+    const n1 = plain('n1')
+    const n2 = plain('n2')
+    const steps = [forEachStep, s1, v2If, n1, n2]
+
+    expect(isStepInsideIfThenBlock(n1, steps, GROUPING_ACTIONS)).toBe(true)
+    // A direct for-each child that is not inside an if-then.
+    expect(isStepInsideIfThenBlock(s1, steps, GROUPING_ACTIONS)).toBe(false)
+  })
+})
+
+describe('isStepInsideForEachBody', () => {
+  it('is true for any step within a for-each body, at any depth', () => {
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const v2If = markedIfThen('v2If', 'n2')
+    const n1 = plain('n1')
+    const n2 = plain('n2')
+    const steps = [forEachStep, s1, v2If, n1, n2]
+
+    expect(isStepInsideForEachBody(s1, steps, GROUPING_ACTIONS)).toBe(true)
+    // A nested if-then's header and its members are inside the for-each body.
+    expect(isStepInsideForEachBody(v2If, steps, GROUPING_ACTIONS)).toBe(true)
+    expect(isStepInsideForEachBody(n1, steps, GROUPING_ACTIONS)).toBe(true)
+  })
+
+  it('is false for the for-each step itself', () => {
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const steps = [forEachStep, s1]
+
+    expect(isStepInsideForEachBody(forEachStep, steps, GROUPING_ACTIONS)).toBe(
+      false,
+    )
+  })
+
+  it('is false when the flow has no for-each', () => {
+    const block = markedIfThen('block', 'b1')
+    const b1 = plain('b1')
+    const steps = [block, b1]
+
+    expect(isStepInsideForEachBody(b1, steps, GROUPING_ACTIONS)).toBe(false)
+  })
+})

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -1,0 +1,247 @@
+import type { IStep } from '@plumber/types'
+
+import { isIfThenStep } from '@/helpers/toolbox'
+
+/**
+ * Purely a read model derived from the steps: it holds no editing state.
+ */
+export type StepsListItem = SingleStep | IfThenBlock | ForEachBlock
+
+export interface SingleStep {
+  type: 'step'
+  step: IStep
+}
+
+/**
+ * A self-contained if-then block: the if-then step plus the plain steps that
+ * run when its condition passes (its children). `endStep` is the last step
+ * (inclusive) inside the block. An empty block self-references
+ * (`endStep === ifThenStep`, `children === []`).
+ *
+ * - `isExplicit`: the extent came from a valid if-then V2 `config.endStepId`
+ *   marker, rather than being derived from the flat list.
+ * - `isDangling`: the if-then carried a marker that was missing or pointed
+ *   behind itself, so the extent fell back to the derived one.
+ *
+ * Children are plain steps only: if-then V2 blocks never nest, and only
+ * for-each bodies recurse.
+ */
+export interface IfThenBlock {
+  type: 'ifThenBlock'
+  ifThenStep: IStep
+  children: IStep[]
+  endStepId: string
+  endStep: IStep
+  isExplicit: boolean
+  isDangling: boolean
+}
+
+/**
+ * Swallows every later step as its body. The body is a recursively
+ * structured list so if-then blocks render inside it.
+ */
+export interface ForEachBlock {
+  type: 'forEachBlock'
+  forEachStep: IStep
+  children: StepsListItem[]
+}
+
+/**
+ * Reads an if-then V1's nesting depth from `parameters.depth`, mirroring how
+ * the flow editor and the backend do. Nesting never shipped for if-then V2
+ * blocks, so this is inert defense.
+ */
+function parseDepth(step: IStep): number {
+  const depth = parseInt(step.parameters?.depth as string)
+  return isNaN(depth) ? 0 : depth
+}
+
+/**
+ * Derives an if-then V1 (marker-less) block's extent: the last step
+ * (inclusive) inside the block. This mirrors the backend's
+ * `deriveIfThenV1EndStep` so an if-then V1 displays over exactly the range it
+ * actually executes over. An empty block (the next if-then immediately
+ * follows) resolves to the if-then itself (self-reference).
+ *
+ * `actionSteps` is the MRF-filtered action-step list (trigger removed), ordered
+ * by position. Because that list is already filtered to a single approval
+ * branch, "the next if-then that passes the MRF same-approval-branch check" is
+ * simply "the next if-then in the list".
+ */
+export function deriveIfThenV1EndStep(
+  actionSteps: IStep[],
+  ifThenStep: IStep,
+): IStep {
+  const startIndex = actionSteps.findIndex((step) => step.id === ifThenStep.id)
+  const currDepth = parseDepth(ifThenStep)
+
+  const nextBoundaryIndex = actionSteps.findIndex(
+    (step, index) =>
+      index > startIndex && isIfThenStep(step) && parseDepth(step) <= currDepth,
+  )
+
+  if (nextBoundaryIndex === -1) {
+    return actionSteps[actionSteps.length - 1]
+  }
+  return actionSteps[nextBoundaryIndex - 1]
+}
+
+/**
+ * `groupingActions` is the set of `<appKey>-<key>` action ids that group
+ * later steps (`groupsLaterSteps`): if-then and for-each today.
+ */
+export function buildStepsList(
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+): StepsListItem[] {
+  const items: StepsListItem[] = []
+  let index = 0
+
+  while (index < actionSteps.length) {
+    const step = actionSteps[index]
+
+    if (isIfThenStep(step)) {
+      const { item, nextIndex } = buildIfThenBlock(actionSteps, index)
+      items.push(item)
+      index = nextIndex
+      continue
+    }
+
+    if (groupingActions.has(`${step.appKey}-${step.key}`)) {
+      items.push({
+        type: 'forEachBlock',
+        forEachStep: step,
+        children: buildStepsList(actionSteps.slice(index + 1), groupingActions),
+      })
+      break
+    }
+
+    items.push({ type: 'step', step })
+    index += 1
+  }
+
+  return items
+}
+
+/**
+ * Resolves a single if-then step into an {@link IfThenBlock} and reports the
+ * index just past the block. A block inside an MRF rejection branch is
+ * nothing special here: write validation keeps it within its branch, so its
+ * marker is read like any other.
+ *
+ * IMPORTANT: the marker test is `!= null`, not `Object.hasOwn`. These steps
+ * are read over GraphQL, whose responses carry every field the query
+ * selected, so a marker-less if-then arrives with `config.endStepId === null`
+ * rather than with the key absent. (The backend, reading the same marker off
+ * its own DB rows, uses `Object.hasOwn`, since there the key really can be
+ * missing.)
+ */
+function buildIfThenBlock(
+  actionSteps: IStep[],
+  startIndex: number,
+): { item: IfThenBlock; nextIndex: number } {
+  const ifThenStep = actionSteps[startIndex]
+  const hasExplicitMarker = ifThenStep.config?.endStepId != null
+
+  let endIndex: number
+  let isExplicit: boolean
+  let isDangling = false
+
+  if (hasExplicitMarker) {
+    const markerId = ifThenStep.config?.endStepId
+    const markerIndex = actionSteps.findIndex((step) => step.id === markerId)
+    if (markerIndex === -1 || markerIndex < startIndex) {
+      // A missing or behind-self marker is corrupt: degrade gracefully to the
+      // derived extent and flag it rather than rendering a broken block.
+      console.warn(
+        `If-then step "${ifThenStep.id}" has a dangling endStepId marker ` +
+          `"${markerId ?? ''}"; falling back to the derived block extent.`,
+      )
+      isDangling = true
+      isExplicit = false
+      endIndex = getIfThenV1EndIndex(actionSteps, ifThenStep)
+    } else {
+      isExplicit = true
+      endIndex = markerIndex
+    }
+  } else {
+    isExplicit = false
+    endIndex = getIfThenV1EndIndex(actionSteps, ifThenStep)
+  }
+
+  const endStep = actionSteps[endIndex]
+
+  return {
+    item: {
+      type: 'ifThenBlock',
+      ifThenStep,
+      // Steps in (ifThen, endStep]; empty for a self-referencing block.
+      children: actionSteps.slice(startIndex + 1, endIndex + 1),
+      endStepId: endStep.id,
+      endStep,
+      isExplicit,
+      isDangling,
+    },
+    nextIndex: endIndex + 1,
+  }
+}
+
+function getIfThenV1EndIndex(actionSteps: IStep[], ifThenStep: IStep): number {
+  const endStep = deriveIfThenV1EndStep(actionSteps, ifThenStep)
+  return actionSteps.findIndex((step) => step.id === endStep.id)
+}
+
+/**
+ * Whether `step` is a member (child) of some if-then block in the flow — the
+ * if-then step itself is not "inside" its own block. Recurses into for-each
+ * bodies so a step inside an if-then nested under a for-each still counts.
+ */
+export function isStepInsideIfThenBlock(
+  step: IStep,
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+): boolean {
+  const isInIfThenBlock = (items: StepsListItem[]): boolean =>
+    items.some((item) => {
+      if (item.type === 'ifThenBlock') {
+        return item.children.some((child) => child.id === step.id)
+      }
+      if (item.type === 'forEachBlock') {
+        return isInIfThenBlock(item.children)
+      }
+      return false
+    })
+
+  return isInIfThenBlock(buildStepsList(actionSteps, groupingActions))
+}
+
+/**
+ * Whether `step` sits anywhere inside a for-each body (at any depth) — the
+ * for-each step itself is not "inside" its own body.
+ */
+export function isStepInsideForEachBody(
+  step: IStep,
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+): boolean {
+  const bodyContainsStep = (items: StepsListItem[]): boolean =>
+    items.some((item) => {
+      if (item.type === 'step') {
+        return item.step.id === step.id
+      }
+      if (item.type === 'ifThenBlock') {
+        return (
+          item.ifThenStep.id === step.id ||
+          item.children.some((child) => child.id === step.id)
+        )
+      }
+      return item.forEachStep.id === step.id || bodyContainsStep(item.children)
+    })
+
+  const isInForEachBody = (items: StepsListItem[]): boolean =>
+    items.some(
+      (item) => item.type === 'forEachBlock' && bodyContainsStep(item.children),
+    )
+
+  return isInForEachBody(buildStepsList(actionSteps, groupingActions))
+}

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -15,6 +15,8 @@ export type StepToDisplayContextValue = {
   appsWithActions: IApp[]
   groupingActions: Set<string> | null
   stepIdToOrder: Record<string, number>
+  // The MRF-filtered steps to display with the trigger dropped.
+  actionStepsToDisplay: IStep[]
 }
 
 export const StepsToDisplayContext = createContext<StepToDisplayContextValue>({
@@ -24,6 +26,7 @@ export const StepsToDisplayContext = createContext<StepToDisplayContextValue>({
   appsWithActions: [],
   groupingActions: null,
   stepIdToOrder: {},
+  actionStepsToDisplay: [],
 })
 
 interface StepExecutionsProviderProps {
@@ -67,6 +70,13 @@ export function StepsToDisplayProvider({
       return false
     })
   }, [allSteps, approvalBranches])
+
+  // The trigger is always first in the MRF-filtered list, so slice(1) drops
+  // it.
+  const actionStepsToDisplay = useMemo(
+    () => stepsToDisplay.slice(1),
+    [stepsToDisplay],
+  )
 
   const appsWithActions: IApp[] = allApps.filter(
     (app: IApp) => !!app.actions?.length,
@@ -147,6 +157,7 @@ export function StepsToDisplayProvider({
         appsWithActions,
         groupingActions,
         stepIdToOrder,
+        actionStepsToDisplay,
       }}
     >
       {children}


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our front-end to support rendering If-Then V2 blocks (while still maintaining compatbility with v1).

UI for add/delete/reorder/etc is done in later PRs, to keep PR size managable.

# Tests

See top of stack.