### PR TITLE
PLU-743: [IF-THEN-THEN-V2-12] Add LD flag for If-Then v2

### DIFF
--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -1,15 +1,18 @@
 import { IStep } from '@plumber/types'
 
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { Center, Flex } from '@chakra-ui/react'
 
+import { buildStepsList } from '@/components/Editor/helpers/steps-utils'
+import IfThen from '@/components/FlowStepGroup/Content/IfThen/IfThen'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { extractBranchesWithSteps, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import { EDITOR_RIGHT_DRAWER_WIDTH } from '../constants'
@@ -28,10 +31,13 @@ export function StepsList({ isNested }: StepsListProps) {
     groupedSteps,
     appsWithActions,
     groupingActions,
+    actionStepsToDisplay,
   } = useContext(StepsToDisplayContext)
   const { flow, isDrawerOpen, isMobile, readOnly } = useContext(EditorContext)
   const { mrfSteps, mrfApprovalSteps, approvalBranches } =
     useContext(MrfContext)
+  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
+    useIfThenV2Enabled()
 
   const { calculateReorderedSteps, handleReorderUpdate } = useReorderSteps(
     flow.id,
@@ -68,6 +74,16 @@ export function StepsList({ isNested }: StepsListProps) {
     ],
   )
 
+  // groupingActions is null until the apps load. Guard before building the
+  // list.
+  const blockItems = useMemo(
+    () =>
+      groupingActions
+        ? buildStepsList(actionStepsToDisplay, groupingActions)
+        : [],
+    [actionStepsToDisplay, groupingActions],
+  )
+
   const nonIfThenActionSteps = actionStepsBeforeGroup.filter(
     (step) => step.key !== TOOLBOX_ACTIONS.IfThen,
   )
@@ -83,7 +99,7 @@ export function StepsList({ isNested }: StepsListProps) {
   const shouldDisableAddButton =
     (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !groupedSteps.length
 
-  if (!appsWithActions || !groupingActions) {
+  if (!appsWithActions || !groupingActions || isIfThenV2Loading) {
     return (
       <Center height="100vh" position="fixed" width="full" top={0} left={0}>
         <PrimarySpinner fontSize="4xl" />
@@ -98,6 +114,98 @@ export function StepsList({ isNested }: StepsListProps) {
           lg: '5rem',
         }
     : 0
+
+  if (isIfThenV2Enabled) {
+    const hasNoActionSteps = actionStepsToDisplay.length === 0
+    const hasExactlyOneEmptyActionStep =
+      actionStepsToDisplay.length === 1 && !actionStepsToDisplay[0].appKey
+    // Same trigger add-button rules as the old layout, kept for backwards
+    // compatibility.
+    const shouldShowEmptyAction = hasNoActionSteps
+    const shouldDisableTriggerAddButton =
+      hasExactlyOneEmptyActionStep || hasNoActionSteps
+
+    return (
+      <Flex
+        {...editorStyles.stepHeaderContainer}
+        flex={isDrawerOpen ? (isMobile ? 0 : 1) : undefined}
+        px={leftStepPadding}
+        maxWidth={`calc(100% - ${
+          isDrawerOpen ? EDITOR_RIGHT_DRAWER_WIDTH : '0px'
+        })`}
+        sx={{
+          scrollbarGutter: 'stable',
+        }}
+      >
+        {triggerStep && (
+          <FlowStepWithAddButton
+            step={triggerStep}
+            isLastStep={hasNoActionSteps}
+            isNested={isNested}
+            allowReorder={false}
+            stepsBeforeGroup={[]}
+            groupedSteps={[]}
+            addButtonProps={{
+              isHidden: readOnly,
+              isDisabled: shouldDisableTriggerAddButton,
+              showEmptyAction: shouldShowEmptyAction,
+            }}
+          />
+        )}
+
+        {blockItems.map((item, index) => {
+          const isLast = index === blockItems.length - 1
+
+          if (item.type === 'ifThenBlock') {
+            return (
+              <IfThen
+                key={item.ifThenStep.id}
+                block={item}
+                isLastBlock={isLast}
+              />
+            )
+          }
+
+          if (item.type === 'forEachBlock') {
+            // The for-each still renders through the existing grouped box, which
+            // wants the branch-shaped grouping. Rebuild it from the for-each's
+            // own steps — it swallows every later step, so they are contiguous
+            // from its position onwards.
+            const forEachIndex = actionStepsToDisplay.findIndex(
+              (step) => step.id === item.forEachStep.id,
+            )
+            return (
+              <FlowStepGroup
+                key={item.forEachStep.id}
+                stepsBeforeGroup={actionStepsToDisplay.slice(0, forEachIndex)}
+                groupedSteps={extractBranchesWithSteps(
+                  actionStepsToDisplay.slice(forEachIndex),
+                  0,
+                )}
+              />
+            )
+          }
+
+          return (
+            <FlowStepWithAddButton
+              key={item.step.id}
+              step={item.step}
+              isLastStep={isLast}
+              isNested={isNested}
+              allowReorder={false}
+              stepsBeforeGroup={[]}
+              groupedSteps={[]}
+              addButtonProps={{
+                isHidden: readOnly,
+                isDisabled: false,
+                showEmptyAction: false,
+              }}
+            />
+          )
+        })}
+      </Flex>
+    )
+  }
 
   return (
     <Flex

--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildStepsList,
   deriveIfThenV1EndStep,
+  hasIfThenV2Block,
+  isBlankPlaceholderStep,
   isStepInsideForEachBody,
   isStepInsideIfThenBlock,
 } from '../steps-utils'
@@ -42,6 +44,10 @@ const forEach = (id: string): IStep =>
 
 const mrfSubmission = (id: string): IStep =>
   ({ id, appKey: 'formsg', key: 'mrfSubmission' } as IStep)
+
+// A leftover blank child from the if-then V1 branch initializer: neither
+// appKey nor key ever set.
+const blank = (id: string): IStep => ({ id } as IStep)
 
 // The set of grouping actions (`groupsLaterSteps`) is exactly if-then and
 // for-each today.
@@ -513,5 +519,55 @@ describe('isStepInsideForEachBody', () => {
     const steps = [block, b1]
 
     expect(isStepInsideForEachBody(b1, steps, GROUPING_ACTIONS)).toBe(false)
+  })
+})
+
+describe('hasIfThenV2Block', () => {
+  it('is true for a populated if-then V2 block', () => {
+    const block = markedIfThen('block', 's2')
+    const s2 = plain('s2')
+
+    expect(hasIfThenV2Block([block, s2])).toBe(true)
+  })
+
+  it('is true for an empty (self-referencing) if-then V2 block', () => {
+    const block = markedIfThen('block', 'block')
+
+    expect(hasIfThenV2Block([block])).toBe(true)
+  })
+
+  it('is false for a marker-less if-then shaped like real GraphQL data', () => {
+    const ifThenA = nullMarkerIfThen('ifThenA')
+
+    expect(hasIfThenV2Block([ifThenA])).toBe(false)
+  })
+
+  it('is false for a flow with no if-then step at all', () => {
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+
+    expect(hasIfThenV2Block([s1, s2])).toBe(false)
+  })
+
+  it('is true when only one of several if-thens carries a marker', () => {
+    const ifThenA = nullMarkerIfThen('ifThenA')
+    const block = markedIfThen('block', 'b1')
+    const b1 = plain('b1')
+
+    expect(hasIfThenV2Block([ifThenA, block, b1])).toBe(true)
+  })
+})
+
+describe('isBlankPlaceholderStep', () => {
+  it('is true for a step with neither appKey nor key', () => {
+    expect(isBlankPlaceholderStep(blank('child'))).toBe(true)
+  })
+
+  it('is false for a fully-configured step', () => {
+    expect(isBlankPlaceholderStep(plain('s1'))).toBe(false)
+  })
+
+  it('is false for an if-then step', () => {
+    expect(isBlankPlaceholderStep(ifThen('block'))).toBe(false)
   })
 })

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -245,3 +245,29 @@ export function isStepInsideForEachBody(
 
   return isInForEachBody(buildStepsList(actionSteps, groupingActions))
 }
+
+/**
+ * Whether the flow already has an if-then V2 block. `useIfThenV2Enabled` uses
+ * this to keep rendering the V2 UI once a pipe has one, regardless of the LD
+ * flag. The V1 renderer has no concept of the marker and would silently
+ * absorb steps that are actually outside the block.
+ *
+ * IMPORTANT: pass the full `flow.steps`, not the MRF-filtered display list,
+ * so a marker on an off-screen branch still counts.
+ */
+export function hasIfThenV2Block(flowSteps: IStep[]): boolean {
+  return flowSteps.some(
+    (step) => isIfThenStep(step) && step.config?.endStepId != null,
+  )
+}
+
+/**
+ * Whether `step` is a blank placeholder left by the if-then V1 branch
+ * initializer — no app or event ever chosen. Mirrors the backend's
+ * `isBlankPlaceholderStep` (toolbox/common/constants.ts): createStep only
+ * omits both fields together, for exactly this case, so a step is never
+ * mid-configuration with just one of them unset.
+ */
+export function isBlankPlaceholderStep(step: IStep): boolean {
+  return !step.appKey && !step.key
+}

--- a/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
+++ b/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
@@ -26,6 +26,11 @@ export default function FlowStepWrapper(props: FlowStepWrapperProps) {
       alignItems="center"
       display={isMobile ? 'block' : 'flex'}
       flexDir="column"
+      // IMPORTANT: some Flex column parents (a for-each body, an if-then
+      // branch's own steps) default to alignItems="stretch" instead of
+      // "center". That would leave this width-narrowed wrapper flush against
+      // the left edge. alignSelf keeps it centred regardless of the parent.
+      alignSelf="center"
       w={
         canChildStepsReorder &&
         !allowReorder &&

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -19,6 +19,7 @@ import ErrorFlowStepHeader from '../ErrorFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
 import { DragHandle } from '../SortableList/components'
+import { NESTED_DRAG_HANDLE_WIDTH } from '../SortableList/components/SortableItem'
 
 import { ApproveReject } from './components/ApproveReject'
 import DeleteStepButton from './components/DeleteStepButton'
@@ -36,6 +37,21 @@ type FlowStepProps = {
   allowReorder?: boolean
   // we use this to control the width of condition steps in if-then and for-each
   canChildStepsReorder?: boolean
+  // An if-then V2 block titles its condition step with the block's own name,
+  // so the block's header reads as the block rather than a generic
+  // "Condition".
+  stepNameOverride?: string
+  // An if-then V2 block's condition step doubles as the block's header, so
+  // the block reads as one big step rather than a card holding a card. The
+  // owning container supplies the selected-state border this drops.
+  isContainerHeader?: boolean
+  // An if-then V2 block's header is a step's usual visuals standing in for
+  // the block's name. It is not a step of its own to configure. That's the
+  // condition card beneath it.
+  isClickable?: boolean
+  // An if-then V2 block's condition card drops its own number since the
+  // block's header above already shows one.
+  hideDisplayPosition?: boolean
 }
 
 export default function FlowStep(
@@ -47,7 +63,23 @@ export default function FlowStep(
     isNested,
     allowReorder = true,
     canChildStepsReorder = false,
+    stepNameOverride,
+    isContainerHeader = false,
+    isClickable = true,
+    hideDisplayPosition = false,
   } = props
+
+  // IMPORTANT: borderTopRadius has to be reset explicitly, not just
+  // borderRadius. It maps to the corner longhands, which beat the shorthand
+  // regardless of prop order.
+  const containerHeaderStyles = isContainerHeader
+    ? {
+        borderWidth: 0,
+        borderTopWidth: 0,
+        borderRadius: 'none',
+        borderTopRadius: 'none',
+      }
+    : {}
 
   const {
     isOpen: isModalOpen,
@@ -71,7 +103,7 @@ export default function FlowStep(
   } = useContext(EditorContext)
   const {
     app,
-    stepName,
+    stepName: derivedStepName,
     displayPosition,
     isCompleted,
     isTrigger,
@@ -83,6 +115,7 @@ export default function FlowStep(
     isMrfStep,
     warnsMrfNoGate,
   } = useStepMetadata(step, allowReorder)
+  const stepName = stepNameOverride ?? derivedStepName
 
   const {
     cancelRef,
@@ -147,6 +180,12 @@ export default function FlowStep(
   }
 
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
+
+  // A nested step's drag handle takes its width from the card's right edge,
+  // pulling the card off the flow's centre line. This offset shifts the card
+  // back to centre.
+  const nestedHandleOffset =
+    isNested && shouldShowDragHandle ? NESTED_DRAG_HANDLE_WIDTH / 2 : 0
 
   // generate help message only if template config exists
   const stepAppEventKey = `${step?.appKey}_${step?.key}`
@@ -213,7 +252,17 @@ export default function FlowStep(
             alignItems={isNested ? 'flex-start' : 'center'}
             justifyContent="center"
             flexDir="column"
-            flex="1"
+            flex={nestedHandleOffset ? undefined : '1'}
+            // Without flexShrink={0}, default flex-shrink would claw the
+            // margin nudge back out of this box's width instead of shifting
+            // its position.
+            flexShrink={nestedHandleOffset ? 0 : undefined}
+            w={
+              nestedHandleOffset
+                ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+                : undefined
+            }
+            ml={nestedHandleOffset ? `${nestedHandleOffset}px` : undefined}
             minW="0"
           >
             {showMrfReadOnlyNote && (
@@ -311,11 +360,16 @@ export default function FlowStep(
               h={isNested ? '56px' : isApprovalStep ? undefined : '64px'}
               minH={isApprovalStep && !isNested ? '124px' : undefined}
               w={headerWidth}
-              onClick={handleClick}
+              onClick={isClickable ? handleClick : undefined}
+              {...(!isClickable && { cursor: 'default', _hover: {} })}
+              {...containerHeaderStyles}
             >
               <Flex {...flowStepStyles.topHeader}>
                 <StepAppIcon
-                  isCompleted={isCompleted}
+                  // The container header stands in for the whole block; its
+                  // own condition step being "complete" doesn't mean the
+                  // block is, so it never shows the checkmark badge.
+                  isCompleted={isContainerHeader ? false : isCompleted}
                   isNested={isNested}
                   isTestSuccessful={isTestSuccessful}
                   shouldTestStepAgain={shouldTestStepAgain}
@@ -323,7 +377,9 @@ export default function FlowStep(
                   step={step}
                 />
                 <StepNameAndDemo
-                  displayPosition={displayPosition}
+                  displayPosition={
+                    hideDisplayPosition ? undefined : displayPosition
+                  }
                   stepName={stepName}
                 />
                 {isDeletable && (
@@ -334,7 +390,9 @@ export default function FlowStep(
                     <DeleteStepButton
                       isNested={isNested}
                       step={step}
-                      displayPosition={displayPosition}
+                      displayPosition={
+                        hideDisplayPosition ? undefined : displayPosition
+                      }
                       stepName={stepName}
                     />
                   </Flex>

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -3,13 +3,17 @@ import { IStep } from '@plumber/types'
 import { useContext, useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
+import { buildStepsList } from '@/components/Editor/helpers/steps-utils'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+import IfThen from '../IfThen/IfThen'
 
 interface ForEachProps {
   groupedSteps: IStep[][]
@@ -19,6 +23,9 @@ interface ForEachProps {
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
   const { flow } = useContext(EditorContext)
+  const { groupingActions } = useContext(StepsToDisplayContext)
+  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
+    useIfThenV2Enabled()
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 
   const forEachSteps = groupedSteps[0]
@@ -101,12 +108,50 @@ export default function ForEach(props: ForEachProps) {
           }}
         />
 
-        {ifThenSteps.length > 0 && (
-          <FlowStepGroup
-            stepsBeforeGroup={forEachSteps}
-            groupedSteps={ifThenSteps}
-          />
-        )}
+        {ifThenSteps.length > 0 &&
+          !isIfThenV2Loading &&
+          (isIfThenV2Enabled ? (
+            <Flex flexDir="column" w="100%" gap={2}>
+              {buildStepsList(
+                ifThenSteps.flat(),
+                groupingActions ?? new Set<string>(),
+              ).map((item, index, items) => {
+                const isLastItem = index === items.length - 1
+
+                if (item.type === 'ifThenBlock') {
+                  return (
+                    <IfThen
+                      key={item.ifThenStep.id}
+                      block={item}
+                      isLastBlock={isLastItem}
+                    />
+                  )
+                }
+
+                if (item.type === 'step') {
+                  // A plain step between/after if-then V2 blocks in the body —
+                  // an explicit endStepId marker can end a block before the
+                  // body's last step, unlike a derived if-then V1 extent.
+                  return (
+                    <GroupStepWithAddButton
+                      key={item.step.id}
+                      step={item.step}
+                      canAddStep={true}
+                      isLastStep={isLastItem}
+                      allowReorder={false}
+                    />
+                  )
+                }
+
+                return null
+              })}
+            </Flex>
+          ) : (
+            <FlowStepGroup
+              stepsBeforeGroup={forEachSteps}
+              groupedSteps={ifThenSteps}
+            />
+          ))}
       </Flex>
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -1,0 +1,262 @@
+import { IStep } from '@plumber/types'
+
+import { useContext } from 'react'
+import { Divider, Flex } from '@chakra-ui/react'
+
+import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
+import {
+  type IfThenBlock,
+  isBlankPlaceholderStep,
+} from '@/components/Editor/helpers/steps-utils'
+import { SortableList } from '@/components/SortableList'
+import { EditorContext } from '@/contexts/Editor'
+import { FlowStep } from '@/exports/components'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { getFlowStepHeaderWidth } from '@/helpers/editor'
+import useReorderSteps from '@/hooks/useReorderSteps'
+
+import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+import { flowStepGroupStyles } from '../../styles'
+
+import { HoverAddStepButton } from './HoverAddStepButton'
+import { branchStyles } from './styles'
+
+interface IfThenProps {
+  block: IfThenBlock
+  isLastBlock: boolean
+}
+
+interface ReorderItem {
+  id: string
+  step: IStep
+  index: number
+}
+
+/**
+ * Drawn as the same grouped box as an if-then V1 group, despite having only
+ * one branch, so the two variants read as the same thing in the editor.
+ *
+ * IMPORTANT: block-level affordances (add-after-block, delete/duplicate) are
+ * not wired here.
+ */
+export default function IfThen({
+  block,
+  isLastBlock,
+}: IfThenProps): JSX.Element {
+  const { ifThenStep, children } = block
+  const { currentStepId, flow, isDrawerOpen, isMobile, readOnly } =
+    useContext(EditorContext)
+  const { handleReorderUpdate } = useReorderSteps(flow.id)
+
+  const isEmptyBlock = children.length === 0
+
+  // A not-yet-upgraded if-then V1 block whose only child is the branch
+  // initializer's leftover blank placeholder should read as an empty V2
+  // block, so the (redundant) hover-+ around that placeholder is suppressed.
+  const isSoleBlankPlaceholder =
+    children.length === 1 && isBlankPlaceholderStep(children[0])
+
+  // The single-branch box merges what an if-then V1 group shows as two lines
+  // (its own caption, plus the branch name inside it) into one header. A
+  // user-renamed step takes priority, as it would for any step. Otherwise the
+  // branch name stands in, captioned as an if-then so it doesn't read as a
+  // name the user chose themselves.
+  const stepName = ifThenStep.config?.stepName
+  const branchName = ifThenStep.parameters?.branchName as string | undefined
+  const headerLabel =
+    stepName ?? (branchName ? `If-then: ${branchName}` : 'If-then')
+
+  const handleReorderSteps = async (items: ReorderItem[]) => {
+    const stepPositions = items.map((item, index) => ({
+      id: item.id,
+      position: ifThenStep.position + index + 1,
+      type: item.step.type as StepEnumType,
+    }))
+
+    try {
+      handleReorderUpdate(stepPositions)
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
+  return (
+    <Flex flexDir="column" w="100%">
+      <Flex
+        w="100%"
+        alignItems="center"
+        justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
+      >
+        <Flex
+          {...flowStepGroupStyles.container}
+          display={isMobile ? 'block' : 'flex'}
+          w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
+          minW={MIN_FLOW_STEP_WIDTH}
+          // The header and branch run edge to edge, so the box clips them to its
+          // own rounded corners.
+          overflow="hidden"
+          // The box carries the selected-state border its flush header drops.
+          borderColor={
+            currentStepId === ifThenStep.id
+              ? 'base.content.brand'
+              : 'base.divider.medium'
+          }
+        >
+          {/*
+            The header stands in for the whole block, not a step of its own to
+            configure. So it takes the block's name and drops click-to-configure
+            and its own border, letting the box read as one step rather than a
+            card holding cards.
+          */}
+          <FlowStep
+            step={ifThenStep}
+            stepNameOverride={headerLabel}
+            isContainerHeader
+            isClickable={false}
+            isNested={true}
+            isLastStep={isEmptyBlock}
+            allowReorder={false}
+          />
+
+          {/*
+            The condition step renders again here as a normal card, matching
+            how an if-then V1 branch draws its condition card and steps in one
+            panel. An empty block keeps this panel and placeholder rather than
+            looking like a different component.
+
+            The panel is white, not branchStyles.container's usual grey, since
+            a single-branch box doesn't need to visually separate branches the
+            way an if-then V1 group's side-by-side branches do.
+          */}
+          <Flex
+            {...branchStyles.container}
+            bg="white"
+            borderRadius="none"
+            // pb drops by the placeholder's own 4px bottom margin so the
+            // empty-block panel stays evenly padded overall.
+            pb={isEmptyBlock ? 2 : 3}
+          >
+            <Flex w="100%" flexDir="column">
+              {/*
+                This is the same condition step the header above renders, now
+                as a normal, clickable card. It drops its own name and
+                position number since the header already carries both.
+              */}
+              <FlowStep
+                step={ifThenStep}
+                stepNameOverride="Condition"
+                hideDisplayPosition
+                isNested={true}
+                isLastStep={false}
+                allowReorder={false}
+                // Matches the width sibling cards give up for their own drag
+                // handles, exactly as an if-then V1 branch's condition card
+                // does, so the condition card isn't wider than the cards below
+                // it.
+                canChildStepsReorder={children.length > 1}
+              />
+
+              {isEmptyBlock ? (
+                // The placeholder card is `w="100%"`, which only resolves to the
+                // panel's width because this column stretches it; left to the
+                // block box, whose items are centred, it would shrink to fit its
+                // own text.
+                <HoverAddStepButton
+                  isDisabled={readOnly}
+                  isDrawerOpen={isDrawerOpen}
+                  isLastStep={true}
+                  prevStep={ifThenStep}
+                  showEmptyAction={true}
+                  step={ifThenStep}
+                  allowReorder={false}
+                />
+              ) : (
+                <>
+                  {/*
+                    Every other card-to-card transition in this panel has a
+                    connector; the condition card is no exception, so a
+                    populated block can insert a step directly after it too.
+                  */}
+                  <HoverAddStepButton
+                    // Reuses isDisabled for the sole-blank-placeholder edge
+                    // case (see isSoleBlankPlaceholder). pointerEvents: none
+                    // keeps the connector but makes the hover-+ itself inert.
+                    isDisabled={readOnly || isSoleBlankPlaceholder}
+                    isDrawerOpen={isDrawerOpen}
+                    isLastStep={false}
+                    prevStep={ifThenStep}
+                    step={ifThenStep}
+                    allowReorder={false}
+                    canChildStepsReorder={children.length > 1}
+                  />
+                  <SortableList
+                    items={children.map((step, index) => ({
+                      id: step.id,
+                      step,
+                      index,
+                    }))}
+                    onChange={handleReorderSteps}
+                    renderItem={(item, isOverlay) => {
+                      const { step, index } = item
+                      const isLastStep = index === children.length - 1
+
+                      // Every step, last one included, gets the same hover +
+                      // to append after it — matching how a for-each body
+                      // (and an if-then V1 branch) appends, rather than the
+                      // last step handing off to its own separate,
+                      // always-visible "Add step" card.
+                      return (
+                        <SortableList.Item id={item.id}>
+                          <Flex w="100%" flexDir="column">
+                            <GroupStepWithAddButton
+                              step={step}
+                              // Same sole-blank-placeholder edge case as the
+                              // leading HoverAddStepButton above: no
+                              // trailing hover-+ after it either, so the
+                              // card reads as an empty block's own
+                              // add-first-step placeholder rather than a
+                              // populated block's last member.
+                              canAddStep={!isSoleBlankPlaceholder}
+                              isLastStep={isLastStep}
+                              isOverlay={isOverlay}
+                              allowReorder={children.length > 1}
+                            />
+                          </Flex>
+                        </SortableList.Item>
+                      )
+                    }}
+                  />
+                </>
+              )}
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+
+      {/*
+        Matches the height AddStepButton draws between two steps: 16+36+16px
+        normally, or a 48px divider in the stronger colour once read-only
+        hides the button. The block has no add-after affordance of its own
+        yet, so it draws a plain line of the same height instead. The last
+        block draws nothing, matching how a last step has no connector.
+      */}
+      {!isLastBlock && (
+        <Flex flexDir="column" alignItems="center" w="100%">
+          {readOnly ? (
+            <Divider
+              h="48px"
+              orientation="vertical"
+              borderColor="base.divider.strong"
+            />
+          ) : (
+            <Divider h="68px" orientation="vertical" />
+          )}
+        </Flex>
+      )}
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThenV1.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThenV1.tsx
@@ -22,7 +22,7 @@ interface IfThenProps {
   stepsBeforeGroup: IStep[]
 }
 
-export default function IfThen(props: IfThenProps): JSX.Element {
+export default function IfThenV1(props: IfThenProps): JSX.Element {
   const { groupedSteps, stepsBeforeGroup } = props
 
   const { depth } = useContext(BranchContext)

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -53,6 +53,11 @@ export const hoverAddStepButtonStyles = {
     my: 1,
     mx: 0,
     transition: 'all 0.3s ease',
+    // IMPORTANT: some Flex column parents (see the `w` prop in
+    // HoverAddStepButton) don't set alignItems="center" and default to
+    // stretch, which would pull this connector off the flow's centre line.
+    // alignSelf keeps it centred regardless of the parent.
+    alignSelf: 'center',
   },
   button: {
     pos: 'absolute' as FlexProps['pos'],

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -15,7 +15,7 @@ import { MIN_FLOW_STEP_WIDTH } from '../Editor/constants'
 import DeleteConfirmationDialog from './components/DeleteConfirmationDialog'
 import Error from './Content/Error'
 import ForEach from './Content/ForEach'
-import IfThen from './Content/IfThen'
+import IfThenV1 from './Content/IfThen/IfThenV1'
 import useDeleteStepConfirmation from './hooks/useDeleteStepConfirmation'
 import { flowStepGroupStyles } from './styles'
 
@@ -128,7 +128,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
           </Flex>
         </Box>
         {stepGroupType === TOOLBOX_ACTIONS.IfThen ? (
-          <IfThen
+          <IfThenV1
             groupedSteps={groupedSteps}
             stepsBeforeGroup={stepsBeforeGroup}
           />

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -14,6 +14,7 @@ export const SGID_FEATURE_FLAG = 'sgid-login'
 export const SSO_FEATURE_FLAG = 'ogp-sso-enabled'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
+export const IF_THEN_THEN_FEATURE_FLAG = 'feature_if_then_then'
 
 /**
  * App/events flags

--- a/packages/frontend/src/graphql/mutations/create-step.ts
+++ b/packages/frontend/src/graphql/mutations/create-step.ts
@@ -17,6 +17,7 @@ export const CREATE_STEP = gql`
       }
       config {
         stepName
+        endStepId
         templateConfig {
           appEventKey
         }

--- a/packages/frontend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/frontend/src/graphql/mutations/duplicate-branch.ts
@@ -19,6 +19,7 @@ export const DUPLICATE_BRANCH = gql`
         }
         config {
           stepName
+          endStepId
         }
       }
     }

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -18,6 +18,7 @@ export const UPDATE_STEP = graphql(`
       }
       config {
         stepName
+        endStepId
         templateConfig {
           appEventKey
         }

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -29,6 +29,7 @@ export const FLOW_FIELDS = gql`
       parameters
       config {
         stepName
+        endStepId
         templateConfig {
           appEventKey
           customTemplate
@@ -78,6 +79,10 @@ export const GET_FLOW = gql`
   query GetFlow($id: String!) {
     getFlow(id: $id) {
       ...DefaultFlowFields
+      collaborators {
+        email
+        role
+      }
     }
   }
   ${FLOW_FIELDS}

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -20,6 +20,7 @@ export const GET_TEST_EXECUTION_STEPS = gql`
             appEventKey
           }
           stepName
+          endStepId
           approval {
             branch
             stepId

--- a/packages/frontend/src/hooks/__tests__/useIfThenV2Enabled.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useIfThenV2Enabled.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { planPipeOwnerFlagEvaluation } from '../useIfThenV2Enabled'
+
+describe('planPipeOwnerFlagEvaluation', () => {
+  const owner = { email: 'owner@example.gov.sg', role: 'owner' }
+  const editor = { email: 'editor@example.gov.sg', role: 'editor' }
+  const viewer = { email: 'viewer@example.gov.sg', role: 'viewer' }
+
+  describe('owner (or unknown role) evaluates against the app own context', () => {
+    it('returns an own-context plan when the current user owns the pipe', () => {
+      expect(planPipeOwnerFlagEvaluation('owner', [owner, editor])).toEqual({
+        kind: 'ownContext',
+      })
+    })
+
+    it('treats a missing role as own-context (the common solo/owner case)', () => {
+      expect(planPipeOwnerFlagEvaluation(null, [])).toEqual({
+        kind: 'ownContext',
+      })
+      expect(planPipeOwnerFlagEvaluation(undefined, [])).toEqual({
+        kind: 'ownContext',
+      })
+      expect(planPipeOwnerFlagEvaluation('', [])).toEqual({
+        kind: 'ownContext',
+      })
+    })
+
+    it('matches the owner role case-insensitively', () => {
+      expect(planPipeOwnerFlagEvaluation('OWNER', [owner])).toEqual({
+        kind: 'ownContext',
+      })
+    })
+  })
+
+  describe('non-owner collaborators follow the pipe owner context', () => {
+    it('resolves the owner email for an editor', () => {
+      expect(planPipeOwnerFlagEvaluation('editor', [editor, owner])).toEqual({
+        kind: 'pipeOwnerContext',
+        ownerEmail: owner.email,
+      })
+    })
+
+    it('resolves the owner email for a viewer', () => {
+      expect(planPipeOwnerFlagEvaluation('viewer', [viewer, owner])).toEqual({
+        kind: 'pipeOwnerContext',
+        ownerEmail: owner.email,
+      })
+    })
+
+    it('finds the owner entry regardless of its role casing', () => {
+      expect(
+        planPipeOwnerFlagEvaluation('editor', [
+          editor,
+          { email: owner.email, role: 'Owner' },
+        ]),
+      ).toEqual({ kind: 'pipeOwnerContext', ownerEmail: owner.email })
+    })
+  })
+
+  describe('non-owner without a resolvable owner degrades', () => {
+    it('returns an unresolved plan when no owner is in the collaborators', () => {
+      expect(planPipeOwnerFlagEvaluation('editor', [editor, viewer])).toEqual({
+        kind: 'unresolvedOwner',
+      })
+    })
+
+    it('returns an unresolved plan when collaborators are empty', () => {
+      expect(planPipeOwnerFlagEvaluation('editor', [])).toEqual({
+        kind: 'unresolvedOwner',
+      })
+    })
+
+    it('returns an unresolved plan when the owner entry has no email', () => {
+      // IFlowCollaborator.email is optional; a client cannot be scoped without
+      // an owner email, so degrade rather than initialise a keyless context.
+      expect(
+        planPipeOwnerFlagEvaluation('editor', [
+          editor,
+          { email: undefined, role: 'owner' },
+        ]),
+      ).toEqual({ kind: 'unresolvedOwner' })
+    })
+  })
+})

--- a/packages/frontend/src/hooks/useIfThenV2Enabled.ts
+++ b/packages/frontend/src/hooks/useIfThenV2Enabled.ts
@@ -1,0 +1,147 @@
+import { useContext, useEffect, useMemo, useState } from 'react'
+import type { LDClient, LDContext } from 'launchdarkly-js-client-sdk'
+import { basicLogger as LDLogger, initialize } from 'launchdarkly-js-client-sdk'
+
+import { hasIfThenV2Block } from '@/components/Editor/helpers/steps-utils'
+import appConfig from '@/config/app'
+import { IF_THEN_THEN_FEATURE_FLAG } from '@/config/flags'
+import { EditorContext } from '@/contexts/Editor'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+
+const OWNER_ROLE = 'owner'
+
+/**
+ * How to evaluate the if-then V2 flag for the pipe being edited. The flag is
+ * scoped to the pipe owner, so a collaborator must evaluate it in the
+ * owner's context rather than their own.
+ */
+export type PipeOwnerFlagPlan =
+  | { kind: 'ownContext' }
+  | { kind: 'pipeOwnerContext'; ownerEmail: string }
+  | { kind: 'unresolvedOwner' }
+
+export function planPipeOwnerFlagEvaluation(
+  role: string | null | undefined,
+  collaborators: ReadonlyArray<{ email?: string | null; role: string }>,
+): PipeOwnerFlagPlan {
+  // Own-context evaluation covers the owner and the common solo/no-role case,
+  // so no second LaunchDarkly client is needed here.
+  if (!role || role.toLowerCase() === OWNER_ROLE) {
+    return { kind: 'ownContext' }
+  }
+
+  const ownerEmail = collaborators.find(
+    (collaborator) => collaborator.role.toLowerCase() === OWNER_ROLE,
+  )?.email
+  if (!ownerEmail) {
+    return { kind: 'unresolvedOwner' }
+  }
+  return { kind: 'pipeOwnerContext', ownerEmail }
+}
+
+export interface IfThenV2State {
+  isEnabled: boolean
+  /**
+   * Only ever true on the collaborator path, while the pipe-scoped client
+   * initialises. Callers gate their initial render on this so the UI mode
+   * never flips after first paint.
+   */
+  isLoading: boolean
+}
+
+/**
+ * Resolves whether the flow editor should render the if-then V2 UI for the
+ * pipe currently being edited.
+ *
+ * A strict collaborator can't reuse the app's singleton LaunchDarkly client,
+ * since browser SDKs only hold the logged-in user's pre-evaluated flags, and
+ * re-identifying the singleton would re-scope every flag in the app. A
+ * second, throwaway client is spun up in the owner's context to read just
+ * this one flag, then closed. If it fails to initialise, or the owner can't
+ * be resolved, the editor falls back to the old UI.
+ */
+export function useIfThenV2Enabled(): IfThenV2State {
+  const { flow } = useContext(EditorContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+
+  const plan = useMemo(
+    () => planPipeOwnerFlagEvaluation(flow.role, flow.collaborators ?? []),
+    [flow.role, flow.collaborators],
+  )
+
+  const hasV2Block = useMemo(() => hasIfThenV2Block(flow.steps), [flow.steps])
+
+  // Pipe-scoped state: only meaningful (and only updated) on the collaborator
+  // path, where the owner's flag resolves asynchronously.
+  const [pipeState, setPipeState] = useState<IfThenV2State>({
+    isEnabled: false,
+    isLoading: true,
+  })
+
+  useEffect(() => {
+    // Already known to be enabled by content; skip spinning up a throwaway
+    // pipe-scoped client to answer a question we don't need answered.
+    if (hasV2Block || plan.kind !== 'pipeOwnerContext') {
+      return
+    }
+
+    let isCancelled = false
+    const ownerContext: LDContext = { kind: 'user', key: plan.ownerEmail }
+    const pipeClient: LDClient = initialize(
+      appConfig.launchDarklyClientId,
+      ownerContext,
+      {
+        logger: LDLogger({ level: 'none' }),
+        // Match the singleton client: no live updates, evaluate once on load.
+        streaming: false,
+      },
+    )
+
+    pipeClient
+      .waitForInitialization()
+      .then(() => {
+        if (isCancelled) {
+          return
+        }
+        setPipeState({
+          isEnabled: Boolean(
+            pipeClient.variation(IF_THEN_THEN_FEATURE_FLAG, false),
+          ),
+          isLoading: false,
+        })
+      })
+      .catch((error) => {
+        console.warn(
+          'Failed to evaluate the if-then V2 flag for the pipe owner; ' +
+            'falling back to the old editor UI.',
+          error,
+        )
+        if (isCancelled) {
+          return
+        }
+        setPipeState({ isEnabled: false, isLoading: false })
+      })
+
+    return () => {
+      isCancelled = true
+      pipeClient.close()
+    }
+  }, [plan, hasV2Block])
+
+  if (hasV2Block) {
+    return { isEnabled: true, isLoading: false }
+  }
+
+  if (plan.kind === 'ownContext') {
+    return {
+      isEnabled: Boolean(getFlagValue(IF_THEN_THEN_FEATURE_FLAG, false)),
+      isLoading: false,
+    }
+  }
+
+  if (plan.kind === 'unresolvedOwner') {
+    return { isEnabled: false, isLoading: false }
+  }
+
+  return pipeState
+}


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our front-end to gate If-Then v2 behind an LD flag (`feature_if_then_then`). The backend basically only writes V2 if `endStepId` (and `previousBlockId` - if needed) are supplied by the frontend, so front-end gating is sufficient.

# Tests

See top of stack.