### PR TITLE
PLU-743: [IF-THEN-THEN-V2-13] Support adding / deleting / re-ordering If-Then V2 in frontend

### DIFF
--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -3,7 +3,12 @@ import { IStep } from '@plumber/types'
 import { useCallback, useContext, useMemo } from 'react'
 import { Center, Flex } from '@chakra-ui/react'
 
-import { buildStepsList } from '@/components/Editor/helpers/steps-utils'
+import {
+  buildStepsList,
+  type ForEachBlock,
+  type IfThenBlock,
+  type SingleStep,
+} from '@/components/Editor/helpers/steps-utils'
 import IfThen from '@/components/FlowStepGroup/Content/IfThen/IfThen'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { SortableList } from '@/components/SortableList'
@@ -74,6 +79,22 @@ export function StepsList({ isNested }: StepsListProps) {
     ],
   )
 
+  // The backend re-pins each block's endStepId marker after a reorder, so
+  // moving it as one contiguous range needs no marker handling here.
+  const handleReorderBlockItems = useCallback(
+    async (
+      reordered: Array<{ id: string; item: IfThenBlock | SingleStep }>,
+    ) => {
+      const reorderedSteps = reordered.flatMap(({ item }) =>
+        item.type === 'ifThenBlock'
+          ? [item.ifThenStep, ...item.children]
+          : [item.step],
+      )
+      await handleReorderSteps(reorderedSteps)
+    },
+    [handleReorderSteps],
+  )
+
   // groupingActions is null until the apps load. Guard before building the
   // list.
   const blockItems = useMemo(
@@ -125,6 +146,27 @@ export function StepsList({ isNested }: StepsListProps) {
     const shouldDisableTriggerAddButton =
       hasExactlyOneEmptyActionStep || hasNoActionSteps
 
+    // A for-each swallows every later step, so it stays outside the
+    // reorderable set and is always last.
+    const forEachItem = blockItems.find(
+      (item): item is ForEachBlock => item.type === 'forEachBlock',
+    )
+    const reorderableItems = blockItems.filter(
+      (item): item is IfThenBlock | SingleStep => item.type !== 'forEachBlock',
+    )
+    const sortableBlockItems = reorderableItems.map((item) => ({
+      id: item.type === 'ifThenBlock' ? item.ifThenStep.id : item.step.id,
+      item,
+    }))
+    const canReorderBlocks = !readOnly && reorderableItems.length > 1
+    const lastReorderableId =
+      sortableBlockItems[sortableBlockItems.length - 1]?.id
+    const forEachIndex = forEachItem
+      ? actionStepsToDisplay.findIndex(
+          (step) => step.id === forEachItem.forEachStep.id,
+        )
+      : -1
+
     return (
       <Flex
         {...editorStyles.stepHeaderContainer}
@@ -153,56 +195,64 @@ export function StepsList({ isNested }: StepsListProps) {
           />
         )}
 
-        {blockItems.map((item, index) => {
-          const isLast = index === blockItems.length - 1
+        <SortableList
+          items={sortableBlockItems}
+          onChange={handleReorderBlockItems}
+          renderItem={(sortableItem, isOverlay) => {
+            const { id, item } = sortableItem
+            // A trailing for-each, not a reorderable item, claims the "last
+            // step" slot when present.
+            const isLast = !forEachItem && id === lastReorderableId
 
-          if (item.type === 'ifThenBlock') {
+            if (item.type === 'ifThenBlock') {
+              return (
+                <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
+                  <IfThen
+                    block={item}
+                    isLastBlock={isLast}
+                    allowReorder={canReorderBlocks}
+                  />
+                </SortableList.Item>
+              )
+            }
+
             return (
-              <IfThen
-                key={item.ifThenStep.id}
-                block={item}
-                isLastBlock={isLast}
-              />
+              <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
+                <Flex
+                  width={isDrawerOpen || isMobile ? '100%' : 'auto'}
+                  flexDir="column"
+                  position="relative"
+                >
+                  <FlowStepWithAddButton
+                    step={item.step}
+                    isLastStep={isLast}
+                    isNested={isNested}
+                    allowReorder={canReorderBlocks}
+                    stepsBeforeGroup={[]}
+                    groupedSteps={[]}
+                    addButtonProps={{
+                      isHidden: readOnly || !!isOverlay,
+                      isDisabled: false,
+                      showEmptyAction: false,
+                    }}
+                  />
+                </Flex>
+              </SortableList.Item>
             )
-          }
+          }}
+        />
 
-          if (item.type === 'forEachBlock') {
-            // The for-each still renders through the existing grouped box, which
-            // wants the branch-shaped grouping. Rebuild it from the for-each's
-            // own steps — it swallows every later step, so they are contiguous
-            // from its position onwards.
-            const forEachIndex = actionStepsToDisplay.findIndex(
-              (step) => step.id === item.forEachStep.id,
-            )
-            return (
-              <FlowStepGroup
-                key={item.forEachStep.id}
-                stepsBeforeGroup={actionStepsToDisplay.slice(0, forEachIndex)}
-                groupedSteps={extractBranchesWithSteps(
-                  actionStepsToDisplay.slice(forEachIndex),
-                  0,
-                )}
-              />
-            )
-          }
-
-          return (
-            <FlowStepWithAddButton
-              key={item.step.id}
-              step={item.step}
-              isLastStep={isLast}
-              isNested={isNested}
-              allowReorder={false}
-              stepsBeforeGroup={[]}
-              groupedSteps={[]}
-              addButtonProps={{
-                isHidden: readOnly,
-                isDisabled: false,
-                showEmptyAction: false,
-              }}
-            />
-          )
-        })}
+        {forEachItem && (
+          // FlowStepGroup expects branch-shaped grouping, so the for-each's
+          // steps get rebuilt into that shape instead of rendered directly.
+          <FlowStepGroup
+            stepsBeforeGroup={actionStepsToDisplay.slice(0, forEachIndex)}
+            groupedSteps={extractBranchesWithSteps(
+              actionStepsToDisplay.slice(forEachIndex),
+              0,
+            )}
+          />
+        )}
       </Flex>
     )
   }

--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildStepsList,
   deriveIfThenV1EndStep,
+  hasEmptyIfThenV2Block,
   hasIfThenV2Block,
   isBlankPlaceholderStep,
   isStepInsideForEachBody,
@@ -555,6 +556,42 @@ describe('hasIfThenV2Block', () => {
     const b1 = plain('b1')
 
     expect(hasIfThenV2Block([ifThenA, block, b1])).toBe(true)
+  })
+})
+
+describe('hasEmptyIfThenV2Block', () => {
+  it('is true for an if-then whose marker self-references (an empty block)', () => {
+    const block = markedIfThen('block', 'block')
+
+    expect(hasEmptyIfThenV2Block([block])).toBe(true)
+  })
+
+  it('is false for an if-then whose marker points at a later child', () => {
+    const block = markedIfThen('block', 's2')
+    const s2 = plain('s2')
+
+    expect(hasEmptyIfThenV2Block([block, s2])).toBe(false)
+  })
+
+  it('is false for a marker-less if-then shaped like real GraphQL data', () => {
+    const ifThenA = nullMarkerIfThen('ifThenA')
+
+    expect(hasEmptyIfThenV2Block([ifThenA])).toBe(false)
+  })
+
+  it('is true when only the second of two blocks is empty', () => {
+    const populated = markedIfThen('populated', 's2')
+    const s2 = plain('s2')
+    const empty = markedIfThen('empty', 'empty')
+
+    expect(hasEmptyIfThenV2Block([populated, s2, empty])).toBe(true)
+  })
+
+  it('is false for a flow with no if-then step at all', () => {
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+
+    expect(hasEmptyIfThenV2Block([s1, s2])).toBe(false)
   })
 })
 

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -216,6 +216,20 @@ export function isStepInsideIfThenBlock(
 }
 
 /**
+ * Whether any if-then V2 block in the flow is empty. Mirrors the backend's
+ * `isIfThenV2` check: a block is empty when its `endStepId` marker points at
+ * itself.
+ *
+ * Takes the full `flow.steps`, not the MRF-filtered display list: a block on
+ * an approval branch that is not on screen must still block publish.
+ */
+export function hasEmptyIfThenV2Block(flowSteps: IStep[]): boolean {
+  return flowSteps.some(
+    (step) => isIfThenStep(step) && step.config?.endStepId === step.id,
+  )
+}
+
+/**
  * Whether `step` sits anywhere inside a for-each body (at any depth) — the
  * for-each step itself is not "inside" its own body.
  */

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -2,6 +2,7 @@ import { useContext, useMemo } from 'react'
 import { Skeleton, Spinner, Text } from '@chakra-ui/react'
 import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
 
+import { hasEmptyIfThenV2Block } from '@/components/Editor/helpers/steps-utils'
 import { EditorContext } from '@/contexts/Editor'
 import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 
@@ -36,6 +37,13 @@ export default function PublishButton({
     [flow?.steps],
   )
 
+  // The backend already refuses to publish a flow with an empty if-then V2
+  // block. Disable the button here too, so the user doesn't attempt it.
+  const hasEmptyIfThenBlock = useMemo(
+    () => hasEmptyIfThenV2Block(flow?.steps ?? []),
+    [flow?.steps],
+  )
+
   return (
     <TouchableTooltip
       label={
@@ -45,13 +53,18 @@ export default function PublishButton({
           ? 'You cannot publish a pipe with a pending transfer'
           : isFlowIncomplete
           ? 'Set up for all steps must be completed before you can publish your pipe'
+          : hasEmptyIfThenBlock
+          ? 'Your If-then has no steps in it'
           : ''
       }
       wrapperStyles={{ width: '100%' }}
     >
       <Button
         isDisabled={
-          isFlowIncomplete || hasFlowTransfer || flow.role === 'viewer'
+          isFlowIncomplete ||
+          hasEmptyIfThenBlock ||
+          hasFlowTransfer ||
+          flow.role === 'viewer'
         }
         isLoading={loading || isEditorContextLoading}
         spinner={<Spinner fontSize={24} />}

--- a/packages/frontend/src/components/FlowStep/__tests__/utils.test.ts
+++ b/packages/frontend/src/components/FlowStep/__tests__/utils.test.ts
@@ -1,0 +1,59 @@
+import type { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { shouldCreateEmptyStep } from '../utils'
+
+const plain = (id: string): IStep =>
+  ({ id, appKey: 'postman', key: 'sendTransactionalEmail' } as IStep)
+
+// A marker-less if-then (if-then V1) as the editor actually receives one: a
+// GraphQL response carries every field the query selected, so the marker is
+// present and null rather than absent. IStepConfig describes the backend's own
+// DB shape, where the key really is missing, hence the cast.
+const ifThenV1 = (id: string): IStep =>
+  ({
+    id,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    config: { endStepId: null },
+  } as unknown as IStep)
+
+// The same step with the key genuinely absent — what a locally built step looks
+// like before any round trip.
+const ifThenV1NoConfig = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'ifThen' } as IStep)
+
+const ifThenV2 = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'ifThen', config: { endStepId: id } } as IStep)
+
+describe('shouldCreateEmptyStep', () => {
+  it('is true when deleting the last step of an if-then V1 branch abutting the next branch', () => {
+    expect(shouldCreateEmptyStep(ifThenV1('a'), ifThenV1('b'))).toBe(true)
+  })
+
+  it('is true when deleting the last step of the last if-then V1 branch', () => {
+    expect(shouldCreateEmptyStep(ifThenV1('a'), undefined)).toBe(true)
+  })
+
+  it('is true for an if-then V1 whose config carries no marker key at all', () => {
+    expect(shouldCreateEmptyStep(ifThenV1NoConfig('a'), undefined)).toBe(true)
+  })
+
+  it('is false when a non-if-then step follows (not the last step in the branch)', () => {
+    expect(shouldCreateEmptyStep(ifThenV1('a'), plain('b'))).toBe(false)
+  })
+
+  it('is false when the previous step is not an if-then', () => {
+    expect(shouldCreateEmptyStep(plain('a'), ifThenV1('b'))).toBe(false)
+  })
+
+  it('is false when there is no previous step', () => {
+    expect(shouldCreateEmptyStep(undefined, ifThenV1('b'))).toBe(false)
+  })
+
+  it('is false when the previous step is an explicit if-then V2 block (its marker is repaired server-side)', () => {
+    expect(shouldCreateEmptyStep(ifThenV2('a'), ifThenV2('b'))).toBe(false)
+    expect(shouldCreateEmptyStep(ifThenV2('a'), undefined)).toBe(false)
+  })
+})

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -28,7 +28,7 @@ import StepAppIcon from './components/StepAppIcon'
 import StepNameAndDemo from './components/StepNameAndDemo'
 import TestAgainInfobox from './components/TestAgainInfobox'
 import FlowStepWrapper from './FlowStepWrapper'
-import { flowStepStyles } from './styles'
+import { flowStepStyles, NESTED_FLOW_STEP_HEIGHT } from './styles'
 
 type FlowStepProps = {
   step: IStep
@@ -357,7 +357,13 @@ export default function FlowStep(
                 shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
               }
               borderTopRadius={hasInfoBox ? 'none' : 'lg'}
-              h={isNested ? '56px' : isApprovalStep ? undefined : '64px'}
+              h={
+                isNested
+                  ? NESTED_FLOW_STEP_HEIGHT
+                  : isApprovalStep
+                  ? undefined
+                  : '64px'
+              }
               minH={isApprovalStep && !isNested ? '124px' : undefined}
               w={headerWidth}
               onClick={isClickable ? handleClick : undefined}

--- a/packages/frontend/src/components/FlowStep/styles.ts
+++ b/packages/frontend/src/components/FlowStep/styles.ts
@@ -1,5 +1,10 @@
 import { FlexProps } from '@chakra-ui/react'
 
+// Exported so a container that must align with a nested step it owns — an
+// if-then V2 block levelling its drag handle with its header — stays in sync
+// with the card's real height.
+export const NESTED_FLOW_STEP_HEIGHT = '56px'
+
 export const flowStepStyles = {
   container: {
     alignItems: 'center',

--- a/packages/frontend/src/components/FlowStep/utils.ts
+++ b/packages/frontend/src/components/FlowStep/utils.ts
@@ -22,9 +22,21 @@ function findAdjacentSteps(
  *    which means that the step being deleted is the 'last' step in the if-then group
  * 2. The previous step is an if-then step and there is no next step,
  *    which means that the step being deleted is the 'last' step in the group
+ *
+ * An explicit if-then V2 block is an exception: the backend repairs its
+ * `endStepId` marker when a member is deleted, so this skips placeholder
+ * injection for it. The check uses `!= null`, not `Object.hasOwn`, because a
+ * marker-less if-then arrives over GraphQL with `endStepId: null` rather than
+ * the key being absent.
  */
 function shouldCreateEmptyStep(prev?: IStep, next?: IStep): boolean {
-  return !!prev && isIfThenStep(prev) && (!next || isIfThenStep(next))
+  if (!prev || !isIfThenStep(prev)) {
+    return false
+  }
+  if (prev.config?.endStepId != null) {
+    return false
+  }
+  return !next || isIfThenStep(next)
 }
 
 export { findAdjacentSteps, shouldCreateEmptyStep }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -25,7 +25,7 @@ import { groupBy } from 'lodash'
 
 import { getAppActionFlag, getAppFlag } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
-import { TOOLBOX_APP_KEY, useIfThenInitializer } from '@/helpers/toolbox'
+import { TOOLBOX_APP_KEY, useIfThenV1Initializer } from '@/helpers/toolbox'
 
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import { useIsAppSelectable } from '../hooks/useIsAppSelectable'
@@ -54,7 +54,7 @@ export default function ChooseApp(props: ChooseAppProps) {
     prevStepId,
   })
 
-  const [_, isInitializingIfThen] = useIfThenInitializer()
+  const [_, isInitializingIfThen] = useIfThenV1Initializer()
   const isLoading = isInitializingIfThen
 
   const [searchQuery, setSearchQuery] = useState('')

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -12,8 +12,10 @@ import { getMrfApprovalConfig } from '@/helpers/formsg'
 import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
-  useIfThenInitializer,
+  useIfThenV1Initializer,
+  useIfThenV2Initializer,
 } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 import {
   APP_ALLOWING_EMPTY_CONNECTION,
@@ -63,7 +65,9 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
 
   const [fetchAppConnections] = useLazyQuery(GET_APP_CONNECTIONS)
 
-  const [initializeIfThen] = useIfThenInitializer()
+  const { isEnabled: isIfThenV2Enabled } = useIfThenV2Enabled()
+  const [initializeIfThenV1] = useIfThenV1Initializer()
+  const [initializeIfThenV2] = useIfThenV2Initializer()
 
   /**
    * Note: App without connections will skip the connection modal screen (custom-api included)
@@ -130,6 +134,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             triggerOrAction.key,
             systemConnection?.id || undefined,
             approvalConfig && { approval: approvalConfig },
+            { isIfThenV2Enabled },
           )
           newStepId = createdStep.id
         } else if (step) {
@@ -139,6 +144,9 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             app.key === TOOLBOX_APP_KEY &&
             triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
           ) {
+            const initializeIfThen = isIfThenV2Enabled
+              ? initializeIfThenV2
+              : initializeIfThenV1
             const ifThen = await initializeIfThen(step)
             newStepId = ifThen.id
           } else {
@@ -175,7 +183,9 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       setCurrentStepId,
       approvalBranches,
       onCreateStep,
-      initializeIfThen,
+      isIfThenV2Enabled,
+      initializeIfThenV1,
+      initializeIfThenV2,
       onUpdateStep,
     ],
   )

--- a/packages/frontend/src/components/FlowStepConfigurationModal/LoadingOverlay.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/LoadingOverlay.tsx
@@ -1,14 +1,14 @@
 import { useContext } from 'react'
 import { Box, Spinner } from '@chakra-ui/react'
 
-import { useIfThenInitializer } from '@/helpers/toolbox'
+import { useIfThenV1Initializer } from '@/helpers/toolbox'
 
 import { FlowStepConfigurationContext } from './FlowStepConfigurationContext'
 
 export default function LoadingOverlay(): JSX.Element {
   const { modalState } = useContext(FlowStepConfigurationContext)
   const { isLoading } = modalState
-  const [_, isInitializingIfThen] = useIfThenInitializer()
+  const [_, isInitializingIfThen] = useIfThenV1Initializer()
 
   const isModalLoading = isLoading || isInitializingIfThen
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -3,11 +3,16 @@ import { IStep } from '@plumber/types'
 import { useContext, useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
-import { buildStepsList } from '@/components/Editor/helpers/steps-utils'
+import {
+  buildStepsList,
+  type IfThenBlock,
+  type SingleStep,
+} from '@/components/Editor/helpers/steps-utils'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
@@ -22,7 +27,7 @@ interface ForEachProps {
 
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
-  const { flow } = useContext(EditorContext)
+  const { flow, readOnly } = useContext(EditorContext)
   const { groupingActions } = useContext(StepsToDisplayContext)
   const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
     useIfThenV2Enabled()
@@ -70,6 +75,65 @@ export default function ForEach(props: ForEachProps) {
     }
   }
 
+  // Every non-condition step in the body shares one reorder domain, matching
+  // the top-level list — a plain step immediately next to an if-then V2
+  // block must be able to swap with it, not be stuck in a separate list. A
+  // block still reorders as one sortable unit; its children only reorder
+  // within the block's own SortableList (in IfThen), never into this one.
+  const bodySteps = useMemo(() => groupedSteps.flat().slice(1), [groupedSteps])
+
+  const ifThenBlockItems = useMemo(() => {
+    if (!isIfThenV2Enabled || bodySteps.length === 0) {
+      return []
+    }
+    return buildStepsList(
+      bodySteps,
+      groupingActions ?? new Set<string>(),
+    ).filter(
+      (item): item is IfThenBlock | SingleStep => item.type !== 'forEachBlock',
+    )
+  }, [isIfThenV2Enabled, bodySteps, groupingActions])
+
+  const hasIfThenBlockItem = ifThenBlockItems.some(
+    (item) => item.type === 'ifThenBlock',
+  )
+
+  const sortableBlockItems = useMemo(
+    () =>
+      ifThenBlockItems.map((item) => ({
+        id: item.type === 'ifThenBlock' ? item.ifThenStep.id : item.step.id,
+        item,
+      })),
+    [ifThenBlockItems],
+  )
+  const canReorderBlocks = !readOnly && ifThenBlockItems.length > 1
+  const lastBlockItemId = sortableBlockItems[sortableBlockItems.length - 1]?.id
+
+  const handleReorderBlockItems = async (
+    reordered: Array<{ id: string; item: IfThenBlock | SingleStep }>,
+  ) => {
+    const reorderedSteps = reordered.flatMap(({ item }) =>
+      item.type === 'ifThenBlock'
+        ? [item.ifThenStep, ...item.children]
+        : [item.step],
+    )
+    const stepPositions = reorderedSteps.map((step, index) => ({
+      id: step.id,
+      position: conditionStep.position + index + 1,
+      type: step.type as StepEnumType,
+    }))
+
+    try {
+      handleReorderUpdate(stepPositions)
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
   return (
     <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
       <Flex flexDir="column" w="100%" px={4} py={3}>
@@ -79,79 +143,91 @@ export default function ForEach(props: ForEachProps) {
           isLastStep={hasNoActionSteps}
           allowReorder={false}
           showEmptyAction={hasNoActionSteps}
-          canChildStepsReorder={actionSteps.length > 1}
+          // True when either sibling list has a reorderable item, so the
+          // header still reserves width for that item's drag handle.
+          canChildStepsReorder={actionSteps.length > 1 || canReorderBlocks}
         />
-        <SortableList
-          items={actionSteps.map((step, index) => ({
-            id: step.id,
-            step,
-            index,
-          }))}
-          onChange={handleReorderSteps}
-          renderItem={(item, isOverlay) => {
-            const { step, index } = item
-            const isLastStep =
-              index === actionSteps.length - 1 && ifThenSteps.length === 0
-            return (
-              <SortableList.Item id={item.id}>
-                <Flex w="100%" flexDir="column">
-                  <GroupStepWithAddButton
-                    step={step}
-                    canAddStep={true}
-                    isLastStep={isLastStep}
-                    isOverlay={isOverlay}
-                    allowReorder={actionSteps.length > 1}
-                  />
-                </Flex>
-              </SortableList.Item>
-            )
-          }}
-        />
-
-        {ifThenSteps.length > 0 &&
-          !isIfThenV2Loading &&
-          (isIfThenV2Enabled ? (
-            <Flex flexDir="column" w="100%" gap={2}>
-              {buildStepsList(
-                ifThenSteps.flat(),
-                groupingActions ?? new Set<string>(),
-              ).map((item, index, items) => {
-                const isLastItem = index === items.length - 1
+        {isIfThenV2Enabled ? (
+          <Flex
+            flexDir="column"
+            w="100%"
+            gap={hasIfThenBlockItem ? 2 : undefined}
+          >
+            <SortableList
+              items={sortableBlockItems}
+              onChange={handleReorderBlockItems}
+              renderItem={(sortableItem, isOverlay) => {
+                const { id, item } = sortableItem
+                const isLastItem = id === lastBlockItemId
 
                 if (item.type === 'ifThenBlock') {
                   return (
-                    <IfThen
-                      key={item.ifThenStep.id}
-                      block={item}
-                      isLastBlock={isLastItem}
-                    />
+                    <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
+                      <IfThen
+                        block={item}
+                        isLastBlock={isLastItem}
+                        allowReorder={canReorderBlocks}
+                      />
+                    </SortableList.Item>
                   )
                 }
 
-                if (item.type === 'step') {
-                  // A plain step between/after if-then V2 blocks in the body —
-                  // an explicit endStepId marker can end a block before the
-                  // body's last step, unlike a derived if-then V1 extent.
-                  return (
-                    <GroupStepWithAddButton
-                      key={item.step.id}
-                      step={item.step}
-                      canAddStep={true}
-                      isLastStep={isLastItem}
-                      allowReorder={false}
-                    />
-                  )
-                }
-
-                return null
-              })}
-            </Flex>
-          ) : (
-            <FlowStepGroup
-              stepsBeforeGroup={forEachSteps}
-              groupedSteps={ifThenSteps}
+                // A plain step around if-then V2 blocks in the body — an
+                // explicit endStepId marker can end a block before the
+                // body's last step, unlike a derived if-then V1 extent.
+                return (
+                  <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
+                    <Flex w="100%" flexDir="column">
+                      <GroupStepWithAddButton
+                        step={item.step}
+                        canAddStep={true}
+                        isLastStep={isLastItem}
+                        isOverlay={isOverlay}
+                        allowReorder={canReorderBlocks}
+                      />
+                    </Flex>
+                  </SortableList.Item>
+                )
+              }}
             />
-          ))}
+          </Flex>
+        ) : (
+          <>
+            <SortableList
+              items={actionSteps.map((step, index) => ({
+                id: step.id,
+                step,
+                index,
+              }))}
+              onChange={handleReorderSteps}
+              renderItem={(item, isOverlay) => {
+                const { step, index } = item
+                const isLastStep =
+                  index === actionSteps.length - 1 && ifThenSteps.length === 0
+                return (
+                  <SortableList.Item id={item.id}>
+                    <Flex w="100%" flexDir="column">
+                      <GroupStepWithAddButton
+                        step={step}
+                        canAddStep={true}
+                        isLastStep={isLastStep}
+                        isOverlay={isOverlay}
+                        allowReorder={actionSteps.length > 1}
+                      />
+                    </Flex>
+                  </SortableList.Item>
+                )
+              }}
+            />
+
+            {ifThenSteps.length > 0 && !isIfThenV2Loading && (
+              <FlowStepGroup
+                stepsBeforeGroup={forEachSteps}
+                groupedSteps={ifThenSteps}
+              />
+            )}
+          </>
+        )}
       </Flex>
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -1,29 +1,48 @@
 import { IStep } from '@plumber/types'
 
-import { useContext } from 'react'
-import { Divider, Flex } from '@chakra-ui/react'
+import {
+  type MouseEventHandler,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react'
+import { BiDuplicate, BiTrash } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import { Box, Divider, Flex, useDisclosure } from '@chakra-ui/react'
+import { IconButton } from '@opengovsg/design-system-react'
 
+import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
 import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
 import {
   type IfThenBlock,
   isBlankPlaceholderStep,
 } from '@/components/Editor/helpers/steps-utils'
+import { NESTED_FLOW_STEP_HEIGHT } from '@/components/FlowStep/styles'
+import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { DELETE_STEP } from '@/graphql/mutations/delete-step'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
 import useReorderSteps from '@/hooks/useReorderSteps'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
 import { flowStepGroupStyles } from '../../styles'
 
 import { HoverAddStepButton } from './HoverAddStepButton'
-import { branchStyles } from './styles'
+import { blockActionButtonStyles, branchStyles } from './styles'
+import useDuplicateBranch from './useDuplicateBranch'
 
 interface IfThenProps {
   block: IfThenBlock
   isLastBlock: boolean
+  // IMPORTANT: only meaningful when the block renders inside a top-level
+  // SortableList.Item. That's what gives it a drag handle at all.
+  allowReorder?: boolean
 }
 
 interface ReorderItem {
@@ -36,16 +55,25 @@ interface ReorderItem {
  * Drawn as the same grouped box as an if-then V1 group, despite having only
  * one branch, so the two variants read as the same thing in the editor.
  *
- * IMPORTANT: block-level affordances (add-after-block, delete/duplicate) are
- * not wired here.
+ * The interior reuses the shared display building blocks, so a step's own
+ * add/reorder affordances behave exactly as they do elsewhere in the editor.
  */
 export default function IfThen({
   block,
   isLastBlock,
+  allowReorder = false,
 }: IfThenProps): JSX.Element {
   const { ifThenStep, children } = block
-  const { currentStepId, flow, isDrawerOpen, isMobile, readOnly } =
-    useContext(EditorContext)
+  const {
+    currentStepId,
+    flow,
+    isDrawerOpen,
+    isMobile,
+    readOnly,
+    onDrawerClose,
+    setCurrentStepId,
+    shouldWarnOnLeave,
+  } = useContext(EditorContext)
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 
   const isEmptyBlock = children.length === 0
@@ -65,6 +93,90 @@ export default function IfThen({
   const branchName = ifThenStep.parameters?.branchName as string | undefined
   const headerLabel =
     stepName ?? (branchName ? `If-then: ${branchName}` : 'If-then')
+
+  // IMPORTANT: assumes allowReorder already excludes read-only. The caller
+  // (StepsList) folds that in before passing it down.
+  const showDragHandle = allowReorder && !isDrawerOpen && !isMobile
+
+  // Whole-block delete. An explicit if-then V2 block sends just the if-then's
+  // id, and the backend expands that to the block's range. An if-then V1
+  // block still sends its derived member ids directly.
+  const {
+    isOpen: deleteConfirmationIsOpen,
+    onOpen: openDeleteConfirmationImpl,
+    onClose: closeDeleteConfirmation,
+  } = useDisclosure()
+  const cancelDeleteButton = useRef<HTMLButtonElement>(null)
+  const [deleteStep, { loading: isDeletingBlock }] = useMutation(DELETE_STEP, {
+    refetchQueries: [GET_FLOW],
+  })
+  const openDeleteConfirmation = useCallback<MouseEventHandler>(
+    (e) => {
+      e.stopPropagation()
+      openDeleteConfirmationImpl()
+    },
+    [openDeleteConfirmationImpl],
+  )
+  const deleteBlock = useCallback(async () => {
+    const idsToDelete = block.isExplicit
+      ? [ifThenStep.id]
+      : [ifThenStep.id, ...children.map((step) => step.id)]
+    await deleteStep({
+      variables: {
+        input: { ids: idsToDelete, flow: { updatedAt: flow.updatedAt } },
+      },
+    })
+
+    setCurrentStepId(null)
+    closeDeleteConfirmation()
+    onDrawerClose()
+  }, [
+    block.isExplicit,
+    ifThenStep.id,
+    children,
+    deleteStep,
+    flow.updatedAt,
+    setCurrentStepId,
+    closeDeleteConfirmation,
+    onDrawerClose,
+  ])
+
+  // Whole-block duplicate via DUPLICATE_BRANCH, passing the block's steps
+  // with endStep as the previous step. The backend re-derives the marker, so
+  // none is sent from the client.
+  const blockSteps = useMemo(
+    () => [ifThenStep, ...children],
+    [ifThenStep, children],
+  )
+  const cancelDuplicateButton = useRef<HTMLButtonElement>(null)
+  const {
+    canDuplicateBranch,
+    duplicateConfirmationIsOpen,
+    isDuplicatingBranch,
+    closeDuplicateConfirmation,
+    duplicateBranch,
+    openDuplicateConfirmation,
+  } = useDuplicateBranch(blockSteps)
+
+  // We only warn on unsaved changes when duplicating, to ensure the latest
+  // changes are saved before the copy is derived.
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: openDuplicateConfirmation,
+  })
+  const onDuplicate = useCallback(() => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      handleProceed()
+    }
+  }, [handleProceed, onWarningOpen, shouldWarnOnLeave])
 
   const handleReorderSteps = async (items: ReorderItem[]) => {
     const stepPositions = items.map((item, index) => ({
@@ -92,148 +204,243 @@ export default function IfThen({
         justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
       >
         <Flex
-          {...flowStepGroupStyles.container}
-          display={isMobile ? 'block' : 'flex'}
+          pos="relative"
+          alignItems="center"
           w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
           minW={MIN_FLOW_STEP_WIDTH}
-          // The header and branch run edge to edge, so the box clips them to its
-          // own rounded corners.
-          overflow="hidden"
-          // The box carries the selected-state border its flush header drops.
-          borderColor={
-            currentStepId === ifThenStep.id
-              ? 'base.content.brand'
-              : 'base.divider.medium'
-          }
         >
-          {/*
-            The header stands in for the whole block, not a step of its own to
-            configure. So it takes the block's name and drops click-to-configure
-            and its own border, letting the box read as one step rather than a
-            card holding cards.
-          */}
-          <FlowStep
-            step={ifThenStep}
-            stepNameOverride={headerLabel}
-            isContainerHeader
-            isClickable={false}
-            isNested={true}
-            isLastStep={isEmptyBlock}
-            allowReorder={false}
-          />
-
-          {/*
-            The condition step renders again here as a normal card, matching
-            how an if-then V1 branch draws its condition card and steps in one
-            panel. An empty block keeps this panel and placeholder rather than
-            looking like a different component.
-
-            The panel is white, not branchStyles.container's usual grey, since
-            a single-branch box doesn't need to visually separate branches the
-            way an if-then V1 group's side-by-side branches do.
-          */}
           <Flex
-            {...branchStyles.container}
-            bg="white"
-            borderRadius="none"
-            // pb drops by the placeholder's own 4px bottom margin so the
-            // empty-block panel stays evenly padded overall.
-            pb={isEmptyBlock ? 2 : 3}
+            {...flowStepGroupStyles.container}
+            display={isMobile ? 'block' : 'flex'}
+            w="100%"
+            // The header and branch run edge to edge, so the box clips them to
+            // its own rounded corners.
+            overflow="hidden"
+            // The box carries the selected-state border its flush header drops.
+            borderColor={
+              currentStepId === ifThenStep.id
+                ? 'base.content.brand'
+                : 'base.divider.medium'
+            }
           >
-            <Flex w="100%" flexDir="column">
-              {/*
-                This is the same condition step the header above renders, now
-                as a normal, clickable card. It drops its own name and
-                position number since the header already carries both.
-              */}
+            {/*
+              The header stands in for the whole block, not a step of its own to
+              configure. So it takes the block's name and drops click-to-configure
+              and its own border, letting the box read as one step rather than a
+              card holding cards.
+
+              Delete/duplicate are overlaid on the header's trailing edge
+              instead of laid out beside it, since hidden-until-hover buttons
+              would otherwise reserve width and pull the header in. They're
+              siblings of the header rather than children, so a click on them
+              never bubbles into the condition card's open-the-drawer handler.
+
+              Being overlaid means they sit outside the header's own padding, so
+              they re-create a step's trailing inset and button metrics
+              themselves (see FlowStep's header) to line up with the delete icon
+              of the steps above and below the block.
+            */}
+            <Flex alignItems="center" w="100%" role="group" pos="relative">
               <FlowStep
                 step={ifThenStep}
-                stepNameOverride="Condition"
-                hideDisplayPosition
+                stepNameOverride={headerLabel}
+                isContainerHeader
+                isClickable={false}
                 isNested={true}
-                isLastStep={false}
+                isLastStep={isEmptyBlock}
                 allowReorder={false}
-                // Matches the width sibling cards give up for their own drag
-                // handles, exactly as an if-then V1 branch's condition card
-                // does, so the condition card isn't wider than the cards below
-                // it.
-                canChildStepsReorder={children.length > 1}
               />
 
-              {isEmptyBlock ? (
-                // The placeholder card is `w="100%"`, which only resolves to the
-                // panel's width because this column stretches it; left to the
-                // block box, whose items are centred, it would shrink to fit its
-                // own text.
-                <HoverAddStepButton
-                  isDisabled={readOnly}
-                  isDrawerOpen={isDrawerOpen}
-                  isLastStep={true}
-                  prevStep={ifThenStep}
-                  showEmptyAction={true}
-                  step={ifThenStep}
-                  allowReorder={false}
-                />
-              ) : (
-                <>
-                  {/*
-                    Every other card-to-card transition in this panel has a
-                    connector; the condition card is no exception, so a
-                    populated block can insert a step directly after it too.
-                  */}
-                  <HoverAddStepButton
-                    // Reuses isDisabled for the sole-blank-placeholder edge
-                    // case (see isSoleBlankPlaceholder). pointerEvents: none
-                    // keeps the connector but makes the hover-+ itself inert.
-                    isDisabled={readOnly || isSoleBlankPlaceholder}
-                    isDrawerOpen={isDrawerOpen}
-                    isLastStep={false}
-                    prevStep={ifThenStep}
-                    step={ifThenStep}
-                    allowReorder={false}
-                    canChildStepsReorder={children.length > 1}
+              {!readOnly && (
+                <Flex
+                  pos="absolute"
+                  top={0}
+                  bottom={0}
+                  // The inset and gap a step's header gives its own
+                  // duplicate/delete pair. Insetting the overlay rather than
+                  // padding it keeps the strip beside the buttons part of the
+                  // header, so clicking there still opens the drawer.
+                  right={4}
+                  gap={1}
+                  alignItems="center"
+                  opacity={{ base: 1, lg: 0 }}
+                  _groupHover={{ opacity: 1 }}
+                >
+                  {canDuplicateBranch && (
+                    <IconButton
+                      {...blockActionButtonStyles}
+                      onClick={onDuplicate}
+                      aria-label="Duplicate if-then"
+                      icon={<BiDuplicate />}
+                      isLoading={isDuplicatingBranch}
+                      isDisabled={isDuplicatingBranch || isDeletingBlock}
+                    />
+                  )}
+                  <IconButton
+                    {...blockActionButtonStyles}
+                    onClick={openDeleteConfirmation}
+                    aria-label="Delete if-then"
+                    icon={<BiTrash />}
+                    isLoading={isDeletingBlock}
+                    isDisabled={isDeletingBlock || isDuplicatingBranch}
                   />
-                  <SortableList
-                    items={children.map((step, index) => ({
-                      id: step.id,
-                      step,
-                      index,
-                    }))}
-                    onChange={handleReorderSteps}
-                    renderItem={(item, isOverlay) => {
-                      const { step, index } = item
-                      const isLastStep = index === children.length - 1
-
-                      // Every step, last one included, gets the same hover +
-                      // to append after it — matching how a for-each body
-                      // (and an if-then V1 branch) appends, rather than the
-                      // last step handing off to its own separate,
-                      // always-visible "Add step" card.
-                      return (
-                        <SortableList.Item id={item.id}>
-                          <Flex w="100%" flexDir="column">
-                            <GroupStepWithAddButton
-                              step={step}
-                              // Same sole-blank-placeholder edge case as the
-                              // leading HoverAddStepButton above: no
-                              // trailing hover-+ after it either, so the
-                              // card reads as an empty block's own
-                              // add-first-step placeholder rather than a
-                              // populated block's last member.
-                              canAddStep={!isSoleBlankPlaceholder}
-                              isLastStep={isLastStep}
-                              isOverlay={isOverlay}
-                              allowReorder={children.length > 1}
-                            />
-                          </Flex>
-                        </SortableList.Item>
-                      )
-                    }}
-                  />
-                </>
+                </Flex>
               )}
             </Flex>
+
+            {/*
+              The condition step renders again here as a normal card, matching
+              how an if-then V1 branch draws its condition card and steps in one
+              panel. An empty block keeps this panel and placeholder rather than
+              looking like a different component.
+
+              The panel is white, not branchStyles.container's usual grey, since
+              a single-branch box doesn't need to visually separate branches the
+              way an if-then V1 group's side-by-side branches do.
+            */}
+            <Flex
+              {...branchStyles.container}
+              bg="white"
+              borderRadius="none"
+              // pb drops by the placeholder's own 4px bottom margin so the
+              // empty-block panel stays evenly padded overall.
+              pb={isEmptyBlock ? 2 : 3}
+            >
+              <Flex w="100%" flexDir="column">
+                {/*
+                  This is the same condition step the header above renders, now
+                  as a normal, clickable card. It drops its own name and
+                  position number since the header already carries both.
+                */}
+                <FlowStep
+                  step={ifThenStep}
+                  stepNameOverride="Condition"
+                  hideDisplayPosition
+                  isNested={true}
+                  isLastStep={false}
+                  allowReorder={false}
+                  // Matches the width sibling cards give up for their own drag
+                  // handles, exactly as an if-then V1 branch's condition card
+                  // does, so the condition card isn't wider than the cards
+                  // below it.
+                  canChildStepsReorder={children.length > 1}
+                />
+
+                {isEmptyBlock ? (
+                  // The placeholder card is `w="100%"`, which only resolves to the
+                  // panel's width because this column stretches it; left to the
+                  // block box, whose items are centred, it would shrink to fit its
+                  // own text.
+                  <HoverAddStepButton
+                    isDisabled={readOnly}
+                    isDrawerOpen={isDrawerOpen}
+                    isLastStep={true}
+                    prevStep={ifThenStep}
+                    showEmptyAction={true}
+                    step={ifThenStep}
+                    allowReorder={false}
+                  />
+                ) : (
+                  <>
+                    {/*
+                      Every other card-to-card transition in this panel has a
+                      connector; the condition card is no exception, so a
+                      populated block can insert a step directly after it too.
+                    */}
+                    <HoverAddStepButton
+                      // Reuses isDisabled for the sole-blank-placeholder edge
+                      // case (see isSoleBlankPlaceholder). pointerEvents: none
+                      // keeps the connector but makes the hover-+ itself inert.
+                      isDisabled={readOnly || isSoleBlankPlaceholder}
+                      isDrawerOpen={isDrawerOpen}
+                      isLastStep={false}
+                      prevStep={ifThenStep}
+                      step={ifThenStep}
+                      allowReorder={false}
+                      canChildStepsReorder={children.length > 1}
+                    />
+                    <SortableList
+                      items={children.map((step, index) => ({
+                        id: step.id,
+                        step,
+                        index,
+                      }))}
+                      onChange={handleReorderSteps}
+                      renderItem={(item, isOverlay) => {
+                        const { step, index } = item
+                        const isLastStep = index === children.length - 1
+
+                        // Every step, last one included, gets the same hover +
+                        // to append after it — matching how a for-each body
+                        // (and an if-then V1 branch) appends, rather than the
+                        // last step handing off to its own separate,
+                        // always-visible "Add step" card.
+                        return (
+                          <SortableList.Item id={item.id}>
+                            <Flex w="100%" flexDir="column">
+                              <GroupStepWithAddButton
+                                step={step}
+                                // Same sole-blank-placeholder edge case as
+                                // the leading HoverAddStepButton above: no
+                                // trailing hover-+ after it either, so the
+                                // card reads as an empty block's own
+                                // add-first-step placeholder rather than a
+                                // populated block's last member.
+                                canAddStep={!isSoleBlankPlaceholder}
+                                isLastStep={isLastStep}
+                                isOverlay={isOverlay}
+                                allowReorder={children.length > 1}
+                              />
+                            </Flex>
+                          </SortableList.Item>
+                        )
+                      }}
+                    />
+                  </>
+                )}
+              </Flex>
+            </Flex>
+
+            <MenuAlertDialog
+              isDialogOpen={deleteConfirmationIsOpen}
+              cancelRef={cancelDeleteButton}
+              onDialogClose={closeDeleteConfirmation}
+              dialogHeader="If-then"
+              dialogType="delete"
+              onClick={deleteBlock}
+              isLoading={isDeletingBlock}
+            />
+
+            <MenuAlertDialog
+              isDialogOpen={duplicateConfirmationIsOpen}
+              cancelRef={cancelDuplicateButton}
+              onDialogClose={closeDuplicateConfirmation}
+              dialogHeader="If-then"
+              dialogType="duplicate-branch"
+              onClick={duplicateBranch}
+              isLoading={isDuplicatingBranch}
+            />
+
+            <UnsavedChangesAlert
+              cancelRef={cancelRef}
+              isOpen={isWarningOpen}
+              onClose={onWarningClose}
+              onLeave={discardChanges}
+            />
           </Flex>
+
+          {/*
+            Positioned outside the box (not laid out inside the header)
+            because the box clips overflow, and an inline handle here would
+            eat into the header's title.
+          */}
+          {showDragHandle && (
+            <Box pos="absolute" left="100%" top={0} h={NESTED_FLOW_STEP_HEIGHT}>
+              <Flex alignItems="center" h="100%">
+                <SortableList.DragHandle />
+              </Flex>
+            </Box>
+          )}
         </Flex>
       </Flex>
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -29,6 +29,19 @@ export const ifThenStyles = {
   },
 }
 
+/**
+ * `boxSize` alone isn't enough: IconButton's own size sets a larger
+ * min-width/min-height that wins, so both are pinned here too — the same way
+ * DeleteStepButton does for a step.
+ */
+export const blockActionButtonStyles = {
+  boxSize: 8,
+  minW: 8,
+  minH: 8,
+  variant: 'clear',
+  colorScheme: 'secondary',
+}
+
 export const branchStyles = {
   container: {
     alignItems: 'center',

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -33,12 +33,19 @@ import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-s
 import {
   isForEachStep,
   isIfThenStep,
+  SELF_END_STEP_SENTINEL,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
-  useIfThenInitializer,
+  useIfThenV1Initializer,
 } from '@/helpers/toolbox'
 import { extractVariables, StepWithVariables } from '@/helpers/variables'
 import { useApps } from '@/hooks/useApps'
+
+interface OnCreateStepOptions {
+  // The caller resolves the owner-scoped flag and passes it here; the
+  // provider component can't read it itself.
+  isIfThenV2Enabled?: boolean
+}
 
 interface IEditorContextValue {
   flow: IFlow
@@ -74,6 +81,7 @@ interface IEditorContextValue {
     eventKey: string,
     connectionId?: string,
     config?: IStepConfig,
+    options?: OnCreateStepOptions,
   ) => Promise<IStep>
   onUpdateStep: (step: IStep, onCompleted?: () => void) => Promise<IStep>
   allApps: IApp[]
@@ -198,7 +206,10 @@ export const EditorProvider = ({
     refetchQueries: [GET_FLOW],
   })
 
-  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
+  // The caller (a flag-aware modal consumer) tells onCreateStep which one to
+  // use, since the provider component can't read its own EditorContext to
+  // evaluate the flag.
+  const [initializeIfThenV1, isInitializingIfThenV1] = useIfThenV1Initializer()
 
   // Add a step to the flow with the given appKey and eventKey
   const onCreateStep = useCallback(
@@ -208,7 +219,12 @@ export const EditorProvider = ({
       eventKey: string,
       connectionId?: string,
       config?: IStepConfig,
+      options?: OnCreateStepOptions,
     ) => {
+      const isIfThen =
+        appKey === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen
+      const isIfThenV2Creation = isIfThen && !!options?.isIfThenV2Enabled
+
       const mutationInput = {
         previousStep: {
           id: previousStepId,
@@ -220,7 +236,13 @@ export const EditorProvider = ({
         appKey,
         key: eventKey,
         connection: { id: connectionId },
-        config,
+        // The real id doesn't exist until after insert, so the backend
+        // resolves the sentinel into a self-reference in the same createStep
+        // transaction — no separate updateStep round-trip, no marker-absent
+        // window.
+        config: isIfThenV2Creation
+          ? { ...config, endStepId: SELF_END_STEP_SENTINEL }
+          : config,
       }
 
       const createdStep = await createStep({
@@ -230,16 +252,17 @@ export const EditorProvider = ({
       let newStep = createdStep.data.createStep
       setCurrentStepId(newStep.id)
 
-      // account for the for-each and if-then
-      if (appKey === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen) {
-        newStep = await initializeIfThen(newStep)
+      // if-then V1 still needs its two-branch setup after creation; V2
+      // self-refs in the same createStep call above.
+      if (isIfThen && !isIfThenV2Creation) {
+        newStep = await initializeIfThenV1(newStep)
       }
       // we refetch GET_FLOW after everything is completed
       await client.refetchQueries({ include: [GET_FLOW] })
 
       return newStep as IStep
     },
-    [createStep, flow, flowId, initializeIfThen],
+    [createStep, flow, flowId, initializeIfThenV1],
   )
 
   /**
@@ -391,7 +414,7 @@ export const EditorProvider = ({
           isLoadingTestExecutionSteps ||
           isCreatingStep ||
           isUpdatingStep ||
-          isInitializingIfThen,
+          isInitializingIfThenV1,
         hasFlowTransfer,
       }}
     >

--- a/packages/frontend/src/helpers/__tests__/toolbox.test.ts
+++ b/packages/frontend/src/helpers/__tests__/toolbox.test.ts
@@ -2,7 +2,10 @@ import { IStep } from '@plumber/types'
 
 import { describe, expect, it } from 'vitest'
 
-import { isOnlyContinueIfStep } from '@/helpers/toolbox'
+import {
+  extractBranchesWithSteps,
+  isOnlyContinueIfStep,
+} from '@/helpers/toolbox'
 
 function makeStep(overrides: Partial<IStep> = {}): IStep {
   return {
@@ -15,6 +18,23 @@ function makeStep(overrides: Partial<IStep> = {}): IStep {
     config: {},
     ...overrides,
   } as IStep
+}
+
+function makeIfThenV1Step(overrides: Partial<IStep> = {}): IStep {
+  return makeStep({
+    key: 'ifThen',
+    parameters: { depth: '0', branchName: 'Branch 1' },
+    ...overrides,
+  })
+}
+
+function makeIfThenV2Step(id: string, endStepId: string = id): IStep {
+  return makeStep({
+    id,
+    key: 'ifThen',
+    parameters: { branchName: 'data == 1', conditions: [] },
+    config: { endStepId },
+  })
 }
 
 describe('isOnlyContinueIfStep', () => {
@@ -32,5 +52,64 @@ describe('isOnlyContinueIfStep', () => {
 
   it('is false for a non-toolbox step with the same key', () => {
     expect(isOnlyContinueIfStep(makeStep({ appKey: 'formsg' }))).toBe(false)
+  })
+})
+
+describe('extractBranchesWithSteps', () => {
+  it('splits off a same-depth if-then V1 branch', () => {
+    const forEachStep = makeStep({ id: 'for-each', key: 'forEach' })
+    const plainStep = makeStep({ id: 'plain', position: 3 })
+    const ifThenStep = makeIfThenV1Step({ id: 'if-then-v1', position: 4 })
+    const childStep = makeStep({ id: 'child', position: 5 })
+
+    expect(
+      extractBranchesWithSteps(
+        [forEachStep, plainStep, ifThenStep, childStep],
+        0,
+      ),
+    ).toEqual([
+      [forEachStep, plainStep],
+      [ifThenStep, childStep],
+    ])
+  })
+
+  // A V2 if-then never sets parameters.depth (config.endStepId carries its
+  // extent instead), so it always parses to NaN depth — the same shape as a
+  // just-chosen, not-yet-configured if-then, which this function folds into
+  // the current branch rather than splitting. Without checking the marker, a
+  // V2 if-then nested in a for-each body never gets split off, so it renders
+  // as a plain step instead of its block UI.
+  it('splits off an if-then V2 step despite its unset parameters.depth', () => {
+    const forEachStep = makeStep({ id: 'for-each', key: 'forEach' })
+    const plainStep = makeStep({ id: 'plain', position: 3 })
+    const ifThenStep = makeIfThenV2Step('if-then-v2')
+
+    expect(
+      extractBranchesWithSteps([forEachStep, plainStep, ifThenStep], 0),
+    ).toEqual([[forEachStep, plainStep], [ifThenStep]])
+  })
+
+  it('splits off each if-then V2 step in a sequence of blocks', () => {
+    const forEachStep = makeStep({ id: 'for-each', key: 'forEach' })
+    const firstIfThen = makeIfThenV2Step('if-then-1')
+    const secondIfThen = makeIfThenV2Step('if-then-2')
+
+    expect(
+      extractBranchesWithSteps([forEachStep, firstIfThen, secondIfThen], 0),
+    ).toEqual([[forEachStep], [firstIfThen], [secondIfThen]])
+  })
+
+  it('still folds a just-chosen, unconfigured if-then into the current branch', () => {
+    const forEachStep = makeStep({ id: 'for-each', key: 'forEach' })
+    const freshIfThenStep = makeStep({
+      id: 'fresh-if-then',
+      key: 'ifThen',
+      parameters: {},
+      config: {},
+    })
+
+    expect(extractBranchesWithSteps([forEachStep, freshIfThenStep], 0)).toEqual(
+      [[forEachStep, freshIfThenStep]],
+    )
   })
 })

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -9,6 +9,11 @@ import { UPDATE_STEP } from '@/graphql/mutations/update-step'
 
 export const TOOLBOX_APP_KEY = 'toolbox'
 
+// Signals a fresh if-then V2 block's self-reference on createStep — the real
+// id doesn't exist until after insert. Mirrors the backend's
+// SELF_END_STEP_SENTINEL (apps/toolbox/common/validate-end-step.ts).
+export const SELF_END_STEP_SENTINEL = 'self'
+
 export enum TOOLBOX_ACTIONS {
   IfThen = 'ifThen',
   ForEach = 'forEach',
@@ -67,14 +72,21 @@ export function extractBranchesWithSteps(
 
     const stepDepth = parseInt(step.parameters.depth as string)
 
-    // If depth is NaN, then this step is a nested branch that was just created
-    // by the user via the "Choose app & event" substep. It cannot have a depth
-    // <= currDepth; this needs us to cross a branch created with a createBranch
-    // mutation _AND_ that branch also has its depth <= currDepth.
-    //
-    // Thus this step must always be part of the current branch, so we add it to
-    // `branchWithSteps`.
+    // If depth is NaN, then this step is either a nested branch that was just
+    // created by the user via the "Choose app & event" substep, or an if-then
+    // V2 step (V2 never sets parameters.depth; config.endStepId carries its
+    // extent instead). A just-created branch cannot have a depth <= currDepth;
+    // this needs us to cross a branch created with a createBranch mutation
+    // _AND_ that branch also has its depth <= currDepth. Thus it must always
+    // be part of the current branch, so we add it to `branchWithSteps`. A
+    // marked V2 if-then has no such guarantee, so it always starts a new
+    // branch instead, the same as a same-depth V1 sibling below.
     if (isNaN(stepDepth)) {
+      if (step.config?.endStepId != null) {
+        result.push(branchWithSteps)
+        branchWithSteps = [step]
+        continue
+      }
       branchWithSteps.push(step)
       continue
     }
@@ -131,11 +143,7 @@ export function areAllIfThenBranchesCompleted(
   return branches.every(isIfThenBranchCompleted)
 }
 
-/**
- * Hook used for initializing If-then when the user _first_ chooses it via the
- * "Choose App & Event" substep.
- */
-export function useIfThenInitializer(): [
+export function useIfThenV1Initializer(): [
   (currStep: IStep) => Promise<IStep>,
   boolean,
 ] {
@@ -254,6 +262,65 @@ export function useIfThenInitializer(): [
       return currStep
     },
     [createStep, depth, updateStep],
+  )
+
+  return [initialize, isInitializing]
+}
+
+/**
+ * Hook for initializing an if-then V2 block on a step that already exists
+ * before its app/key are chosen (e.g. a template, or an empty action left
+ * over on an old pipe) — `Editor.onCreateStep` handles a freshly-created
+ * if-then itself, via the SELF_END_STEP_SENTINEL on createStep.
+ *
+ * Preserves `config.approval` alongside the marker (updateStep merges
+ * config), so a block created inside an MRF rejection branch stays confined
+ * to it, per the backend's region rule.
+ */
+export function useIfThenV2Initializer(): [
+  (currStep: IStep) => Promise<IStep>,
+  boolean,
+] {
+  const [isInitializing, setIsInitializing] = useState(false)
+  const { depth } = useContext(BranchContext)
+
+  const [updateStep] = useMutation(UPDATE_STEP, { fetchPolicy: 'no-cache' })
+
+  const initialize = useCallback(
+    async (currStep: IStep) => {
+      setIsInitializing(true)
+
+      const approvalConfig = currStep.config?.approval
+        ? { approval: currStep.config.approval }
+        : {}
+
+      await updateStep({
+        variables: {
+          input: {
+            id: currStep.id,
+            appKey: TOOLBOX_APP_KEY,
+            key: TOOLBOX_ACTIONS.IfThen,
+            flow: {
+              id: currStep.flowId,
+              updatedAt: currStep.flow.updatedAt,
+            },
+            parameters: {
+              depth,
+            },
+            connection: {
+              id: null,
+            },
+            config: { ...approvalConfig, endStepId: currStep.id },
+          },
+        },
+      })
+
+      setIsInitializing(false)
+
+      // The caller refetches GET_FLOW; this hook doesn't.
+      return currStep
+    },
+    [depth, updateStep],
   )
 
   return [initialize, isInitializing]

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -32,8 +32,14 @@ const useReorderSteps = (flowId: string) => {
       mrfApprovalSteps: IStep[]
       approvalBranches: { [stepId: string]: IStepApprovalBranch }
     }): StepPositionInput[] => {
-      // we start from 2 because the first step is the trigger step and not part of the sortable list
-      let nextPosition = 2
+      // Seed from the earliest position in the reordered set so a subset that
+      // doesn't begin right after the trigger renumbers from its own start.
+      // The top-level action list starts at position 2 (position 1 is the
+      // trigger, which is not part of the sortable list), so this is
+      // behaviour-identical for the old layout.
+      let nextPosition = reorderedSteps.length
+        ? Math.min(...reorderedSteps.map((step) => step.position))
+        : 2
       let currentApprovalBranch: {
         stepId: string
         branch: 'approve' | 'reject'


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our frontend to allow creating, deleting and re-ordering If-Then v2 blocks.

# Tests

See top of stack.