### PR TITLE
PLU-743: [IF-THEN-THEN-V2-14] Support adding steps after If-Then V2

### DIFF
--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -8,6 +8,7 @@ import {
   hasEmptyIfThenV2Block,
   hasIfThenV2Block,
   isBlankPlaceholderStep,
+  isIfThenBlockRegionConfined,
   isStepInsideForEachBody,
   isStepInsideIfThenBlock,
 } from '../steps-utils'
@@ -45,6 +46,12 @@ const forEach = (id: string): IStep =>
 
 const mrfSubmission = (id: string): IStep =>
   ({ id, appKey: 'formsg', key: 'mrfSubmission' } as IStep)
+
+const approvalStep = (id: string): IStep =>
+  ({
+    ...plain(id),
+    config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+  } as IStep)
 
 // A leftover blank child from the if-then V1 branch initializer: neither
 // appKey nor key ever set.
@@ -446,6 +453,147 @@ describe('buildStepsList', () => {
         ],
       },
     ])
+  })
+})
+
+describe('isIfThenBlockRegionConfined', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('is true for a marker-less block wholly within a single region', () => {
+    const ifThenA = ifThen('ifThenA')
+    const steps = [ifThenA, plain('a1'), plain('a2')]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(true)
+  })
+
+  it('is true for a flow with no MRF or approval steps', () => {
+    const ifThenA = ifThen('ifThenA')
+    const ifThenB = ifThen('ifThenB')
+    const steps = [ifThenA, plain('a1'), ifThenB, plain('b1'), plain('b2')]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenB)).toBe(true)
+  })
+
+  it('reads a null marker (the GraphQL shape) as marker-less, over the derived extent', () => {
+    // The extent must come from the derived scan, so the MRF submission that
+    // follows the next if-then stays outside this block.
+    const ifThenA = nullMarkerIfThen('ifThenA')
+    const ifThenB = nullMarkerIfThen('ifThenB')
+    const steps = [
+      ifThenA,
+      plain('a1'),
+      ifThenB,
+      mrfSubmission('mrf'),
+      plain('after'),
+    ]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(true)
+    expect(isIfThenBlockRegionConfined(steps, ifThenB)).toBe(false)
+  })
+
+  it('is true for an explicit if-then V2 block confined to one region', () => {
+    const block = markedIfThen('block', 'a2')
+    const steps = [block, plain('a1'), plain('a2'), plain('after')]
+
+    expect(isIfThenBlockRegionConfined(steps, block)).toBe(true)
+  })
+
+  it('is true for an empty self-referencing block', () => {
+    const block = markedIfThen('block', 'block')
+    const steps = [block, plain('after')]
+
+    expect(isIfThenBlockRegionConfined(steps, block)).toBe(true)
+  })
+
+  it('is false when an MRF submission step sits inside the derived extent', () => {
+    // ifThenA's derived extent runs up to the step before the reject-branch
+    // if-then, i.e. it includes the MRF submission — a straddling block.
+    const ifThenA = ifThen('ifThenA')
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'ifThenA' } },
+    })
+    const steps = [
+      ifThenA,
+      plain('a1'),
+      mrfSubmission('mrf'),
+      rejectIfThen,
+      plain('after'),
+    ]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(false)
+  })
+
+  it('is false when a top-level block reaches into a rejection branch', () => {
+    const ifThenA = ifThen('ifThenA')
+    const steps = [
+      ifThenA,
+      plain('a1'),
+      approvalStep('approvalMid'),
+      plain('a3'),
+    ]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(false)
+  })
+
+  it('is true for a block confined to one rejection branch', () => {
+    // Bounded by the next if-then in the same branch, so the extent stays in it.
+    const approvalIfThen = ifThen('approvalIf', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const nextApprovalIfThen = ifThen('nextApprovalIf', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [
+      approvalIfThen,
+      approvalStep('a1'),
+      nextApprovalIfThen,
+      approvalStep('b1'),
+    ]
+
+    expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(true)
+  })
+
+  it('is false when a rejection-branch block reaches back out to the main flow', () => {
+    const approvalIfThen = ifThen('approvalIf', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [approvalIfThen, approvalStep('a1'), plain('topLevel')]
+
+    expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(false)
+  })
+
+  it('is false for a block spanning two different rejection branches', () => {
+    const approvalIfThen = ifThen('approvalIf', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const otherBranchStep = {
+      ...plain('otherBranch'),
+      config: { approval: { branch: 'reject', stepId: 'otherApprovalStep' } },
+    } as IStep
+    const steps = [approvalIfThen, otherBranchStep]
+
+    expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(false)
+  })
+
+  it('is true for an empty self-referencing block in a rejection branch', () => {
+    const approvalIfThen = ifThen('approvalIf', {
+      config: {
+        approval: { branch: 'reject', stepId: 'someApprovalStep' },
+        endStepId: 'approvalIf',
+      },
+    })
+    const steps = [approvalIfThen, approvalStep('a1')]
+
+    expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(true)
+  })
+
+  it('is false for an explicit marker whose extent spans an MRF submission', () => {
+    const block = markedIfThen('block', 'end')
+    const steps = [block, plain('a1'), mrfSubmission('mrf'), plain('end')]
+
+    expect(isIfThenBlockRegionConfined(steps, block)).toBe(false)
   })
 })
 

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -1,5 +1,6 @@
 import type { IStep } from '@plumber/types'
 
+import { FORMSG_APP_KEY, MRF_ACTION_KEY } from '@/helpers/formsg'
 import { isIfThenStep } from '@/helpers/toolbox'
 
 /**
@@ -84,6 +85,72 @@ export function deriveIfThenV1EndStep(
     return actionSteps[actionSteps.length - 1]
   }
   return actionSteps[nextBoundaryIndex - 1]
+}
+
+function isMrfSubmissionStep(step: IStep): boolean {
+  return step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY
+}
+
+/**
+ * Resolves the if-then's endStep exactly as `buildIfThenBlock` would, so the
+ * confinement check reasons about the same extent the block renders.
+ */
+function resolveBlockEndStep(
+  flowSteps: IStep[],
+  ifThenStep: IStep,
+  startIndex: number,
+): IStep {
+  const markerId = ifThenStep.config?.endStepId
+  if (markerId != null) {
+    const markerIndex = flowSteps.findIndex((step) => step.id === markerId)
+    if (markerIndex !== -1 && markerIndex >= startIndex) {
+      return flowSteps[markerIndex]
+    }
+  }
+  return deriveIfThenV1EndStep(flowSteps, ifThenStep)
+}
+
+/**
+ * Mirrors the backend's `getRejectionBranchId`. `config.approval` is only
+ * ever written for rejection branches, so its `stepId` (the approval step
+ * the branch hangs off) identifies the branch on its own.
+ */
+function getRejectionBranchId(step: IStep): string | null {
+  return step.config?.approval?.stepId ?? null
+}
+
+/**
+ * Whether the if-then's block extent is confined to a single MRF region, so
+ * an `endStepId` write over it would pass the backend's region check.
+ * Mirrors `checkEndStepWrite`'s region rule (validate-end-step.ts).
+ *
+ * IMPORTANT: pass the full `flow.steps`, not the MRF-filtered display list.
+ * That list can hide a boundary step that still sits inside the block's
+ * full-flow range.
+ */
+export function isIfThenBlockRegionConfined(
+  flowSteps: IStep[],
+  ifThenStep: IStep,
+): boolean {
+  const startIndex = flowSteps.findIndex((step) => step.id === ifThenStep.id)
+  if (startIndex === -1) {
+    return false
+  }
+
+  const endStep = resolveBlockEndStep(flowSteps, ifThenStep, startIndex)
+  const endIndex = flowSteps.findIndex((step) => step.id === endStep.id)
+  const blockRejectionBranchId = getRejectionBranchId(ifThenStep)
+
+  for (let index = startIndex + 1; index <= endIndex; index++) {
+    const step = flowSteps[index]
+    if (
+      isMrfSubmissionStep(step) ||
+      getRejectionBranchId(step) !== blockRejectionBranchId
+    ) {
+      return false
+    }
+  }
+  return true
 }
 
 /**

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -79,9 +79,8 @@ export default function ChooseAndAddConnection(
     setCurrentStepId,
     executeTestStep,
   } = useContext(EditorContext)
-  const { modalState, patchModalState, step, prevStep } = useContext(
-    FlowStepConfigurationContext,
-  )
+  const { modalState, patchModalState, step, prevStep, previousBlockId } =
+    useContext(FlowStepConfigurationContext)
 
   const { approvalBranches } = useContext(MrfContext)
   const { currentScreen, selectedApp, selectedEvent } = modalState
@@ -143,6 +142,7 @@ export default function ChooseAndAddConnection(
             selectedEvent.key,
             connectionId,
             approvalConfig && { approval: approvalConfig },
+            { previousBlockId },
           )
           newStepId = createdStep.id
         } else if (step) {
@@ -175,6 +175,7 @@ export default function ChooseAndAddConnection(
       selectedEvent,
       patchModalState,
       prevStep,
+      previousBlockId,
       step,
       onClose,
       onDrawerOpen,

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -52,9 +52,14 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
     flowId,
   } = useContext(EditorContext)
 
-  const { modalState, patchModalState, prevStep, isTrigger, step } = useContext(
-    FlowStepConfigurationContext,
-  )
+  const {
+    modalState,
+    patchModalState,
+    prevStep,
+    isTrigger,
+    step,
+    previousBlockId,
+  } = useContext(FlowStepConfigurationContext)
   const { approvalBranches } = useContext(MrfContext)
 
   const { currentScreen, selectedApp } = modalState
@@ -134,7 +139,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             triggerOrAction.key,
             systemConnection?.id || undefined,
             approvalConfig && { approval: approvalConfig },
-            { isIfThenV2Enabled },
+            { previousBlockId, isIfThenV2Enabled },
           )
           newStepId = createdStep.id
         } else if (step) {
@@ -177,6 +182,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       flowId,
       patchModalState,
       prevStep,
+      previousBlockId,
       step,
       onClose,
       onDrawerOpen,

--- a/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
@@ -12,6 +12,10 @@ interface FlowStepConfigurationContextValue {
   prevStep?: IStep
   prevStepId?: string
   step?: IStep
+  // Set only when the modal is launched from an if-then block's add-after
+  // affordance. Sent on the CREATE_STEP so the backend places the new step
+  // after the named block and (for an if-then V1 block) pins its extent.
+  previousBlockId?: string
 }
 
 export const FlowStepConfigurationContext =
@@ -52,6 +56,7 @@ interface FlowStepConfigurationContextProps {
   isTrigger: boolean
   isLastStep: boolean
   prevStep?: IStep
+  previousBlockId?: string
   children: React.ReactNode
 }
 
@@ -62,6 +67,7 @@ export const FlowStepConfigurationContextProvider = ({
   isTrigger,
   isLastStep,
   prevStep,
+  previousBlockId,
   children,
 }: FlowStepConfigurationContextProps) => {
   const [modalState, setModalState] = useState<ModalState>({
@@ -86,6 +92,7 @@ export const FlowStepConfigurationContextProvider = ({
         prevStep,
         prevStepId: prevStep?.id,
         step,
+        previousBlockId,
       }}
     >
       {children}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -21,6 +21,8 @@ interface FlowStepConfigurationModalProps {
   app?: IApp
   event?: ITrigger | IAction
   prevStep?: IStep
+  // Set only when launched from an if-then block's add-after affordance.
+  previousBlockId?: string
 }
 
 function FlowStepConfigurationModalContent({
@@ -53,7 +55,16 @@ function FlowStepConfigurationModalContent({
 export default function FlowStepConfigurationModal(
   props: FlowStepConfigurationModalProps,
 ): JSX.Element {
-  const { onClose, isTrigger, isLastStep, step, app, event, prevStep } = props
+  const {
+    onClose,
+    isTrigger,
+    isLastStep,
+    step,
+    app,
+    event,
+    prevStep,
+    previousBlockId,
+  } = props
 
   return (
     <FlowStepConfigurationContextProvider
@@ -62,6 +73,7 @@ export default function FlowStepConfigurationModal(
       app={app}
       event={event}
       prevStep={prevStep}
+      previousBlockId={previousBlockId}
       step={step}
     >
       <Modal

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/AddAfterBlockButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/AddAfterBlockButton.tsx
@@ -1,0 +1,136 @@
+import { useContext } from 'react'
+import { BiPlus } from 'react-icons/bi'
+import { Box, Divider, Flex, useDisclosure } from '@chakra-ui/react'
+import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
+
+import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
+import {
+  type IfThenBlock,
+  isIfThenBlockRegionConfined,
+} from '@/components/Editor/helpers/steps-utils'
+import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
+import { EditorContext } from '@/contexts/Editor'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+
+import { HoverAddStepButton } from './HoverAddStepButton'
+
+interface AddAfterBlockButtonProps {
+  block: IfThenBlock
+  isLastStep: boolean
+  // Whether the block sits inside a for-each body, so its trailing connector
+  // matches that body's HoverAddStepButton look instead of standing out.
+  isNested?: boolean
+}
+
+/**
+ * Adds a step after an if-then block, outside its rail.
+ *
+ * IMPORTANT: only sends `previousBlockId` when the block's region is
+ * confined. The backend rejects an `endStepId` write that straddles an MRF
+ * region.
+ */
+export function AddAfterBlockButton({
+  block,
+  isLastStep,
+  isNested = false,
+}: AddAfterBlockButtonProps): JSX.Element {
+  const { flow, readOnly, isDrawerOpen } = useContext(EditorContext)
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave,
+  } = useUnsavedChanges({
+    onProceed: onOpen,
+  })
+
+  const { ifThenStep, endStep } = block
+  const previousBlockId = isIfThenBlockRegionConfined(flow.steps, ifThenStep)
+    ? ifThenStep.id
+    : undefined
+
+  if (isNested) {
+    return (
+      <HoverAddStepButton
+        isDisabled={readOnly}
+        isDrawerOpen={isDrawerOpen}
+        isLastStep={isLastStep}
+        prevStep={endStep}
+        step={endStep}
+        previousBlockId={previousBlockId}
+      />
+    )
+  }
+
+  // Mirrors AddStepButton's read-only behavior, so a read-only block sits in
+  // the same rhythm as a read-only step.
+  if (readOnly) {
+    return isLastStep ? (
+      <></>
+    ) : (
+      <Flex flexDir="column" alignItems="center" w="100%">
+        <Divider
+          h={12}
+          orientation="vertical"
+          borderColor="base.divider.strong"
+        />
+      </Flex>
+    )
+  }
+
+  return (
+    <>
+      {/*
+        IMPORTANT: `pos="relative"` gives TouchableTooltip's hidden label a
+        local containing block. Without it, the label's static position is
+        computed against Editor's own wrapper, inflating its scrollHeight and
+        producing a duplicate scrollbar.
+      */}
+      <Flex flexDir="column" alignItems="center" w="100%" pos="relative">
+        <Box h={4}>
+          <Divider orientation="vertical" />
+        </Box>
+        <TouchableTooltip label="Add step" placement="right" marginX="auto">
+          <IconButton
+            onClick={handleProceed}
+            aria-label="Add step after block"
+            icon={<BiPlus />}
+            variant={isLastStep ? 'outline' : 'clear'}
+            size="xs"
+            color="interaction.sub.default"
+            borderRadius="full"
+            borderColor={isLastStep ? 'base.divider.strong' : undefined}
+            _hover={{ bg: 'interaction.muted.neutral.hover' }}
+            _active={{ bg: 'interaction.muted.neutral.active' }}
+            h={8}
+          />
+        </TouchableTooltip>
+        {!isLastStep && (
+          <Box h={4}>
+            <Divider orientation="vertical" />
+          </Box>
+        )}
+      </Flex>
+
+      {isOpen && (
+        <FlowStepConfigurationModal
+          onClose={onClose}
+          isTrigger={false}
+          isLastStep={isLastStep}
+          prevStep={endStep}
+          previousBlockId={previousBlockId}
+        />
+      )}
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={handleLeave}
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -23,6 +23,10 @@ interface HoverAddStepButtonProps {
   step: IStep
   allowReorder?: boolean
   canChildStepsReorder?: boolean
+  // Set only when this button stands in for AddAfterBlockButton (an if-then
+  // V2 block nested in a for-each body), to pin/upgrade the block's marker
+  // as the top-level button would.
+  previousBlockId?: string
 }
 
 export function HoverAddStepButton(
@@ -36,6 +40,7 @@ export function HoverAddStepButton(
     step,
     allowReorder,
     canChildStepsReorder,
+    previousBlockId,
   } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
@@ -109,6 +114,7 @@ export function HoverAddStepButton(
           isTrigger={false} // Can only add an action all the time
           isLastStep={isLastStep}
           prevStep={prevStep}
+          previousBlockId={previousBlockId}
         />
       )}
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { BiDuplicate, BiTrash } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
-import { Box, Divider, Flex, useDisclosure } from '@chakra-ui/react'
+import { Box, Flex, useDisclosure } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
@@ -17,11 +17,14 @@ import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
 import {
   type IfThenBlock,
   isBlankPlaceholderStep,
+  isStepInsideForEachBody,
 } from '@/components/Editor/helpers/steps-utils'
 import { NESTED_FLOW_STEP_HEIGHT } from '@/components/FlowStep/styles'
 import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
+import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStep } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
@@ -33,12 +36,15 @@ import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
 import { flowStepGroupStyles } from '../../styles'
 
+import { AddAfterBlockButton } from './AddAfterBlockButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
 import { blockActionButtonStyles, branchStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 
 interface IfThenProps {
   block: IfThenBlock
+  // Whether this block is the last item in the flow, which drives the
+  // add-after button's last-step styling.
   isLastBlock: boolean
   // IMPORTANT: only meaningful when the block renders inside a top-level
   // SortableList.Item. That's what gives it a drag handle at all.
@@ -74,6 +80,9 @@ export default function IfThen({
     setCurrentStepId,
     shouldWarnOnLeave,
   } = useContext(EditorContext)
+  const { actionStepsToDisplay, groupingActions } = useContext(
+    StepsToDisplayContext,
+  )
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 
   const isEmptyBlock = children.length === 0
@@ -83,6 +92,14 @@ export default function IfThen({
   // block, so the (redundant) hover-+ around that placeholder is suppressed.
   const isSoleBlankPlaceholder =
     children.length === 1 && isBlankPlaceholderStep(children[0])
+
+  // Only true for a for-each body today, letting the block borrow that
+  // body's width and connector style instead of the top-level one.
+  const isNestedInBlock = isStepInsideForEachBody(
+    ifThenStep,
+    actionStepsToDisplay,
+    groupingActions ?? new Set<string>(),
+  )
 
   // The single-branch box merges what an if-then V1 group shows as two lines
   // (its own caption, plus the branch name inside it) into one header. A
@@ -97,6 +114,12 @@ export default function IfThen({
   // IMPORTANT: assumes allowReorder already excludes read-only. The caller
   // (StepsList) folds that in before passing it down.
   const showDragHandle = allowReorder && !isDrawerOpen && !isMobile
+
+  // IMPORTANT: without this, a nested block's box sits off-centre because
+  // nothing else absorbs the inline handle's width. Mirrors the offset a
+  // reorderable step's own row makes for its own handle.
+  const blockHandleOffset =
+    isNestedInBlock && showDragHandle ? NESTED_DRAG_HANDLE_WIDTH / 2 : 0
 
   // Whole-block delete. An explicit if-then V2 block sends just the if-then's
   // id, and the backend expands that to the block's range. An if-then V1
@@ -206,13 +229,28 @@ export default function IfThen({
         <Flex
           pos="relative"
           alignItems="center"
-          w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
+          w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNestedInBlock)}
           minW={MIN_FLOW_STEP_WIDTH}
         >
           <Flex
             {...flowStepGroupStyles.container}
             display={isMobile ? 'block' : 'flex'}
-            w="100%"
+            // Lets the box give up room to the inline drag handle below
+            // instead of overflowing the slot.
+            // Replaced by an explicit width and offset when the handle is
+            // present (see blockHandleOffset).
+            flex={blockHandleOffset ? undefined : '1'}
+            // flexShrink 0 keeps the nudge as a real position shift. Default
+            // shrink would otherwise claw the margin back out of the box's
+            // width.
+            flexShrink={blockHandleOffset ? 0 : undefined}
+            w={
+              blockHandleOffset
+                ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+                : undefined
+            }
+            ml={blockHandleOffset ? `${blockHandleOffset}px` : undefined}
+            minW="0"
             // The header and branch run edge to edge, so the box clips them to
             // its own rounded corners.
             overflow="hidden"
@@ -430,40 +468,48 @@ export default function IfThen({
           </Flex>
 
           {/*
-            Positioned outside the box (not laid out inside the header)
-            because the box clips overflow, and an inline handle here would
-            eat into the header's title.
+            Sits outside the box so it doesn't crowd the header title.
+            Positioned absolutely at the top level so it can't pull the box
+            off centre. Nested in a for-each it's laid out as a row sibling
+            instead. That slot fills the parent's width, so an
+            absolutely-positioned handle would overflow past the for-each's
+            edge.
           */}
-          {showDragHandle && (
-            <Box pos="absolute" left="100%" top={0} h={NESTED_FLOW_STEP_HEIGHT}>
-              <Flex alignItems="center" h="100%">
-                <SortableList.DragHandle />
+          {showDragHandle &&
+            (isNestedInBlock ? (
+              <Flex
+                alignItems="center"
+                alignSelf="flex-start"
+                h={NESTED_FLOW_STEP_HEIGHT}
+                flexShrink={0}
+              >
+                <SortableList.DragHandle isNested />
               </Flex>
-            </Box>
-          )}
+            ) : (
+              <Box
+                pos="absolute"
+                left="100%"
+                top={0}
+                h={NESTED_FLOW_STEP_HEIGHT}
+              >
+                <Flex alignItems="center" h="100%">
+                  <SortableList.DragHandle />
+                </Flex>
+              </Box>
+            ))}
         </Flex>
       </Flex>
 
       {/*
-        Matches the height AddStepButton draws between two steps: 16+36+16px
-        normally, or a 48px divider in the stronger colour once read-only
-        hides the button. The block has no add-after affordance of its own
-        yet, so it draws a plain line of the same height instead. The last
-        block draws nothing, matching how a last step has no connector.
+        The connector down to whatever follows the block, which doubles as the
+        affordance for adding a step after the whole block. Same place, height
+        and dividers as a plain step's add button relative to its card.
       */}
-      {!isLastBlock && (
-        <Flex flexDir="column" alignItems="center" w="100%">
-          {readOnly ? (
-            <Divider
-              h="48px"
-              orientation="vertical"
-              borderColor="base.divider.strong"
-            />
-          ) : (
-            <Divider h="68px" orientation="vertical" />
-          )}
-        </Flex>
-      )}
+      <AddAfterBlockButton
+        block={block}
+        isLastStep={isLastBlock}
+        isNested={isNestedInBlock}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -42,6 +42,7 @@ import { extractVariables, StepWithVariables } from '@/helpers/variables'
 import { useApps } from '@/hooks/useApps'
 
 interface OnCreateStepOptions {
+  previousBlockId?: string
   // The caller resolves the owner-scoped flag and passes it here; the
   // provider component can't read it itself.
   isIfThenV2Enabled?: boolean
@@ -229,6 +230,10 @@ export const EditorProvider = ({
         previousStep: {
           id: previousStepId,
         },
+        // Set only from an if-then block's add-after affordance, so the
+        // backend can place the step after the block and pin an if-then V1
+        // block's extent.
+        previousBlockId: options?.previousBlockId,
         flow: {
           id: flowId,
           updatedAt: flow.updatedAt,


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our frontend to support adding steps _after_ an If-Then V2 block.

# Tests

See top of stack.