### PR TITLE
PLU-743: [IF-THEN-THEN-V2-15] UX fixes (wrong add step button & selectivity) 

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -45,13 +45,20 @@ interface ChooseAppProps {
 export default function ChooseApp(props: ChooseAppProps) {
   const { apps, onSelectAppEvent } = props
   const { getFlagValue } = useContext(LaunchDarklyContext)
-  const { patchModalState, isTrigger, isLastStep, step, prevStepId } =
-    useContext(FlowStepConfigurationContext)
+  const {
+    patchModalState,
+    isTrigger,
+    isLastStep,
+    step,
+    prevStepId,
+    anchorPlacement,
+  } = useContext(FlowStepConfigurationContext)
 
   const appSelectableMap = useIsAppSelectable({
     isLastStep,
     step,
     prevStepId,
+    anchorPlacement,
   })
 
   const [_, isInitializingIfThen] = useIfThenV1Initializer()
@@ -280,7 +287,13 @@ export default function ChooseApp(props: ChooseAppProps) {
                           key={action.key}
                           action={action}
                           onSelectAppEvent={() => onSelectAppEvent(app, action)}
-                          isDisabled={appSelectableMap?.[action.key] === false}
+                          isDisabled={
+                            appSelectableMap?.[action.key]?.isSelectable ===
+                            false
+                          }
+                          disabledReason={
+                            appSelectableMap?.[action.key]?.disabledReason
+                          }
                           searchQuery={searchQuery}
                         />
                       ))
@@ -294,7 +307,8 @@ export default function ChooseApp(props: ChooseAppProps) {
                         ? triggersOrActions[0]
                         : null
 
-                    const isAppDisabled = appSelectableMap?.[app.key] === false
+                    const isAppDisabled =
+                      appSelectableMap?.[app.key]?.isSelectable === false
 
                     if (!triggersOrActions?.length) {
                       return null

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
@@ -5,6 +5,8 @@ import { SlLoop } from 'react-icons/sl'
 import { Flex, Icon, Text } from '@chakra-ui/react'
 import { TouchableTooltip } from '@opengovsg/design-system-react'
 
+import { LAST_STEP_ONLY_REASON } from '../hooks/useIsAppSelectable'
+
 import { HighlightedText } from './HighlightedText'
 import NewBadge from './NewBadge'
 
@@ -18,14 +20,23 @@ interface ToolboxEventProps {
   action: IAction
   onSelectAppEvent: () => void
   isDisabled: boolean
+  // Defaults to the reason it carried when "last step only" was the toolbox's
+  // only rule.
+  disabledReason?: string
   searchQuery: string
 }
 
 export default function ToolboxEvent(props: ToolboxEventProps): JSX.Element {
-  const { action, isDisabled, onSelectAppEvent, searchQuery } = props
+  const {
+    action,
+    isDisabled,
+    disabledReason = LAST_STEP_ONLY_REASON,
+    onSelectAppEvent,
+    searchQuery,
+  } = props
   return (
     <TouchableTooltip
-      label={isDisabled ? 'This can only be used as the last step' : ''}
+      label={isDisabled ? disabledReason : ''}
       placement="bottom"
       openDelay={100}
       closeDelay={100}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
@@ -4,6 +4,8 @@ import { IAction, IApp, IStep, ITrigger } from '@plumber/types'
 
 import { createContext, useCallback, useState } from 'react'
 
+import type { AnchorPlacement } from './helpers/anchor-placement'
+
 interface FlowStepConfigurationContextValue {
   modalState: ModalState
   patchModalState: (modalState: Partial<ModalState>) => void
@@ -16,6 +18,9 @@ interface FlowStepConfigurationContextValue {
   // affordance. Sent on the CREATE_STEP so the backend places the new step
   // after the named block and (for an if-then V1 block) pins its extent.
   previousBlockId?: string
+  // Set only by the affordances whose anchor step misrepresents where their
+  // new step lands relative to an if-then block. See AnchorPlacement.
+  anchorPlacement?: AnchorPlacement
 }
 
 export const FlowStepConfigurationContext =
@@ -57,6 +62,7 @@ interface FlowStepConfigurationContextProps {
   isLastStep: boolean
   prevStep?: IStep
   previousBlockId?: string
+  anchorPlacement?: AnchorPlacement
   children: React.ReactNode
 }
 
@@ -68,6 +74,7 @@ export const FlowStepConfigurationContextProvider = ({
   isLastStep,
   prevStep,
   previousBlockId,
+  anchorPlacement,
   children,
 }: FlowStepConfigurationContextProps) => {
   const [modalState, setModalState] = useState<ModalState>({
@@ -93,6 +100,7 @@ export const FlowStepConfigurationContextProvider = ({
         prevStepId: prevStep?.id,
         step,
         previousBlockId,
+        anchorPlacement,
       }}
     >
       {children}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/helpers/__tests__/anchor-placement.test.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/helpers/__tests__/anchor-placement.test.ts
@@ -1,0 +1,222 @@
+import type { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  isAnchorInsideForEachBody,
+  isAnchorInsideIfThenBlock,
+} from '../anchor-placement'
+
+//
+// Fixtures. The resolution runs over the MRF-filtered action-step list (the
+// trigger already removed), ordered by position, so these never include a
+// trigger.
+//
+
+const plain = (id: string): IStep =>
+  ({ id, appKey: 'postman', key: 'sendTransactionalEmail' } as IStep)
+
+const ifThen = (id: string, extra: Partial<IStep> = {}): IStep =>
+  ({
+    id,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    parameters: { depth: '0' },
+    ...extra,
+  } as IStep)
+
+// The endStepId marker is what makes an if-then V2, so tests that need one
+// use this instead of the plain `ifThen` fixture.
+const markedIfThen = (id: string, endStepId: string): IStep =>
+  ifThen(id, { config: { endStepId } })
+
+const forEach = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'forEach' } as IStep)
+
+// The set of grouping actions (`groupsLaterSteps`) is exactly if-then and
+// for-each today.
+const GROUPING_ACTIONS = new Set(['toolbox-ifThen', 'toolbox-forEach'])
+
+describe('isAnchorInsideIfThenBlock', () => {
+  it('believes a launcher that places the step after a block, over its anchor', () => {
+    // The add-after-block button's anchor is the block's last child, which
+    // is itself inside the block. Its step lands outside.
+    const child = plain('child')
+    const actionSteps = [markedIfThen('ifThen', 'child'), child]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorPlacement: 'after-if-then-block',
+        anchorStep: child,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+
+  it('believes a launcher that places the step inside a block, over its anchor', () => {
+    // The empty-block placeholder's anchor is the if-then step itself, which
+    // is not inside its own block. Its step lands inside.
+    const emptyBlock = markedIfThen('ifThen', 'ifThen')
+    const actionSteps = [emptyBlock, plain('after')]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorPlacement: 'inside-if-then-block',
+        anchorStep: emptyBlock,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('reads a block child off the anchor when no placement is given', () => {
+    const child = plain('child')
+    const actionSteps = [markedIfThen('ifThen', 'child'), child, plain('after')]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorStep: child,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('reads a top-level step off the anchor as outside every block', () => {
+    const after = plain('after')
+    const actionSteps = [markedIfThen('ifThen', 'child'), plain('child'), after]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorStep: after,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+
+  it('reads a for-each body step outside any block as outside every block', () => {
+    const inBody = plain('inBody')
+    const actionSteps = [forEach('forEach'), inBody]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorStep: inBody,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+
+  it('reads a step in a block nested under a for-each as inside a block', () => {
+    const nestedChild = plain('nestedChild')
+    const actionSteps = [
+      forEach('forEach'),
+      plain('inBody'),
+      markedIfThen('nestedIfThen', 'nestedChild'),
+      nestedChild,
+    ]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        anchorStep: nestedChild,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('is outside every block when there is no anchor at all', () => {
+    const actionSteps = [markedIfThen('ifThen', 'child'), plain('child')]
+
+    expect(
+      isAnchorInsideIfThenBlock({
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isAnchorInsideForEachBody', () => {
+  it('counts a for-each step as its own body, since a step after it lands there', () => {
+    const forEachStep = forEach('forEach')
+    const actionSteps = [plain('before'), forEachStep, plain('inBody')]
+
+    expect(
+      isAnchorInsideForEachBody({
+        anchorStep: forEachStep,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('counts a step in the body', () => {
+    const inBody = plain('inBody')
+    const actionSteps = [forEach('forEach'), inBody]
+
+    expect(
+      isAnchorInsideForEachBody({
+        anchorStep: inBody,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('counts a step inside a block nested in the body', () => {
+    const nestedChild = plain('nestedChild')
+    const actionSteps = [
+      forEach('forEach'),
+      markedIfThen('nestedIfThen', 'nestedChild'),
+      nestedChild,
+    ]
+
+    expect(
+      isAnchorInsideForEachBody({
+        anchorStep: nestedChild,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not count a step before the for-each', () => {
+    const before = plain('before')
+    const actionSteps = [before, forEach('forEach'), plain('inBody')]
+
+    expect(
+      isAnchorInsideForEachBody({
+        anchorStep: before,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not count anything in a flow with no for-each', () => {
+    const child = plain('child')
+    const actionSteps = [markedIfThen('ifThen', 'child'), child]
+
+    expect(
+      isAnchorInsideForEachBody({
+        anchorStep: child,
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+
+  it('is outside every body when there is no anchor at all', () => {
+    const actionSteps = [forEach('forEach'), plain('inBody')]
+
+    expect(
+      isAnchorInsideForEachBody({
+        actionSteps,
+        groupingActions: GROUPING_ACTIONS,
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/frontend/src/components/FlowStepConfigurationModal/helpers/anchor-placement.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/helpers/anchor-placement.ts
@@ -1,0 +1,63 @@
+import type { IStep } from '@plumber/types'
+
+import {
+  isStepInsideForEachBody,
+  isStepInsideIfThenBlock,
+} from '@/components/Editor/helpers/steps-utils'
+import { isForEachStep } from '@/helpers/toolbox'
+
+/**
+ * Explicit override for the launchers whose anchor step does not reflect
+ * where the new step actually lands relative to an if-then block.
+ */
+export type AnchorPlacement = 'inside-if-then-block' | 'after-if-then-block'
+
+/**
+ * Whether the new step will land inside an if-then block.
+ *
+ * `actionSteps` must be the MRF-filtered action-step list (trigger removed),
+ * matching what `isStepInsideIfThenBlock` expects.
+ */
+export function isAnchorInsideIfThenBlock({
+  anchorPlacement,
+  anchorStep,
+  actionSteps,
+  groupingActions,
+}: {
+  anchorPlacement?: AnchorPlacement
+  anchorStep?: IStep
+  actionSteps: IStep[]
+  groupingActions: Set<string>
+}): boolean {
+  if (anchorPlacement) {
+    return anchorPlacement === 'inside-if-then-block'
+  }
+  if (!anchorStep) {
+    return false
+  }
+  return isStepInsideIfThenBlock(anchorStep, actionSteps, groupingActions)
+}
+
+/**
+ * Whether the new step will land inside a for-each body.
+ *
+ * A for-each has no bounded extent, so anchoring on the for-each step itself
+ * counts as inside its body, same as anchoring on a step already inside it.
+ */
+export function isAnchorInsideForEachBody({
+  anchorStep,
+  actionSteps,
+  groupingActions,
+}: {
+  anchorStep?: IStep
+  actionSteps: IStep[]
+  groupingActions: Set<string>
+}): boolean {
+  if (!anchorStep) {
+    return false
+  }
+  return (
+    isForEachStep(anchorStep) ||
+    isStepInsideForEachBody(anchorStep, actionSteps, groupingActions)
+  )
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -6,7 +6,42 @@ import { BranchContext } from '@/components/FlowStepGroup/Content/IfThen/BranchC
 import { NESTED_IFTHEN_FEATURE_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { isForEachStep, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
+
+import {
+  type AnchorPlacement,
+  isAnchorInsideForEachBody,
+  isAnchorInsideIfThenBlock,
+} from '../helpers/anchor-placement'
+
+/**
+ * The reason every unselectable action has carried since the toolbox shipped:
+ * back then the only rules were "last step only", so it doubles as the default
+ * for an action the hook says nothing about.
+ */
+export const LAST_STEP_ONLY_REASON = 'This can only be used as the last step'
+
+/**
+ * An if-then block runs the steps it contains, so an if-then among them would
+ * be a nested branch — which the block model does not support.
+ */
+const IF_THEN_INSIDE_BLOCK_REASON =
+  'You cannot add an If-then inside another If-then'
+
+const FOR_EACH_INSIDE_BLOCK_REASON = 'For-each cannot be used in an If-then'
+
+export interface AppSelectability {
+  isSelectable: boolean
+  disabledReason: string
+}
+
+function selectability(
+  isSelectable: boolean,
+  disabledReason: string = LAST_STEP_ONLY_REASON,
+): AppSelectability {
+  return { isSelectable, disabledReason }
+}
 
 /**
  * Helper function to check if Delay action should be selectable
@@ -78,18 +113,68 @@ function isIfThenSelectable({
   return !isNestedBranch
 }
 
+/**
+ * Selectability under the if-then V2 block model: since a block has a bounded
+ * extent, an if-then is no longer forced to be the flow's last or only step,
+ * leaving nesting as the sole restriction. For-each has no such extent, so it
+ * still swallows every later step and must stay last.
+ */
+function getIfThenV2Selectability({
+  isLastStep,
+  anchorPlacement,
+  anchorStep,
+  actionSteps,
+  groupingActions,
+}: {
+  isLastStep: boolean
+  anchorPlacement?: AnchorPlacement
+  anchorStep?: IStep
+  actionSteps: IStep[]
+  groupingActions: Set<string>
+}): Record<string, AppSelectability> {
+  const isInsideIfThenBlock = isAnchorInsideIfThenBlock({
+    anchorPlacement,
+    anchorStep,
+    actionSteps,
+    groupingActions,
+  })
+  const hasForEach = actionSteps.some(isForEachStep)
+
+  return {
+    [TOOLBOX_ACTIONS.IfThen]: selectability(
+      !isInsideIfThenBlock,
+      IF_THEN_INSIDE_BLOCK_REASON,
+    ),
+    [TOOLBOX_ACTIONS.ForEach]: selectability(
+      isLastStep && !hasForEach && !isInsideIfThenBlock,
+      isInsideIfThenBlock
+        ? FOR_EACH_INSIDE_BLOCK_REASON
+        : LAST_STEP_ONLY_REASON,
+    ),
+    delay: selectability(
+      !isAnchorInsideForEachBody({ anchorStep, actionSteps, groupingActions }),
+    ),
+  }
+}
+
 export const useIsAppSelectable = ({
   isLastStep,
   step,
   prevStepId,
+  anchorPlacement,
 }: {
   isLastStep: boolean
   step?: IStep
   prevStepId?: string
-}): Record<string, boolean> => {
+  anchorPlacement?: AnchorPlacement
+}): Record<string, AppSelectability> => {
   const { depth } = useContext(BranchContext)
-  const { groupedSteps } = useContext(StepsToDisplayContext)
+  const { groupedSteps, actionStepsToDisplay, groupingActions } = useContext(
+    StepsToDisplayContext,
+  )
   const { getFlagValue } = useContext(LaunchDarklyContext)
+  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
+    useIfThenV2Enabled()
 
   const hasIfThen = groupedSteps.some((group) =>
     group.some((step) => step.key === TOOLBOX_ACTIONS.IfThen),
@@ -99,20 +184,42 @@ export const useIsAppSelectable = ({
     group.some((step) => step.key === TOOLBOX_ACTIONS.ForEach),
   )
 
-  return {
-    [TOOLBOX_ACTIONS.IfThen]: isIfThenSelectable({
-      depth,
-      hasIfThen,
+  // While the flag is resolving, keep the old rules. Selectability must not
+  // loosen out from under an already-open toolbox.
+  if (isIfThenV2Enabled && !isIfThenV2Loading) {
+    return getIfThenV2Selectability({
       isLastStep,
-      getFlagValue,
-    }),
+      anchorPlacement,
+      // A previous step that is the trigger resolves to nothing, which is
+      // correct: a trigger is inside no block.
+      anchorStep:
+        step ??
+        actionStepsToDisplay.find((actionStep) => actionStep.id === prevStepId),
+      actionSteps: actionStepsToDisplay,
+      groupingActions: groupingActions ?? new Set<string>(),
+    })
+  }
+
+  return {
+    [TOOLBOX_ACTIONS.IfThen]: selectability(
+      isIfThenSelectable({
+        depth,
+        hasIfThen,
+        isLastStep,
+        getFlagValue,
+      }),
+    ),
     /**
      * For-each should only be selectable if:
      * - We're the last step.
      * - There's no other for-each action
      * - There's no other if-then action
      */
-    [TOOLBOX_ACTIONS.ForEach]: isLastStep && !hasIfThen && !hasForEach,
-    delay: isDelaySelectable({ hasForEach, groupedSteps, step, prevStepId }),
+    [TOOLBOX_ACTIONS.ForEach]: selectability(
+      isLastStep && !hasIfThen && !hasForEach,
+    ),
+    delay: selectability(
+      isDelaySelectable({ hasForEach, groupedSteps, step, prevStepId }),
+    ),
   }
 }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -3,6 +3,7 @@ import type { IAction, IApp, IStep, ITrigger } from '@plumber/types'
 import { useContext } from 'react'
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 
+import type { AnchorPlacement } from './helpers/anchor-placement'
 import ChooseAndAddConnection from './ChooseAndAddConnection'
 import ChooseAppAndEvent from './ChooseAppAndEvent'
 import {
@@ -23,6 +24,9 @@ interface FlowStepConfigurationModalProps {
   prevStep?: IStep
   // Set only when launched from an if-then block's add-after affordance.
   previousBlockId?: string
+  // Set only by launchers whose anchor step misrepresents where their new step
+  // lands relative to an if-then block. See AnchorPlacement.
+  anchorPlacement?: AnchorPlacement
 }
 
 function FlowStepConfigurationModalContent({
@@ -64,6 +68,7 @@ export default function FlowStepConfigurationModal(
     event,
     prevStep,
     previousBlockId,
+    anchorPlacement,
   } = props
 
   return (
@@ -74,6 +79,7 @@ export default function FlowStepConfigurationModal(
       event={event}
       prevStep={prevStep}
       previousBlockId={previousBlockId}
+      anchorPlacement={anchorPlacement}
       step={step}
     >
       <Modal

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/AddAfterBlockButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/AddAfterBlockButton.tsx
@@ -61,6 +61,9 @@ export function AddAfterBlockButton({
         prevStep={endStep}
         step={endStep}
         previousBlockId={previousBlockId}
+        // Same reasoning as the top-level path below: the anchor (the block's
+        // last child) reads as "inside" the block unless told otherwise.
+        anchorPlacement="after-if-then-block"
       />
     )
   }
@@ -122,6 +125,9 @@ export function AddAfterBlockButton({
           isLastStep={isLastStep}
           prevStep={endStep}
           previousBlockId={previousBlockId}
+          // previousBlockId can't say "after the whole block" either: it is
+          // unset for a region-unconfined block.
+          anchorPlacement="after-if-then-block"
         />
       )}
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -7,6 +7,7 @@ import { Divider, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '@/components/EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
+import type { AnchorPlacement } from '@/components/FlowStepConfigurationModal/helpers/anchor-placement'
 import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
@@ -27,6 +28,9 @@ interface HoverAddStepButtonProps {
   // V2 block nested in a for-each body), to pin/upgrade the block's marker
   // as the top-level button would.
   previousBlockId?: string
+  // Opt-in: this button also serves if-then V1 branches and for-each bodies, so
+  // where the new step lands is the caller's to state, not the button's.
+  anchorPlacement?: AnchorPlacement
 }
 
 export function HoverAddStepButton(
@@ -41,6 +45,7 @@ export function HoverAddStepButton(
     allowReorder,
     canChildStepsReorder,
     previousBlockId,
+    anchorPlacement,
   } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
@@ -115,6 +120,7 @@ export function HoverAddStepButton(
           isLastStep={isLastStep}
           prevStep={prevStep}
           previousBlockId={previousBlockId}
+          anchorPlacement={anchorPlacement}
         />
       )}
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -377,6 +377,9 @@ export default function IfThen({
                     showEmptyAction={true}
                     step={ifThenStep}
                     allowReorder={false}
+                    // The if-then step, this card's anchor, sits outside its
+                    // own block. This step sits inside it.
+                    anchorPlacement="inside-if-then-block"
                   />
                 ) : (
                   <>
@@ -396,6 +399,9 @@ export default function IfThen({
                       step={ifThenStep}
                       allowReorder={false}
                       canChildStepsReorder={children.length > 1}
+                      // Same reasoning as the empty-block placeholder above:
+                      // this step also lands inside the block.
+                      anchorPlacement="inside-if-then-block"
                     />
                     <SortableList
                       items={children.map((step, index) => ({


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Does some small UX fixes:

1. When within For-Each blocks, If-then v2 blocks were not using use the pink square hover "add step" button _after_ the block.
2. The choose app modal was not allowing If-then to be selected in the middle of a pipe.

# Tests

See top of stack.