### PR TITLE
PLU-743: [IF-THEN-THEN-V2-16] Filter away conditionally accessible variables

### DIFF
--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildStepsList,
   deriveIfThenV1EndStep,
+  getEligibleVariableStepIds,
   hasEmptyIfThenV2Block,
   hasIfThenV2Block,
   isBlankPlaceholderStep,
@@ -754,5 +755,176 @@ describe('isBlankPlaceholderStep', () => {
 
   it('is false for an if-then step', () => {
     expect(isBlankPlaceholderStep(ifThen('block'))).toBe(false)
+  })
+})
+
+describe('getEligibleVariableStepIds', () => {
+  it('mirrors the live repro: 3 sibling if-then blocks + plain steps, none of the blocks leak their children or their own condition id', () => {
+    const p1 = plain('p1')
+    const blockA = markedIfThen('blockA', 'a2')
+    const a1 = plain('a1')
+    const a2 = plain('a2')
+    const blockB = markedIfThen('blockB', 'b1')
+    const b1 = plain('b1')
+    const p2 = plain('p2')
+    const blockC = markedIfThen('blockC', 'c2')
+    const c1 = plain('c1')
+    const c2 = plain('c2')
+    const target = plain('target')
+    const steps = [p1, blockA, a1, a2, blockB, b1, p2, blockC, c1, c2, target]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'target'),
+    ).toEqual(['p1', 'p2'])
+  })
+
+  it('returns an empty list when the target is the very first action step', () => {
+    const target = plain('target')
+    const s2 = plain('s2')
+    const steps = [target, s2]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'target'),
+    ).toEqual([])
+  })
+
+  it('contributes nothing from a block when the target is its own condition step', () => {
+    const before = plain('before')
+    const block = markedIfThen('block', 's2')
+    const s2 = plain('s2')
+    const steps = [before, block, s2]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'block'),
+    ).toEqual(['before'])
+  })
+
+  it("contributes nothing (not even the condition id) when the target is a block's first child", () => {
+    const block = markedIfThen('block', 's3')
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+    const steps = [block, s2, s3]
+
+    expect(getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 's2')).toEqual(
+      [],
+    )
+  })
+
+  it("includes only earlier same-block siblings (never the condition id) when the target is a block's later child", () => {
+    const block = markedIfThen('block', 's4')
+    const s2 = plain('s2')
+    const s3 = plain('s3')
+    const s4 = plain('s4')
+    const steps = [block, s2, s3, s4]
+
+    expect(getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 's3')).toEqual([
+      's2',
+    ])
+  })
+
+  it('contributes nothing for an empty (self-referencing) if-then block before the target', () => {
+    const block = markedIfThen('block', 'block')
+    const after = plain('after')
+    const steps = [block, after]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'after'),
+    ).toEqual([])
+  })
+
+  it('treats a dangling-marker if-then like any other block: never its condition id, isDangling/isExplicit are irrelevant', () => {
+    // The dangling marker falls back to the derived V1 extent bounded by
+    // `boundary`, not to unbounded inclusion.
+    const block = markedIfThen('block', 'ghost')
+    const s2 = plain('s2')
+    const boundary = ifThen('boundary')
+    const target = plain('target')
+    const steps = [block, s2, boundary, target]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'target'),
+    ).toEqual([])
+  })
+
+  it('applies uniformly to two consecutive marker-less if-then V1 branches: neither condition id, no children', () => {
+    const ifThenA = nullMarkerIfThen('ifThenA')
+    const sA = plain('sA')
+    const ifThenB = nullMarkerIfThen('ifThenB')
+    const target = plain('target')
+    const steps = [ifThenA, sA, ifThenB, target]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'target'),
+    ).toEqual([])
+  })
+
+  it('excludes a later for-each entirely when the target precedes it', () => {
+    const before = plain('before')
+    const target = plain('target')
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const steps = [before, target, forEachStep, s1]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'target'),
+    ).toEqual(['before'])
+  })
+
+  it('fully includes a for-each (own id + its not-yet-run body) when the target is the for-each step itself', () => {
+    // Mirrors groupStepsToInclude's existing behaviour verbatim. Safe only
+    // because the caller (StepExecutions.tsx) applies a downstream position
+    // filter that excludes anything not-yet-executed.
+    const forEachStep = forEach('forEach')
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+    const steps = [forEachStep, s1, s2]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'forEach'),
+    ).toEqual(['forEach', 's1', 's2'])
+  })
+
+  it('fully flattens a for-each body when the target is nested inside an if-then within it, siblings included but not the condition id', () => {
+    const forEachStep = forEach('forEach')
+    const before = plain('before')
+    const nestedIf = markedIfThen('nestedIf', 'n2')
+    const n1 = plain('n1')
+    const n2 = plain('n2')
+    const steps = [forEachStep, before, nestedIf, n1, n2]
+
+    expect(getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'n2')).toEqual([
+      'forEach',
+      'before',
+      'n1',
+      'n2',
+    ])
+  })
+
+  it('excludes a later for-each when the target is inside an earlier top-level if-then block (V2 sibling coexistence)', () => {
+    // V1 never allowed an if-then and a for-each to coexist in one flow at
+    // all; V2's getIfThenV2Selectability drops that restriction.
+    const block = markedIfThen('block', 'b2')
+    const b1 = plain('b1')
+    const b2 = plain('b2')
+    const forEachStep = forEach('forEach')
+    const f1 = plain('f1')
+    const steps = [block, b1, b2, forEachStep, f1]
+
+    expect(getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'b2')).toEqual([
+      'b1',
+    ])
+  })
+
+  it('returns the full walk with no breaks when the target id is not present at all (simulates the trigger)', () => {
+    // buildStepsList never sees the trigger; the caller's own downstream
+    // position filter means nothing can be "prior to" the trigger regardless,
+    // so returning everything here is safe.
+    const s1 = plain('s1')
+    const s2 = plain('s2')
+    const steps = [s1, s2]
+
+    expect(
+      getEligibleVariableStepIds(steps, GROUPING_ACTIONS, 'trigger'),
+    ).toEqual(['s1', 's2'])
   })
 })

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -352,3 +352,74 @@ export function hasIfThenV2Block(flowSteps: IStep[]): boolean {
 export function isBlankPlaceholderStep(step: IStep): boolean {
   return !step.appKey && !step.key
 }
+
+/**
+ * Ids of steps eligible as a "Use data from…" variable source for
+ * `targetStepId`, under the if-then V2 block model.
+ *
+ * An if-then's own condition output (e.g. `isConditionMet`) is never
+ * offered, by product decision. For-each flattening mirrors
+ * StepExecutions.tsx's existing groupStepsToInclude behaviour verbatim, kept
+ * for backward compatibility.
+ *
+ * IMPORTANT: `actionSteps` must already exclude the trigger, as
+ * buildStepsList expects. Callers add the trigger's id back themselves.
+ */
+export function getEligibleVariableStepIds(
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+  targetStepId: string,
+): string[] {
+  const items = buildStepsList(actionSteps, groupingActions)
+  const result: string[] = []
+
+  for (const item of items) {
+    if (item.type === 'step') {
+      if (item.step.id === targetStepId) {
+        break
+      }
+      result.push(item.step.id)
+      continue
+    }
+
+    if (item.type === 'ifThenBlock') {
+      if (item.ifThenStep.id === targetStepId) {
+        break
+      }
+      const childIndex = item.children.findIndex(
+        (child) => child.id === targetStepId,
+      )
+      if (childIndex !== -1) {
+        result.push(
+          ...item.children.slice(0, childIndex).map((child) => child.id),
+        )
+        break
+      }
+      continue
+    }
+
+    // A for-each is always buildStepsList's last top-level item, so nothing
+    // legitimate follows it here.
+    result.push(item.forEachStep.id, ...flattenStepIds(item.children))
+    break
+  }
+
+  return result
+}
+
+/**
+ * Flattens every step id in `items`, mirroring for-each's pre-existing
+ * behaviour of including its full contents unconditionally. Still drops each
+ * if-then block's own condition id, matching `getEligibleVariableStepIds`.
+ */
+function flattenStepIds(items: StepsListItem[]): string[] {
+  return items.flatMap((item) => {
+    if (item.type === 'step') {
+      return [item.step.id]
+    }
+    if (item.type === 'ifThenBlock') {
+      return item.children.map((child) => child.id)
+    }
+    return [item.forEachStep.id, ...flattenStepIds(item.children)]
+  })
+}

--- a/packages/frontend/src/contexts/StepExecutions.tsx
+++ b/packages/frontend/src/contexts/StepExecutions.tsx
@@ -2,7 +2,9 @@ import type { IExecutionStep, IStep } from '@plumber/types'
 
 import { createContext, useContext, useMemo } from 'react'
 
+import { getEligibleVariableStepIds } from '@/components/Editor/helpers/steps-utils'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 import { EditorContext } from './Editor'
 import { StepsToDisplayContext } from './StepsToDisplay'
@@ -26,7 +28,12 @@ export const StepExecutionsProvider = ({
     triggerStep,
     actionStepsBeforeGroup: stepsBeforeGroup,
     groupedSteps,
+    actionStepsToDisplay,
+    groupingActions,
   } = useContext(StepsToDisplayContext)
+
+  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
+    useIfThenV2Enabled()
 
   //
   // Compute which steps are eligible for variable extraction.
@@ -37,6 +44,9 @@ export const StepExecutionsProvider = ({
   // - we include some grouped steps as there is no longer a nested editor
   // - we identify the group by checking if the current step id is in the group
   // - for-each steps are always included
+  //
+  // If-then V1 only. Left untouched because the if-then V2-aware fork below
+  // is additive.
   const groupStepsToInclude = useMemo(() => {
     return groupedSteps.flatMap((group) =>
       group.some(
@@ -48,15 +58,36 @@ export const StepExecutionsProvider = ({
     )
   }, [currentStep?.id, groupedSteps])
 
-  const stepExecutionsToInclude = useMemo(
+  const eligibleBlockStepIds = useMemo(
     () =>
-      new Set([
-        ...(triggerStep?.id ? [triggerStep.id] : []),
-        ...stepsBeforeGroup.map((step) => step.id),
-        ...groupStepsToInclude.map((s) => s.id),
-      ]),
-    [triggerStep, stepsBeforeGroup, groupStepsToInclude],
+      getEligibleVariableStepIds(
+        actionStepsToDisplay,
+        groupingActions ?? new Set<string>(),
+        currentStep.id,
+      ),
+    [actionStepsToDisplay, groupingActions, currentStep.id],
   )
+
+  const stepExecutionsToInclude = useMemo(() => {
+    if (isIfThenV2Enabled && !isIfThenV2Loading) {
+      return new Set([
+        ...(triggerStep?.id ? [triggerStep.id] : []),
+        ...eligibleBlockStepIds,
+      ])
+    }
+    return new Set([
+      ...(triggerStep?.id ? [triggerStep.id] : []),
+      ...stepsBeforeGroup.map((step) => step.id),
+      ...groupStepsToInclude.map((s) => s.id),
+    ])
+  }, [
+    isIfThenV2Enabled,
+    isIfThenV2Loading,
+    eligibleBlockStepIds,
+    triggerStep,
+    stepsBeforeGroup,
+    groupStepsToInclude,
+  ])
 
   const priorExecutionSteps = useMemo(
     () =>


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our variables suggestion popover to filter out variables from other If-Then blocks as needed.

# Tests

See top of stack.