### PR TITLE
PLU-743: [IF-THEN-THEN-V2-6] Support updating endStepId when deleting step

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -1,8 +1,12 @@
+import type { IStepConfig } from '@plumber/types'
+
 import { describe, expect, it } from 'vitest'
 
 import {
   deriveIfThenV1EndStep,
+  expandIfThenBlockDeletions,
   findBlankPlaceholderMemberIds,
+  reassignIfThenEndStepsOnDelete,
 } from '../../../../actions/if-then/infra/end-step-utils'
 
 type Fixture = {
@@ -11,6 +15,7 @@ type Fixture = {
   key?: string
   parameters?: Record<string, any>
   position: number
+  config?: IStepConfig
 }
 
 const trigger = (position: number): Fixture => ({
@@ -197,5 +202,172 @@ describe('findBlankPlaceholderMemberIds', () => {
     const steps = [trigger(1), ifThenA, real, outsideBlank]
 
     expect(findBlankPlaceholderMemberIds(steps, ifThenA, real)).toEqual([])
+  })
+})
+
+const markedIfThen = (
+  id: string,
+  position: number,
+  endStepId: string,
+): Fixture => ifThen(id, position, { config: { endStepId } })
+
+describe('reassignIfThenEndStepsOnDelete', () => {
+  it('repoints a block whose endStep (tail) was deleted to the new highest survivor', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 's3' },
+    ])
+  })
+
+  it('repoints to the highest surviving member when the tail run is deleted', () => {
+    const block = markedIfThen('A', 2, 's5')
+    const steps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4', 's5'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 's3' },
+    ])
+  })
+
+  it('empties a block to self-reference when every member is deleted', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3', 's4'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 'A' },
+    ])
+  })
+
+  it('leaves a block untouched when a mid-block member is deleted but the endStep survives', () => {
+    const block = markedIfThen('A', 2, 's5')
+    const steps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s4'])).toEqual([])
+  })
+
+  it('does not repair a block whose own if-then is deleted', () => {
+    const block = markedIfThen('A', 2, 's3')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['A', 's3'])).toEqual([])
+  })
+
+  it('leaves a surviving empty (self-referencing) block untouched', () => {
+    const block = markedIfThen('A', 2, 'A')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3'])).toEqual([])
+  })
+
+  it('repairs multiple blocks in a single batch', () => {
+    const blockA = markedIfThen('A', 2, 'a3')
+    const blockB = markedIfThen('B', 4, 'b5')
+    const steps = [trigger(1), blockA, plain('a3', 3), blockB, plain('b5', 5)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['a3', 'b5'])).toEqual([
+      { ifThenStepId: 'A', endStepId: 'A' },
+      { ifThenStepId: 'B', endStepId: 'B' },
+    ])
+  })
+
+  it('never repairs a legacy (marker-less) if-then', () => {
+    const legacy = ifThen('L', 2)
+    const steps = [trigger(1), legacy, plain('s3', 3)]
+
+    expect(reassignIfThenEndStepsOnDelete(steps, ['s3'])).toEqual([])
+  })
+})
+
+describe('expandIfThenBlockDeletions', () => {
+  const ids = (set: Set<string>) => [...set].sort()
+
+  it('expands a single marked if-then id to its whole block range', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A', 's3', 's4'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('is a no-op when the full range is already requested', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds } = expandIfThenBlockDeletions(steps, ['A', 's3', 's4'])
+    expect(ids(expandedIds)).toEqual(['A', 's3', 's4'])
+  })
+
+  it('never expands a legacy (marker-less) if-then', () => {
+    const legacy = ifThen('L', 2)
+    const steps = [trigger(1), legacy, plain('s3', 3), plain('s4', 4)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['L'],
+    )
+    expect(ids(expandedIds)).toEqual(['L'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('expands an empty (self-referencing) block to just its if-then', () => {
+    const block = markedIfThen('A', 2, 'A')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual([])
+  })
+
+  it('does not expand a block with a dangling marker and reports it', () => {
+    const block = markedIfThen('A', 2, 'ghost')
+    const steps = [trigger(1), block, plain('s3', 3)]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual(['A'])
+  })
+
+  it('treats a marker pointing before the if-then as dangling', () => {
+    const block = markedIfThen('A', 4, 's2')
+    const steps = [trigger(1), plain('s2', 2), plain('s3', 3), block]
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      steps,
+      ['A'],
+    )
+    expect(ids(expandedIds)).toEqual(['A'])
+    expect(danglingIfThenIds).toEqual(['A'])
+  })
+
+  it('passes plain-step deletions through unchanged', () => {
+    const block = markedIfThen('A', 2, 's4')
+    const steps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    // Deleting an interior member (not the if-then) does not expand.
+    const { expandedIds } = expandIfThenBlockDeletions(steps, ['s3'])
+    expect(ids(expandedIds)).toEqual(['s3'])
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -1,8 +1,10 @@
 import type { IStep } from '@plumber/types'
 
 import {
+  BLOCK_END_STEP_ID,
   isBlankPlaceholderStep,
   isIfThenStep,
+  isIfThenV2,
   type StepLike,
 } from '../../../common/constants'
 
@@ -11,6 +13,16 @@ import {
 type ExtentStep = StepLike &
   Pick<IStep, 'id' | 'position'> &
   Partial<Pick<IStep, 'parameters'>>
+
+// Loose enough that unit tests can pass partial plain objects instead of
+// full Step rows.
+// IMPORTANT: callers must pass steps ordered by position ascending.
+type RepairStep = StepLike & Pick<IStep, 'id' | 'position'>
+
+export interface EndStepPatch {
+  ifThenStepId: string
+  endStepId: string
+}
 
 // Mirrors getIfThenV1StepIdToSkipTo's depth defaulting; nesting never shipped,
 // so this is dead-code defense.
@@ -63,4 +75,87 @@ export function findBlankPlaceholderMemberIds<T extends ExtentStep>(
         isBlankPlaceholderStep(step),
     )
     .map((step) => step.id)
+}
+
+/**
+ * IMPORTANT: `stepsBeforeDelete` must be ordered by position ascending and
+ * reflect pre-delete positions. A block whose own if-then was deleted needs
+ * no repair here — block-expansion removes it whole instead.
+ */
+export function reassignIfThenEndStepsOnDelete<T extends RepairStep>(
+  stepsBeforeDelete: T[],
+  deletedIds: string[],
+): EndStepPatch[] {
+  const deleted = new Set(deletedIds)
+  const patches: EndStepPatch[] = []
+
+  for (const step of stepsBeforeDelete) {
+    if (!isIfThenV2(step) || deleted.has(step.id)) {
+      continue
+    }
+    const oldEndStepId = step.config?.[BLOCK_END_STEP_ID]
+    // endStep survived, or the marker was already dangling — nothing to repair.
+    if (oldEndStepId === undefined || !deleted.has(oldEndStepId)) {
+      continue
+    }
+    const oldEnd = stepsBeforeDelete.find((s) => s.id === oldEndStepId)
+    if (!oldEnd) {
+      continue
+    }
+
+    let endStepId = step.id
+    let endPosition = step.position
+    for (const candidate of stepsBeforeDelete) {
+      if (
+        !deleted.has(candidate.id) &&
+        candidate.position > step.position &&
+        candidate.position <= oldEnd.position &&
+        candidate.position > endPosition
+      ) {
+        endStepId = candidate.id
+        endPosition = candidate.position
+      }
+    }
+    patches.push({ ifThenStepId: step.id, endStepId })
+  }
+
+  return patches
+}
+
+/**
+ * Expands a requested delete set so deleting a new-style if-then also
+ * deletes its whole block range. A client that already sent the full range
+ * (e.g. an old-UI branch delete) is a no-op via the set union.
+ *
+ * IMPORTANT: `flowSteps` must be ordered by position ascending.
+ */
+export function expandIfThenBlockDeletions<T extends RepairStep>(
+  flowSteps: T[],
+  requestedIds: string[],
+): { expandedIds: Set<string>; danglingIfThenIds: string[] } {
+  const requested = new Set(requestedIds)
+  const expandedIds = new Set(requestedIds)
+  const danglingIfThenIds: string[] = []
+
+  for (const step of flowSteps) {
+    if (!requested.has(step.id) || !isIfThenV2(step)) {
+      continue
+    }
+    const endStepId = step.config?.[BLOCK_END_STEP_ID]
+    const endStep = flowSteps.find((s) => s.id === endStepId)
+    if (!endStep || endStep.position < step.position) {
+      danglingIfThenIds.push(step.id)
+      continue
+    }
+    for (const member of flowSteps) {
+      if (
+        member.position >= step.position &&
+        member.position <= endStep.position
+      ) {
+        expandedIds.add(member.id)
+      }
+    }
+  }
+
+  return { expandedIds, danglingIfThenIds }
 }

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -5,6 +5,7 @@ import { raw, Transaction } from 'objection'
 import {
   deriveIfThenV1EndStep,
   findBlankPlaceholderMemberIds,
+  reassignIfThenEndStepsOnDelete,
 } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
@@ -275,5 +276,41 @@ export async function deriveV1EndStepDroppingBlankMembers(
       refetchedSteps.find((step) => step.id === ifThenStep.id),
     ),
     cleaned: true,
+  }
+}
+
+/**
+ * Repairs if-then markers after a deleteStep. Runs over the surviving step
+ * set (not the deleted ids), so it also covers steps removed indirectly via
+ * `removeMrfSteps`.
+ *
+ * IMPORTANT: a repaired marker only ever shrinks its block, so it stays
+ * valid by construction. Structural mutations repair here, never reject.
+ */
+export async function repairEndStepsOnDeleteStep({
+  trx,
+  flow,
+  stepsBeforeDelete,
+}: {
+  trx: Transaction
+  flow: Flow
+  stepsBeforeDelete: Step[]
+}): Promise<void> {
+  const survivingSteps = await flow.$relatedQuery('steps', trx)
+  const survivingIds = new Set(survivingSteps.map((step) => step.id))
+  const deletedIds = stepsBeforeDelete
+    .map((step) => step.id)
+    .filter((id) => !survivingIds.has(id))
+
+  const patches = reassignIfThenEndStepsOnDelete(stepsBeforeDelete, deletedIds)
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+    logger.info({
+      event: 'end-step-repaired',
+      mutation: 'deleteStep',
+      ifThenStepId,
+      endStepId,
+      flowId: flow.id,
+    })
   }
 }

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -1,7 +1,8 @@
 import { NotFoundError } from 'objection'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import deleteStep from '@/graphql/mutations/delete-step'
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import User from '@/models/user'
@@ -281,5 +282,197 @@ describe('deleteStep mutation', () => {
         context,
       ),
     ).rejects.toThrow(NotFoundError)
+  })
+
+  describe('new-style if-then block expansion and marker repair', () => {
+    let blockFlow: Flow
+    let blockFlowInput: { flow: { updatedAt: string } }
+    let loggerErrorSpy: MockInstance
+
+    const addTrigger = (
+      key: 'catchRawWebhook' | 'newSubmission',
+      appKey: 'custom-api' | 'formsg',
+    ) =>
+      generateMockStep(context, key, appKey, 'trigger', blockFlow.id, 1, {}, {})
+
+    const addIfThen = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        blockFlow.id,
+        position,
+        { depth: '0' },
+        config,
+      )
+
+    const addPlain = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        blockFlow.id,
+        position,
+        { email: 'test@example.com' },
+        config,
+      )
+
+    const currentSteps = () =>
+      blockFlow.$relatedQuery('steps').orderBy('position', 'asc')
+
+    beforeEach(async () => {
+      loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+      blockFlow = await owner.$relatedQuery('flows').insertAndFetch({
+        name: 'Block Flow',
+      })
+      blockFlowInput = { flow: { updatedAt: blockFlow.updatedAt } }
+    })
+
+    it('deletes the whole block when only the marked if-then id is sent', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+      await addPlain(3)
+      const after = await addPlain(5)
+
+      await deleteStep(
+        null,
+        { input: { ids: [ifThen.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([
+        steps[0].id, // trigger
+        after.id,
+      ])
+      expect(steps[1].position).toBe(2)
+    })
+
+    it('is a no-op double-delete when the full range is sent (old-UI branch delete)', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+      const after = await addPlain(5)
+
+      await deleteStep(
+        null,
+        {
+          input: { ids: [ifThen.id, s3.id, s4.id], ...blockFlowInput },
+        },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, after.id])
+    })
+
+    it('never expands a legacy (marker-less) if-then', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const legacy = await addIfThen(2) // no endStepId marker
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+
+      await deleteStep(
+        null,
+        { input: { ids: [legacy.id], ...blockFlowInput } },
+        context,
+      )
+
+      // Only the if-then is deleted. The following steps keep old-client
+      // single-id delete semantics.
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, s3.id, s4.id])
+    })
+
+    it('repoints a surviving block to its new highest member when the endStep is deleted', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const s4 = await addPlain(4)
+      const ifThen = await addIfThen(2, { endStepId: s4.id })
+
+      await deleteStep(
+        null,
+        { input: { ids: [s4.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(s3.id)
+    })
+
+    it('empties a block to self-reference when its only member is deleted', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: s3.id })
+
+      await deleteStep(
+        null,
+        { input: { ids: [s3.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(ifThen.id)
+    })
+
+    it('does not expand a dangling marker and logs it', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: 'does-not-exist' })
+
+      await deleteStep(
+        null,
+        { input: { ids: [ifThen.id], ...blockFlowInput } },
+        context,
+      )
+
+      // Only the if-then is deleted; its member survives.
+      const steps = await currentSteps()
+      expect(steps.map((s) => s.id)).toEqual([steps[0].id, s3.id])
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'if-then-dangling-end-step',
+          mutation: 'deleteStep',
+          ifThenStepId: ifThen.id,
+        }),
+      )
+    })
+
+    it('preserves an intact block marker when the trigger (MRF) branch is deleted', async () => {
+      const trigger = await addTrigger('newSubmission', 'formsg')
+      const s3 = await addPlain(3)
+      const ifThen = await addIfThen(2, { endStepId: s3.id })
+      // An MRF submission step outside the block, removed by removeMrfSteps.
+      await generateMockStep(
+        context,
+        'mrfSubmission',
+        'formsg',
+        'action',
+        blockFlow.id,
+        4,
+        {},
+        {},
+      )
+
+      await deleteStep(
+        null,
+        { input: { ids: [trigger.id], ...blockFlowInput } },
+        context,
+      )
+
+      // removeMrfSteps drops the mrfSubmission step. The block's marker is
+      // repaired over the survivor set and stays intact since its endStep
+      // survived.
+      const steps = await currentSteps()
+      const repaired = steps.find((s) => s.id === ifThen.id)
+      expect(repaired?.config.endStepId).toBe(s3.id)
+      expect(steps.some((s) => s.key === 'mrfSubmission')).toBe(false)
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -1,7 +1,10 @@
 import { raw } from 'objection'
 
 import { removeMrfSteps } from '@/apps/formsg/triggers/new-submission/remove-mrf-steps'
+import { expandIfThenBlockDeletions } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import { repairEndStepsOnDeleteStep } from '@/apps/toolbox/common/validate-end-step'
 import { hasStepReference } from '@/helpers/check-step-parameters'
+import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -29,30 +32,62 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
   return await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
     // Include SELECTs in transaction too just in case there's concurrent modification.
-    const steps = await context.currentUser
+    // Loads the whole flow's steps (not just the requested ids), since the
+    // integrity logic below needs the full set to expand a marked if-then to
+    // its block range and repair surviving blocks after the delete.
+    const stepsBeforeDelete = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', input.ids)
+      .whereIn(
+        'steps.flow_id',
+        Step.query(trx).select('flow_id').whereIn('id', input.ids),
+      )
       .orderBy('steps.position', 'asc')
       .throwIfNotFound({
         message: 'Step not found. Refresh the page and try again.',
       })
 
-    const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
+    const steps = stepsBeforeDelete.filter((step) =>
+      input.ids.includes(step.id),
+    )
 
+    // Confirm the request is single-pipe before deriving the flow, so
+    // `steps[0].flow` is unambiguous (stepsBeforeDelete may span pipes if the
+    // request mixed them).
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
     }
+
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
+
+    const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
+      stepsBeforeDelete,
+      input.ids,
+    )
+    for (const ifThenStepId of danglingIfThenIds) {
+      logger.error({
+        event: 'if-then-dangling-end-step',
+        mutation: 'deleteStep',
+        ifThenStepId,
+        flowId: flow.id,
+      })
+    }
+    const stepsToDelete = stepsBeforeDelete.filter((step) =>
+      expandedIds.has(step.id),
+    )
 
     //
     // ** IMPORTANT NOTE **
     // We only support deleting single trigger steps or contiguous action steps.
     //
-    if (steps.length === 1 && steps[0].type === 'trigger') {
-      const deletedStepId = steps[0].id
+    if (stepsToDelete.length === 1 && stepsToDelete[0].type === 'trigger') {
+      const deletedStepId = stepsToDelete[0].id
 
-      if (steps[0].appKey === 'formsg' && steps[0].key === 'newSubmission') {
+      if (
+        stepsToDelete[0].appKey === 'formsg' &&
+        stepsToDelete[0].key === 'newSubmission'
+      ) {
         await removeMrfSteps(flow.id, trx)
       }
 
@@ -71,7 +106,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
 
       // we delete and add a new trigger upon deletion to preserve past execution steps' context
-      await steps[0].$query(trx).delete()
+      await stepsToDelete[0].$query(trx).delete()
       await flow.$relatedQuery('steps', trx).insert({
         key: null,
         appKey: null,
@@ -82,16 +117,17 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
     } else {
       if (
-        !steps.every(
+        !stepsToDelete.every(
           (step, index) =>
-            (index === 0 || step.position === steps[index - 1].position + 1) &&
+            (index === 0 ||
+              step.position === stepsToDelete[index - 1].position + 1) &&
             step.type === 'action',
         )
       ) {
         throw new Error('Must delete contiguous action steps!')
       }
 
-      const stepIds = steps.map((step) => step.id)
+      const stepIds = stepsToDelete.map((step) => step.id)
 
       // check for steps whose parameters reference the deletedStepId
       const allSteps = await flow
@@ -115,9 +151,15 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
 
       await flow
         .$relatedQuery('steps', trx)
-        .where('position', '>', steps[steps.length - 1].position)
-        .patch({ position: raw(`position - ${steps.length}`) })
+        .where(
+          'position',
+          '>',
+          stepsToDelete[stepsToDelete.length - 1].position,
+        )
+        .patch({ position: raw(`position - ${stepsToDelete.length}`) })
     }
+
+    await repairEndStepsOnDeleteStep({ trx, flow, stepsBeforeDelete })
 
     await flow.patchLastUpdated({
       flowId: flow.id,


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Enables our `deleteStep` mutation to fixup `endStepId` to the correct step ID (e.g. if the user deleted the last step in a If-then V2 block).

# Tests

See top of stack.