### PR TITLE
PLU-743: [IF-THEN-THEN-V2-7] Support updating endStepId when re-ordering steps

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -7,6 +7,7 @@ import {
   expandIfThenBlockDeletions,
   findBlankPlaceholderMemberIds,
   reassignIfThenEndStepsOnDelete,
+  reassignIfThenEndStepsOnReorder,
 } from '../../../../actions/if-then/infra/end-step-utils'
 
 type Fixture = {
@@ -369,5 +370,103 @@ describe('expandIfThenBlockDeletions', () => {
     // Deleting an interior member (not the if-then) does not expand.
     const { expandedIds } = expandIfThenBlockDeletions(steps, ['s3'])
     expect(ids(expandedIds)).toEqual(['s3'])
+  })
+})
+
+describe('reassignIfThenEndStepsOnReorder', () => {
+  it('moves the endStep to the member that now sits at the highest position', () => {
+    const block = markedIfThen('A', 2, 's5')
+    const preSteps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+    const newPositions = [
+      { id: 's5', position: 3 },
+      { id: 's3', position: 4 },
+      { id: 's4', position: 5 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([
+      { ifThenStepId: 'A', endStepId: 's4' },
+    ])
+  })
+
+  it('is a no-op when the reorder does not touch a block', () => {
+    const block = markedIfThen('A', 2, 's3')
+    const preSteps = [
+      trigger(1),
+      block,
+      plain('s3', 3),
+      plain('a4', 4),
+      plain('a5', 5),
+    ]
+    const newPositions = [
+      { id: 'a5', position: 4 },
+      { id: 'a4', position: 5 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('preserves membership when a whole block moves as a unit', () => {
+    const before = plain('before', 2)
+    const block = markedIfThen('A', 3, 's5')
+    const preSteps = [trigger(1), before, block, plain('s4', 4), plain('s5', 5)]
+    const newPositions = [
+      { id: 'A', position: 2 },
+      { id: 's4', position: 3 },
+      { id: 's5', position: 4 },
+      { id: 'before', position: 5 },
+    ]
+
+    // s5 is still the highest-positioned member, so nothing changes.
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('leaves an empty (self-referencing) block untouched', () => {
+    const block = markedIfThen('A', 2, 'A')
+    const preSteps = [trigger(1), block, plain('a3', 3), plain('a4', 4)]
+    const newPositions = [
+      { id: 'a3', position: 4 },
+      { id: 'a4', position: 3 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('leaves a block with a dangling marker untouched', () => {
+    const block = markedIfThen('A', 2, 'ghost')
+    const preSteps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+    const newPositions = [
+      { id: 's3', position: 4 },
+      { id: 's4', position: 3 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([])
+  })
+
+  it('repairs only the block whose interior was reordered', () => {
+    const blockA = markedIfThen('A', 2, 'a4')
+    const blockB = markedIfThen('B', 5, 'b7')
+    const preSteps = [
+      trigger(1),
+      blockA,
+      plain('a3', 3),
+      plain('a4', 4),
+      blockB,
+      plain('b6', 6),
+      plain('b7', 7),
+    ]
+    const newPositions = [
+      { id: 'b7', position: 6 },
+      { id: 'b6', position: 7 },
+    ]
+
+    expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([
+      { ifThenStepId: 'B', endStepId: 'b6' },
+    ])
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -159,3 +159,54 @@ export function expandIfThenBlockDeletions<T extends RepairStep>(
 
   return { expandedIds, danglingIfThenIds }
 }
+
+/**
+ * Computes marker reassignments after a reorder. A reorder never changes
+ * block membership, so a block moved as a whole unit produces no patch —
+ * only an endStep that's no longer the highest-positioned member does.
+ *
+ * IMPORTANT: `preSteps` must be ordered by position ascending.
+ */
+export function reassignIfThenEndStepsOnReorder<T extends RepairStep>(
+  preSteps: T[],
+  newPositions: { id: string; position: number }[],
+): EndStepPatch[] {
+  const newPositionById = new Map(
+    newPositions.map(({ id, position }) => [id, position]),
+  )
+  const positionOf = (step: T): number =>
+    newPositionById.get(step.id) ?? step.position
+
+  const patches: EndStepPatch[] = []
+
+  for (const step of preSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const oldEndStepId = step.config?.[BLOCK_END_STEP_ID]
+    const oldEnd = preSteps.find((s) => s.id === oldEndStepId)
+    // A dangling marker is out of scope for reorder repair.
+    if (!oldEnd) {
+      continue
+    }
+    const members = preSteps.filter(
+      (s) => s.position > step.position && s.position <= oldEnd.position,
+    )
+    // An empty (self-referencing) block has nothing to reassign.
+    if (members.length === 0) {
+      continue
+    }
+
+    let newEnd = members[0]
+    for (const member of members) {
+      if (positionOf(member) > positionOf(newEnd)) {
+        newEnd = member
+      }
+    }
+    if (newEnd.id !== oldEndStepId) {
+      patches.push({ ifThenStepId: step.id, endStepId: newEnd.id })
+    }
+  }
+
+  return patches
+}

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -6,6 +6,7 @@ import {
   deriveIfThenV1EndStep,
   findBlankPlaceholderMemberIds,
   reassignIfThenEndStepsOnDelete,
+  reassignIfThenEndStepsOnReorder,
 } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
@@ -308,6 +309,37 @@ export async function repairEndStepsOnDeleteStep({
     logger.info({
       event: 'end-step-repaired',
       mutation: 'deleteStep',
+      ifThenStepId,
+      endStepId,
+      flowId: flow.id,
+    })
+  }
+}
+
+/**
+ * Repairs if-then markers after an updateStepPositions, patching only the
+ * markers that actually changed.
+ *
+ * IMPORTANT: a repaired marker still points at a block member, so it stays
+ * valid by construction. Structural mutations repair here, never reject.
+ */
+export async function repairEndStepsOnReorder({
+  trx,
+  flow,
+  preSteps,
+  newPositions,
+}: {
+  trx: Transaction
+  flow: Flow
+  preSteps: Step[]
+  newPositions: { id: string; position: number }[]
+}): Promise<void> {
+  const patches = reassignIfThenEndStepsOnReorder(preSteps, newPositions)
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+    logger.info({
+      event: 'end-step-repaired',
+      mutation: 'updateStepPositions',
       ifThenStepId,
       endStepId,
       flowId: flow.id,

--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -1,8 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStepPositions from '@/graphql/mutations/update-step-positions'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
 
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
 
@@ -106,6 +110,8 @@ describe('updateStepPositions mutation', () => {
     })
     vi.spyOn(Step, 'query').mockReturnValue({
       findById: stepFindByIdSpy,
+      // Subquery builder used to scope the step load to the flow.
+      select: vi.fn().mockReturnValue({ whereIn: vi.fn() }),
     } as any)
 
     // Fake the chained query methods on context.currentUser.$relatedQuery('steps')
@@ -322,5 +328,153 @@ describe('updateStepPositions mutation', () => {
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
       'Failed to update: steps were not found',
     )
+  })
+})
+
+// Real-DB integration tests, kept separate from the mock-based suite above
+// so the repair runs against real flow steps.
+describe('updateStepPositions endStepId repair', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let loggerInfoSpy: MockInstance
+
+  const flowInput = () => ({
+    updatedAt: new Date(testFlow.updatedAt).getTime().toString(),
+  })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  const wasRepaired = () =>
+    loggerInfoSpy.mock.calls.some(
+      ([arg]) =>
+        arg?.event === 'end-step-repaired' &&
+        arg?.mutation === 'updateStepPositions',
+    )
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Reorder Flow',
+      updatedBy: owner.id,
+    })
+
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => null)
+  })
+
+  it('moves the endStep marker to the new highest member after an interior reorder', async () => {
+    const [, ifThen, s3, s4, s5] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: s5.id } })
+
+    // Reorder the block interior [s3, s4, s5] -> [s5, s3, s4].
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: s5.id, position: 3, type: 'action' as const },
+            { id: s3.id, position: 4, type: 'action' as const },
+            { id: s4.id, position: 5, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(s4.id)
+    expect(wasRepaired()).toBe(true)
+  })
+
+  it('leaves the marker untouched when the reorder does not touch the block', async () => {
+    const [, ifThen, s3, a4, a5] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: s3.id } })
+
+    // Reorder two later steps that sit outside the block.
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: a5.id, position: 4, type: 'action' as const },
+            { id: a4.id, position: 5, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(s3.id)
+    expect(wasRepaired()).toBe(false)
+  })
+
+  it('reorders a legacy (marker-less) flow without writing any marker', async () => {
+    const [, legacy, s3, s4] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await updateStepPositions(
+      null,
+      {
+        input: {
+          stepPositions: [
+            { id: s4.id, position: 3, type: 'action' as const },
+            { id: s3.id, position: 4, type: 'action' as const },
+          ],
+          flow: flowInput(),
+        },
+      },
+      context,
+    )
+
+    expect((await reload(legacy.id)).config.endStepId).toBeUndefined()
+    expect(wasRepaired()).toBe(false)
   })
 })

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -2,6 +2,7 @@ import { IStep } from '@plumber/types'
 
 import { PartialModelObject, raw } from 'objection'
 
+import { repairEndStepsOnReorder } from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
@@ -39,23 +40,44 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
   const updatedPositions = await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
-    const steps = await context.currentUser
+    // Queries all steps of the impacted flow so block end steps can be
+    // repaired after the reorder. The steps named in the request params
+    // drive the position update itself.
+    const allSteps = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', stepIds)
+      .whereIn(
+        'steps.flow_id',
+        Step.query(trx).select('flow_id').whereIn('id', stepIds),
+      )
       .orderBy('steps.position', 'asc')
       .throwIfNotFound()
 
-    if (steps[0].flow.active) {
+    const stepsFromParams = allSteps.filter((step) => stepIds.includes(step.id))
+
+    // Confirm the request is single-pipe before deriving the flow, so
+    // `stepsFromParams[0].flow` is unambiguous (allSteps may span pipes if the
+    // request mixed them).
+    if (
+      !stepsFromParams.every(
+        (step) => step.flowId === stepsFromParams[0].flowId,
+      )
+    ) {
+      throw new BadUserInputError(
+        'Failed to update: steps must be from the same pipe!',
+      )
+    }
+
+    const flow = stepsFromParams[0].flow
+    if (flow.active) {
       throw new BadUserInputError(
         'Pipe is active. Cannot update step in active pipe!',
       )
     }
 
-    const flow = steps[0].flow
     flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
-    const foundStepIds = steps.map((step) => step.id)
+    const foundStepIds = stepsFromParams.map((step) => step.id)
     const missingStepIds = stepIds.filter(
       (id: string) => !foundStepIds.includes(id),
     )
@@ -67,8 +89,8 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     // since we are only updating actions based on their groups
     // e.g., non grouped steps, or actions within an if-then branch
     // validate that the step positions are not out of bounds
-    const minPosition = steps[0].position
-    const maxPosition = steps[steps.length - 1].position
+    const minPosition = stepsFromParams[0].position
+    const maxPosition = stepsFromParams[stepsFromParams.length - 1].position
     if (
       stepPositions.some((obj) => obj.position > maxPosition) ||
       stepPositions.some((obj) => obj.position < minPosition)
@@ -92,6 +114,13 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       }
       await Step.query(trx).findById(stepPosition.id).patch(patchData)
     }
+
+    await repairEndStepsOnReorder({
+      trx,
+      flow,
+      preSteps: allSteps,
+      newPositions: stepPositions,
+    })
 
     // Update the flow's lastUpdatedAt timestamp
     const updatedFlow = await flow


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Enables our `updateStepPositions` mutation (i.e re-ordering) to fixup `endStepId` to the correct step ID (e.g. if the user moved the last step in a If-then V2 block).

# Tests

See top of stack.