### PR TITLE
PLU-743: [IF-THEN-THEN-V2-8] Support remapping endStepId when duplicating

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -8,6 +8,8 @@ import {
   findBlankPlaceholderMemberIds,
   reassignIfThenEndStepsOnDelete,
   reassignIfThenEndStepsOnReorder,
+  remapIfThenEndStepIdsOnDuplicate,
+  remapIfThenEndStepIdsOnDuplicateBranch,
 } from '../../../../actions/if-then/infra/end-step-utils'
 
 type Fixture = {
@@ -468,5 +470,142 @@ describe('reassignIfThenEndStepsOnReorder', () => {
     expect(reassignIfThenEndStepsOnReorder(preSteps, newPositions)).toEqual([
       { ifThenStepId: 'B', endStepId: 'b6' },
     ])
+  })
+})
+
+describe('remapIfThenEndStepIdsOnDuplicate', () => {
+  it('remaps a marker to the copied endStep id', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 's3'), plain('s3', 3)]
+    const map = { trigger1: 'newTrigger', A: 'newA', s3: 'newS3' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [{ ifThenStepId: 'newA', endStepId: 'newS3' }],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('remaps a self-referencing (empty) block to the new self id', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 'A')]
+    const map = { trigger1: 'newTrigger', A: 'newA' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [{ ifThenStepId: 'newA', endStepId: 'newA' }],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('reports a source marker that does not resolve to a copied step', () => {
+    const sourceSteps = [trigger(1), markedIfThen('A', 2, 'ghost')]
+    const map = { trigger1: 'newTrigger', A: 'newA' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [],
+      danglingSourceStepIds: ['A'],
+    })
+  })
+
+  it('ignores legacy (marker-less) if-thens', () => {
+    const sourceSteps = [trigger(1), ifThen('L', 2), plain('s3', 3)]
+    const map = { trigger1: 'newTrigger', L: 'newL', s3: 'newS3' }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [],
+      danglingSourceStepIds: [],
+    })
+  })
+
+  it('remaps multiple blocks', () => {
+    const sourceSteps = [
+      trigger(1),
+      markedIfThen('A', 2, 'a3'),
+      plain('a3', 3),
+      markedIfThen('B', 4, 'b5'),
+      plain('b5', 5),
+    ]
+    const map = {
+      trigger1: 'nt',
+      A: 'nA',
+      a3: 'na3',
+      B: 'nB',
+      b5: 'nb5',
+    }
+
+    expect(remapIfThenEndStepIdsOnDuplicate(sourceSteps, map)).toEqual({
+      patches: [
+        { ifThenStepId: 'nA', endStepId: 'na3' },
+        { ifThenStepId: 'nB', endStepId: 'nb5' },
+      ],
+      danglingSourceStepIds: [],
+    })
+  })
+})
+
+describe('remapIfThenEndStepIdsOnDuplicateBranch', () => {
+  it('remaps an intra-selection marker to the ordinal counterpart copy', () => {
+    const sourceSelection = [markedIfThen('A', 2, 's2'), plain('s2', 3)]
+    const newStepIds = ['nA', 'ns2']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [{ ifThenStepId: 'nA', endStepId: 'ns2' }],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('remaps a self-referencing (empty) block to its own copy', () => {
+    const sourceSelection = [markedIfThen('A', 2, 'A')]
+    const newStepIds = ['nA']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [{ ifThenStepId: 'nA', endStepId: 'nA' }],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('leaves the copy marker-less and reports when the marker points outside the selection', () => {
+    const sourceSelection = [markedIfThen('A', 2, 'outsider'), plain('s3', 3)]
+    const newStepIds = ['nA', 'ns3']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [],
+      strippedSourceStepIds: ['A'],
+    })
+  })
+
+  it('ignores legacy (marker-less) if-thens in the selection', () => {
+    const sourceSelection = [ifThen('L', 2), plain('s3', 3)]
+    const newStepIds = ['nL', 'ns3']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [],
+      strippedSourceStepIds: [],
+    })
+  })
+
+  it('remaps multiple intra-selection blocks by ordinal position', () => {
+    const sourceSelection = [
+      markedIfThen('A', 2, 'a2'),
+      plain('a2', 3),
+      markedIfThen('B', 4, 'b2'),
+      plain('b2', 5),
+    ]
+    const newStepIds = ['nA', 'na2', 'nB', 'nb2']
+
+    expect(
+      remapIfThenEndStepIdsOnDuplicateBranch(sourceSelection, newStepIds),
+    ).toEqual({
+      patches: [
+        { ifThenStepId: 'nA', endStepId: 'na2' },
+        { ifThenStepId: 'nB', endStepId: 'nb2' },
+      ],
+      strippedSourceStepIds: [],
+    })
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -210,3 +210,71 @@ export function reassignIfThenEndStepsOnReorder<T extends RepairStep>(
 
   return patches
 }
+
+/**
+ * Remaps if-then markers after a whole-flow duplication. `endStepId` is a
+ * forward reference, so this must run as a post-pass once every step has a
+ * copy.
+ *
+ * IMPORTANT: returned patch ids are the NEW (copied) step ids, not the
+ * source ids.
+ */
+export function remapIfThenEndStepIdsOnDuplicate<T extends RepairStep>(
+  sourceSteps: T[],
+  oldToNewStepIds: Record<string, string>,
+): { patches: EndStepPatch[]; danglingSourceStepIds: string[] } {
+  const patches: EndStepPatch[] = []
+  const danglingSourceStepIds: string[] = []
+
+  for (const step of sourceSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const newIfThenId = oldToNewStepIds[step.id]
+    const newEndStepId = oldToNewStepIds[step.config?.[BLOCK_END_STEP_ID] ?? '']
+    if (newIfThenId === undefined) {
+      continue
+    }
+    if (newEndStepId === undefined) {
+      danglingSourceStepIds.push(step.id)
+      continue
+    }
+    patches.push({ ifThenStepId: newIfThenId, endStepId: newEndStepId })
+  }
+
+  return { patches, danglingSourceStepIds }
+}
+
+/**
+ * Remaps if-then markers after a branch duplication. `sourceSelection[i]`
+ * was copied to `newStepIds[i]`.
+ *
+ * IMPORTANT: markers are read from the source rows, never from
+ * client-copied config values.
+ */
+export function remapIfThenEndStepIdsOnDuplicateBranch<T extends RepairStep>(
+  sourceSelection: T[],
+  newStepIds: string[],
+): { patches: EndStepPatch[]; strippedSourceStepIds: string[] } {
+  const patches: EndStepPatch[] = []
+  const strippedSourceStepIds: string[] = []
+
+  for (let i = 0; i < sourceSelection.length; i++) {
+    const sourceStep = sourceSelection[i]
+    if (!isIfThenV2(sourceStep)) {
+      continue
+    }
+    const oldEndStepId = sourceStep.config?.[BLOCK_END_STEP_ID]
+    const endIndex = sourceSelection.findIndex((s) => s.id === oldEndStepId)
+    if (endIndex === -1) {
+      strippedSourceStepIds.push(sourceStep.id)
+      continue
+    }
+    patches.push({
+      ifThenStepId: newStepIds[i],
+      endStepId: newStepIds[endIndex],
+    })
+  }
+
+  return { patches, strippedSourceStepIds }
+}

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -7,6 +7,8 @@ import {
   findBlankPlaceholderMemberIds,
   reassignIfThenEndStepsOnDelete,
   reassignIfThenEndStepsOnReorder,
+  remapIfThenEndStepIdsOnDuplicate,
+  remapIfThenEndStepIdsOnDuplicateBranch,
 } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
@@ -30,6 +32,24 @@ interface EndStepWriteValidationArgs {
   ifThenStepId: string
   endStepId: string
   flowId: string
+}
+
+// endStepId is maintained by the endStep write rules and the duplication
+// remaps, never accepted directly from the client.
+const SERVER_OWNED_CONFIG_KEYS = [BLOCK_END_STEP_ID] as const
+
+/**
+ * Strips server-owned keys from a client-supplied config so a mutation only
+ * persists the marker via its own server-side rules.
+ */
+export function sanitizeServerSideConfig(
+  config: IStepConfig | null | undefined,
+): IStepConfig {
+  const sanitized = { ...(config ?? {}) }
+  for (const key of SERVER_OWNED_CONFIG_KEYS) {
+    delete sanitized[key]
+  }
+  return sanitized
 }
 
 /**
@@ -344,5 +364,109 @@ export async function repairEndStepsOnReorder({
       endStepId,
       flowId: flow.id,
     })
+  }
+}
+
+/**
+ * Remaps if-then markers after a whole-flow duplication.
+ *
+ * IMPORTANT: a source marker that fails to resolve means the SOURCE flow
+ * itself was corrupt, not this code. Logs and throws so the whole
+ * duplication rolls back.
+ */
+export async function remapEndStepIdsOnDuplicateFlow({
+  trx,
+  originalFlowId,
+  duplicatedFlowId,
+  sourceSteps,
+  oldToNewStepIds,
+}: {
+  trx: Transaction
+  originalFlowId: string
+  duplicatedFlowId: string
+  sourceSteps: Step[]
+  oldToNewStepIds: Record<string, string>
+}): Promise<void> {
+  const { patches, danglingSourceStepIds } = remapIfThenEndStepIdsOnDuplicate(
+    sourceSteps,
+    oldToNewStepIds,
+  )
+
+  if (danglingSourceStepIds.length > 0) {
+    logger.error({
+      event: 'duplicate-flow-dangling-end-step',
+      originalFlowId,
+      duplicatedFlowId,
+      danglingSourceStepIds,
+    })
+    throw new Error('duplicateFlow: dangling endStepId marker in source flow')
+  }
+
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
+  }
+}
+
+/**
+ * Remaps if-then markers after a branch duplication, deriving the source
+ * selection from the DB rather than the client-copied config: a copied
+ * marker still references the SOURCE step ids, and older editor bundles
+ * don't even send `config.endStepId`.
+ *
+ * IMPORTANT: called after the insertion loop. The copies land after
+ * `previousStep` and only shift later positions, so the source rows'
+ * positions are still valid to re-derive from here.
+ */
+export async function remapEndStepIdsOnDuplicateBranch({
+  trx,
+  flow,
+  previousStepId,
+  newSteps,
+}: {
+  trx: Transaction
+  flow: Flow
+  previousStepId: string
+  newSteps: Step[]
+}): Promise<void> {
+  const previousStep = await flow
+    .$relatedQuery('steps', trx)
+    .findOne({ id: previousStepId })
+    .throwIfNotFound()
+  const sourceSelection = await flow
+    .$relatedQuery('steps', trx)
+    .where('position', '>=', previousStep.position - newSteps.length + 1)
+    .andWhere('position', '<=', previousStep.position)
+    .orderBy('position', 'asc')
+
+  // A mismatch means the derivation invariant (previousStep is the
+  // selection's last step) didn't hold. Degrade to marker-less copies rather
+  // than risk a wrong remap.
+  if (sourceSelection.length !== newSteps.length) {
+    logger.warn({
+      event: 'duplicate-branch-stripped-end-step',
+      reason: 'source-selection-size-mismatch',
+      flowId: flow.id,
+      sourceCount: sourceSelection.length,
+      copyCount: newSteps.length,
+    })
+    return
+  }
+
+  const { patches, strippedSourceStepIds } =
+    remapIfThenEndStepIdsOnDuplicateBranch(
+      sourceSelection,
+      newSteps.map((step) => step.id),
+    )
+
+  for (const sourceStepId of strippedSourceStepIds) {
+    logger.info({
+      event: 'duplicate-branch-stripped-end-step',
+      flowId: flow.id,
+      sourceStepId,
+    })
+  }
+
+  for (const { ifThenStepId, endStepId } of patches) {
+    await pinEndStep(trx, ifThenStepId, endStepId)
   }
 }

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import duplicateBranch from '@/graphql/mutations/duplicate-branch'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+// Real-DB integration tests for the DB-derived endStepId remap when a branch
+// (contiguous selection) is duplicated. Markers are read from the source rows,
+// never from the client-sent config.
+describe('duplicateBranch endStepId remap', () => {
+  let owner: User
+  let context: Context
+  let testFlow: Flow
+  let loggerInfoSpy: MockInstance
+
+  const flowInput = () => ({
+    id: testFlow.id,
+    updatedAt: new Date(testFlow.updatedAt).getTime().toString(),
+  })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Branch Flow',
+      updatedBy: owner.id,
+    })
+
+    loggerInfoSpy = vi.spyOn(logger, 'info').mockImplementation(() => null)
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('remaps an intra-selection marker DB-derived, ignoring the client-sent value', async () => {
+    // Block [ifThen, member], endStep = member; a trailing step follows.
+    const [, ifThen, member] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: member.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: member.id },
+          steps: [
+            {
+              key: 'ifThen',
+              appKey: 'toolbox',
+              parameters: {},
+              // A bogus client-sent marker that must be ignored.
+              config: { endStepId: 'client-bogus' },
+            },
+            {
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              parameters: {},
+            },
+          ],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen, copiedMember] = result.steps
+    const reloaded = await reload(copiedIfThen.id)
+    expect(reloaded.config.endStepId).toBe(copiedMember.id)
+    expect(reloaded.config.endStepId).not.toBe('client-bogus')
+    expect(reloaded.config.endStepId).not.toBe(member.id)
+  })
+
+  it('remaps a self-referencing (empty) block to its own copy', async () => {
+    const [, ifThen] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThen.id },
+          steps: [{ key: 'ifThen', appKey: 'toolbox', parameters: {} }],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen] = result.steps
+    expect((await reload(copiedIfThen.id)).config.endStepId).toBe(
+      copiedIfThen.id,
+    )
+  })
+
+  it('leaves the copy marker-less and logs when the source marker points outside the selection', async () => {
+    const [, ifThen, member, tail] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({ config: { endStepId: tail.id } })
+
+    const result = await duplicateBranch(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: member.id },
+          steps: [
+            { key: 'ifThen', appKey: 'toolbox', parameters: {} },
+            {
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              parameters: {},
+            },
+          ],
+        },
+      },
+      context,
+    )
+
+    const [copiedIfThen] = result.steps
+    expect((await reload(copiedIfThen.id)).config.endStepId).toBeUndefined()
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'duplicate-branch-stripped-end-step',
+        sourceStepId: ifThen.id,
+      }),
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import duplicateFlow from '@/graphql/mutations/duplicate-flow'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+// Real-DB integration tests for the endStepId forward-reference remap when a
+// whole flow is duplicated.
+describe('duplicateFlow endStepId remap', () => {
+  let owner: User
+  let context: Context
+  let loggerErrorSpy: MockInstance
+
+  async function seedFlow(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+    }>,
+  ): Promise<{ flow: Flow; steps: Step[] }> {
+    const flow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'Source Flow',
+      updatedBy: owner.id,
+    })
+    const steps = (await flow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: {},
+        config: spec.config ?? {},
+      })),
+    )) as unknown as Step[]
+    return { flow, steps }
+  }
+
+  const copiedSteps = async (): Promise<Step[]> => {
+    const copy = await Flow.query()
+      .where('name', '[COPY] Source Flow')
+      .first()
+      .throwIfNotFound()
+    return copy.$relatedQuery('steps').orderBy('position', 'asc')
+  }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+  })
+
+  it('remaps a block marker to the copied endStep id', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen, s3] = steps
+    await ifThen.$query().patch({ config: { endStepId: s3.id } })
+
+    await duplicateFlow(null, { input: { id: flow.id } }, context)
+
+    const copies = await copiedSteps()
+    const copiedIfThen = copies[1]
+    const copiedS3 = copies[2]
+    expect(copiedIfThen.config.endStepId).toBe(copiedS3.id)
+    expect(copiedIfThen.config.endStepId).not.toBe(s3.id)
+  })
+
+  it('remaps a self-referencing (empty) block to the new self id', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen] = steps
+    await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
+
+    await duplicateFlow(null, { input: { id: flow.id } }, context)
+
+    const copies = await copiedSteps()
+    const copiedIfThen = copies[1]
+    expect(copiedIfThen.config.endStepId).toBe(copiedIfThen.id)
+    expect(copiedIfThen.config.endStepId).not.toBe(ifThen.id)
+  })
+
+  it('rolls back the whole duplication when a source marker is dangling', async () => {
+    const { flow, steps } = await seedFlow([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThen] = steps
+    await ifThen.$query().patch({ config: { endStepId: 'does-not-exist' } })
+
+    await expect(
+      duplicateFlow(null, { input: { id: flow.id } }, context),
+    ).rejects.toThrow(/dangling endStepId/)
+
+    const copy = await Flow.query().where('name', '[COPY] Source Flow').first()
+    expect(copy).toBeUndefined()
+    const original = await Flow.query().findById(flow.id)
+    expect(original.config?.duplicateCount).toBeUndefined()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'duplicate-flow-dangling-end-step',
+        danglingSourceStepIds: [ifThen.id],
+      }),
+    )
+  })
+})

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -2,6 +2,10 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import {
+  remapEndStepIdsOnDuplicateBranch,
+  sanitizeServerSideConfig,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import Step from '@/models/step'
@@ -74,6 +78,11 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
         })
         .where('position', '>=', previousStep.position + 1)
 
+      // A copied endStepId still points at the SOURCE step, not this new
+      // copy. Stripping it here lets the DB-derived post-pass remap set the
+      // correct copied id instead.
+      const sanitizedConfig = sanitizeServerSideConfig(config as IStepConfig)
+
       const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
         key,
         appKey,
@@ -81,7 +90,7 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
         position: previousStep.position + 1,
         parameters,
         connectionId: connection?.id,
-        config: config as IStepConfig,
+        config: sanitizedConfig,
         version: getStepVersion(appKey, key),
       })
 
@@ -93,6 +102,15 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       // as the connection would have already been added when the step
       // was created in the original branch
     }
+
+    // Remaps intra-selection endStepId markers onto the copies (DB-derived).
+    // A marker pointing outside the selection leaves the copy marker-less.
+    await remapEndStepIdsOnDuplicateBranch({
+      trx,
+      flow,
+      previousStepId: input.previousStep.id,
+      newSteps,
+    })
 
     const updatedFlow = await flow.patchLastUpdated({
       flowId: flow.id,

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 
+import { remapEndStepIdsOnDuplicateFlow } from '@/apps/toolbox/common/validate-end-step'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
 import { updateStepVariables } from '@/helpers/update-duplicated-steps'
@@ -88,6 +89,15 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
         })
       oldToNewStepIdsMap[oldStep.id] = duplicatedStep.id // update map after duplicating step
     }
+
+    // endStepId is a forward reference, so remap it once every step has a copy.
+    await remapEndStepIdsOnDuplicateFlow({
+      trx,
+      originalFlowId: oldFlowId,
+      duplicatedFlowId: duplicatedFlow.id,
+      sourceSteps: flow.steps,
+      oldToNewStepIds: oldToNewStepIdsMap,
+    })
 
     logger.info('Duplicate flow details', {
       event: 'duplicate-flow-request',


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our duplicate branch / duplicate pipe mutations to map old`endStepId` to the new step IDs in the duplicated pipe / block.

# Tests

See top of stack.