### PR TITLE
PLU-743: [IF-THEN-THEN-V2-9] Prevent publishing with invalid endStepIds

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -7,6 +7,7 @@ import logger from '@/helpers/logger'
 import {
   extractSelfEndStepIntent,
   validateEndStepWrite,
+  validateFlowBlocks,
 } from '../../common/validate-end-step'
 
 type Fixture = {
@@ -407,6 +408,168 @@ describe('extractSelfEndStepIntent', () => {
       expect.objectContaining({
         event: 'end-step-write-rejected',
         reason: 'invalid-end-step-sentinel',
+      }),
+    )
+  })
+})
+
+describe('validateFlowBlocks', () => {
+  let loggerWarnSpy: MockInstance
+
+  beforeEach(() => {
+    loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => null)
+  })
+
+  it('passes a flow whose blocks are all valid and non-empty', () => {
+    const blockB = ifThen('blockB', 2, { endStepId: 's3' })
+    const blockC = ifThen('blockC', 4, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      plain('s3', 3),
+      blockC,
+      plain('s5', 5),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores legacy (marker-less) if-thens', () => {
+    const flowSteps = [trigger(1), ifThen('legacy', 2), plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty (self-referencing) block', () => {
+    const block = ifThen('block', 2, { endStepId: 'block' })
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'empty-block',
+      }),
+    )
+  })
+
+  it('rejects a dangling marker', () => {
+    const block = ifThen('block', 2, { endStepId: 'ghost' })
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'end-step-not-in-flow',
+      }),
+    )
+  })
+
+  it('rejects a marker pointing before the if-then', () => {
+    const block = ifThen('block', 3, { endStepId: 's2' })
+    const flowSteps = [trigger(1), plain('s2', 2), block]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'end-step-before-self',
+      }),
+    )
+  })
+
+  it('accepts a block confined to one MRF rejection branch', () => {
+    const rejection = { approval: REJECTION_BRANCH }
+    const block = ifThen('block', 3, { ...rejection, endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('s4', 4, rejection),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).not.toThrow()
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a marked if-then whose block leaves its rejection branch', () => {
+    const block = ifThen('block', 3, {
+      approval: REJECTION_BRANCH,
+      endStepId: 's4',
+    })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects a block whose region contains an mrfSubmission step', () => {
+    const block = ifThen('block', 2, { endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      block,
+      mrfSubmission('mrf', 3),
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'mrf-step-in-region',
+      }),
+    )
+  })
+
+  it('rejects a top-level block whose region reaches into a rejection branch', () => {
+    const block = ifThen('block', 2, { endStepId: 's4' })
+    const flowSteps = [
+      trigger(1),
+      block,
+      plain('approvalChild', 3, {
+        approval: { branch: 'reject', stepId: 'x' },
+      }),
+      plain('s4', 4),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects overlapping (nested) new-style blocks', () => {
+    const blockB = ifThen('blockB', 2, { endStepId: 's4' })
+    const blockC = ifThen('blockC', 3, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      blockC,
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(() => validateFlowBlocks(flowSteps, FLOW_ID)).toThrow()
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'publish-invalid-end-step',
+        reason: 'overlapping-blocks',
       }),
     )
   })

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -64,8 +64,30 @@ export function rejectEndStepWrite(
   throw new Error(`endStepId write rejected: ${reason}`)
 }
 
+/**
+ * Unlike a write rejection (a should-never-happen bug), publish is the one
+ * place a user can trip a bad marker, most notably an empty block. So the
+ * message here is actionable and the log level is warn, not error.
+ */
+function rejectPublishEndStep(
+  reason: string,
+  details: Record<string, unknown>,
+): never {
+  logger.warn({ event: 'publish-invalid-end-step', reason, ...details })
+  throw new Error(
+    reason === 'empty-block'
+      ? 'Cannot publish: an If-then block has no steps. Add a step inside it or remove the block.'
+      : 'Cannot publish: an If-then block is misconfigured. Contact Plumber support to resolve this.',
+  )
+}
+
 function isMrfSubmissionStep(step: ValidationStep): boolean {
   return step.appKey === 'formsg' && step.key === 'mrfSubmission'
+}
+
+interface EndStepViolation {
+  reason: string
+  details: Record<string, unknown>
 }
 
 /**
@@ -79,44 +101,47 @@ function getRejectionBranchId(step: ValidationStep): string | null {
 }
 
 /**
- * Enforces every endStepId write invariant; throws and logs
- * `end-step-write-rejected` on violation, rolling back the mutation.
+ * Pure invariant check for a single if-then V2 endStepId. Returns the first
+ * violation (reason + details) or null when valid.
  *
- * Exported for unit coverage — mutations should go through
- * `validateEndStepOn{Create,Update}Step` below instead.
+ * Shared by the write path (throws) and the publish validator (warns), so
+ * the invariant lives in one place. IMPORTANT: a self-referencing (empty)
+ * block passes here. Only publish rejects it.
  */
-export function validateEndStepWrite({
+function checkEndStepWrite({
   flowSteps,
   ifThenStepId,
   endStepId,
   flowId,
-}: EndStepWriteValidationArgs): void {
+}: EndStepWriteValidationArgs): EndStepViolation | null {
   const ifThenStep = flowSteps.find((step) => step.id === ifThenStepId)
 
   // Target must be a toolbox/ifThen present in this flow.
   if (!ifThenStep || !isIfThenStep(ifThenStep)) {
-    rejectEndStepWrite('target-not-if-then', { ifThenStepId, flowId })
+    return { reason: 'target-not-if-then', details: { ifThenStepId, flowId } }
   }
 
   // endStep must exist in the same flow.
   const endStep = flowSteps.find((step) => step.id === endStepId)
   if (!endStep) {
-    rejectEndStepWrite('end-step-not-in-flow', {
-      ifThenStepId,
-      endStepId,
-      flowId,
-    })
+    return {
+      reason: 'end-step-not-in-flow',
+      details: { ifThenStepId, endStepId, flowId },
+    }
   }
 
   // endStep must be at or after the if-then (self-ref is the empty block).
   if (endStep.position < ifThenStep.position) {
-    rejectEndStepWrite('end-step-before-self', {
-      ifThenStepId,
-      endStepId,
-      endStepPosition: endStep.position,
-      ifThenPosition: ifThenStep.position,
-      flowId,
-    })
+    return {
+      reason: 'end-step-before-self',
+      details: {
+        ifThenStepId,
+        endStepId,
+        endStepPosition: endStep.position,
+        ifThenPosition: ifThenStep.position,
+        flowId,
+      },
+    }
   }
 
   // IMPORTANT: a block that crosses this boundary would jump execution into
@@ -130,22 +155,23 @@ export function validateEndStepWrite({
       continue
     }
     if (isMrfSubmissionStep(step)) {
-      rejectEndStepWrite('mrf-step-in-region', {
-        ifThenStepId,
-        endStepId,
-        offendingStepId: step.id,
-        flowId,
-      })
+      return {
+        reason: 'mrf-step-in-region',
+        details: { ifThenStepId, endStepId, offendingStepId: step.id, flowId },
+      }
     }
     if (getRejectionBranchId(step) !== blockRejectionBranchId) {
-      rejectEndStepWrite('approval-branch-crossed', {
-        ifThenStepId,
-        endStepId,
-        offendingStepId: step.id,
-        blockRejectionBranchId,
-        offendingRejectionBranchId: getRejectionBranchId(step),
-        flowId,
-      })
+      return {
+        reason: 'approval-branch-crossed',
+        details: {
+          ifThenStepId,
+          endStepId,
+          offendingStepId: step.id,
+          blockRejectionBranchId,
+          offendingRejectionBranchId: getRejectionBranchId(step),
+          flowId,
+        },
+      }
     }
   }
 
@@ -165,12 +191,67 @@ export function validateEndStepWrite({
       ifThenStep.position <= otherEnd.position &&
       other.position <= endStep.position
     if (overlaps) {
-      rejectEndStepWrite('overlapping-blocks', {
-        ifThenStepId,
-        endStepId,
-        otherIfThenStepId: other.id,
-        flowId,
-      })
+      return {
+        reason: 'overlapping-blocks',
+        details: {
+          ifThenStepId,
+          endStepId,
+          otherIfThenStepId: other.id,
+          flowId,
+        },
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Throws (rolling back the mutation) and logs `end-step-write-rejected` on
+ * any `checkEndStepWrite` violation.
+ *
+ * Exported for unit coverage — mutations should go through
+ * `validateEndStepOn{Create,Update}Step` below instead.
+ */
+export function validateEndStepWrite(args: EndStepWriteValidationArgs): void {
+  const violation = checkEndStepWrite(args)
+  if (violation) {
+    rejectEndStepWrite(violation.reason, violation.details)
+  }
+}
+
+/**
+ * Publish-time check over a whole flow's blocks, so the execution-time
+ * fail-loud path in `checkEndStepWrite` stays rare.
+ *
+ * IMPORTANT: an empty (self-referencing) block is valid mid-edit but
+ * rejected here. Unlike the old UI's auto-created empty step, it has no
+ * incomplete child of its own to block publish otherwise.
+ *
+ * `flowSteps` must be ordered by position ascending.
+ */
+export function validateFlowBlocks(
+  flowSteps: ValidationStep[],
+  flowId: string,
+): void {
+  for (const step of flowSteps) {
+    if (!isIfThenV2(step)) {
+      continue
+    }
+    const endStepId = step.config?.[BLOCK_END_STEP_ID] ?? ''
+
+    if (endStepId === step.id) {
+      rejectPublishEndStep('empty-block', { ifThenStepId: step.id, flowId })
+    }
+
+    const violation = checkEndStepWrite({
+      flowSteps,
+      ifThenStepId: step.id,
+      endStepId,
+      flowId,
+    })
+    if (violation) {
+      rejectPublishEndStep(violation.reason, violation.details)
     }
   }
 }

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -228,6 +228,63 @@ describe('updateFlowStatus', () => {
     ).resolves.not.toThrow()
   })
 
+  it('throws when publishing a flow with an empty (self-referencing) if-then block', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 'block' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow('If-then block has no steps')
+  })
+
+  it('throws when publishing a flow with a dangling if-then marker', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 'ghost' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow('If-then block is misconfigured')
+  })
+
+  it('publishes a flow with a valid non-empty if-then block', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { id: 't', position: 1, config: {} },
+      {
+        id: 'block',
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.IF_THEN,
+        config: { endStepId: 's3' },
+      },
+      { id: 's3', position: 3, config: {} },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).resolves.not.toThrow()
+  })
+
   it('activates the flow and enqueues a job for non-webhook triggers', async () => {
     // Starting state where the flow is inactive and input sets it to active.
     fakeFlow.active = false

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -2,6 +2,7 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
+import { validateFlowBlocks } from '@/apps/toolbox/common/validate-end-step'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
@@ -59,6 +60,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
 
   if (params.input.active) {
     validateFlowSteps(flow.steps)
+    validateFlowBlocks(flow.steps, flow.id)
   }
   const jobName = `${JOB_NAME}-${flow.id}`
 


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our backend to validate endStepId on publish. Ideally the frontend should prevent any problems, but bugs happen so I'm adding one more defence in depth measure..

# Tests

See top of stack.