### PR TITLE
PLU-743 [IF-THEN-THEN-V2-10] Opportunistically upgrade if-then V1 blocks to V2

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -1,14 +1,45 @@
 import type { IStepConfig } from '@plumber/types'
 
+import { raw, Transaction } from 'objection'
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
+import type Flow from '@/models/flow'
 
+import { BLOCK_END_STEP_ID } from '../../common/constants'
 import {
   extractSelfEndStepIntent,
+  upgradeIfThenV1BlocksIfEnabled,
   validateEndStepWrite,
   validateFlowBlocks,
 } from '../../common/validate-end-step'
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+const stepPatchMocks = vi.hoisted(() => ({
+  patchCalls: [] as { id: string; patch: unknown }[],
+  deleteCalls: [] as string[],
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: (id: string) => ({
+        patch: (patch: unknown) => {
+          stepPatchMocks.patchCalls.push({ id, patch })
+          return Promise.resolve()
+        },
+        delete: () => {
+          stepPatchMocks.deleteCalls.push(id)
+          return Promise.resolve()
+        },
+      }),
+    }),
+  },
+}))
 
 type Fixture = {
   id: string
@@ -572,5 +603,258 @@ describe('validateFlowBlocks', () => {
         reason: 'overlapping-blocks',
       }),
     )
+  })
+})
+
+describe('upgradeIfThenV1BlocksIfEnabled', () => {
+  const getLdFlagValueMock = vi.mocked(getLdFlagValue)
+  const trx = {} as Transaction
+
+  const flowPositionPatchMocks = {
+    patchCalls: [] as { threshold: number; patch: unknown }[],
+  }
+
+  // `stepsAfterBlankRemoval` stands in for what a real DB re-fetch would
+  // return after the blank-cleanup deletes and compacts positions. Only
+  // consulted by tests that actually trigger a cleanup.
+  function fakeFlow(
+    ownerEmail: string,
+    stepsAfterBlankRemoval: Fixture[] = [],
+  ): Flow {
+    return {
+      id: FLOW_ID,
+      $relatedQuery: vi.fn((relation: string) => {
+        if (relation === 'user') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            throwIfNotFound: vi.fn().mockResolvedValue({ email: ownerEmail }),
+          }
+        }
+        return {
+          orderBy: vi.fn().mockResolvedValue(stepsAfterBlankRemoval),
+          where: vi.fn((_column: string, _operator: string, value: number) => ({
+            patch: vi.fn((patch: unknown) => {
+              flowPositionPatchMocks.patchCalls.push({
+                threshold: value,
+                patch,
+              })
+              return Promise.resolve()
+            }),
+          })),
+        }
+      }),
+    } as unknown as Flow
+  }
+
+  const pinPatch = (endStepId: string) => ({
+    config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+      JSON.stringify(endStepId),
+    ]),
+  })
+
+  const shiftPatch = () => ({ position: raw('position - 1') })
+
+  // A leftover blank child from the V1 branch initializer.
+  const blank = (id: string, position: number): Fixture => ({
+    id,
+    position,
+    config: {},
+  })
+
+  beforeEach(() => {
+    getLdFlagValueMock.mockReset()
+    stepPatchMocks.patchCalls.length = 0
+    stepPatchMocks.deleteCalls.length = 0
+    flowPositionPatchMocks.patchCalls.length = 0
+  })
+
+  it('returns before checking the flag when there are no V1 if-thens', async () => {
+    const flowSteps = [trigger(1), plain('s2', 2)]
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(getLdFlagValueMock).not.toHaveBeenCalled()
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('does nothing when the flag is off for the pipe owner', async () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+    getLdFlagValueMock.mockResolvedValue(false)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(getLdFlagValueMock).toHaveBeenCalledWith(
+      'feature_if_then_then',
+      'owner@example.com',
+      false,
+    )
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('pins every V1 if-then block to its own independently-derived endStep', async () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const childA = plain('childA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const childB = plain('childB', 5)
+    const trailing = plain('trailing', 6)
+    const flowSteps = [trigger(1), ifThenA, childA, ifThenB, childB, trailing]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'ifThenA', patch: pinPatch('childA') },
+      { id: 'ifThenB', patch: pinPatch('trailing') },
+    ])
+  })
+
+  it('excludes steps about to be deleted from consideration', async () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+      new Set(['block']),
+    )
+
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('throws end-step-write-rejected when a derived extent violates region confinement', async () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('topLevel', 4),
+    ]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await expect(
+      upgradeIfThenV1BlocksIfEnabled(
+        trx,
+        fakeFlow('owner@example.com'),
+        flowSteps,
+      ),
+    ).rejects.toThrow()
+    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+  })
+
+  it('deletes a lone blank member and self-references the emptied block', async () => {
+    const block = ifThen('block', 2)
+    const child = blank('child', 3)
+    const flowSteps = [trigger(1), block, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [trigger(1), block])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['child'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('block') },
+    ])
+  })
+
+  it('deletes a blank member and pins to the surviving real step', async () => {
+    const block = ifThen('block', 2)
+    const real = plain('real', 3)
+    const child = blank('child', 4)
+    const flowSteps = [trigger(1), block, real, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [trigger(1), block, real])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['child'])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
+  })
+
+  it('deletes multiple blank members in the same block, highest position first', async () => {
+    const block = ifThen('block', 2)
+    const firstBlank = blank('firstBlank', 3)
+    const real = plain('real', 4)
+    const secondBlank = blank('secondBlank', 5)
+    const flowSteps = [trigger(1), block, firstBlank, real, secondBlank]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [
+      trigger(1),
+      block,
+      { ...real, position: 3 },
+    ])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['secondBlank', 'firstBlank'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 5, patch: shiftPatch() },
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
+  })
+
+  it('does not delete a blank member the caller already excluded', async () => {
+    const block = ifThen('block', 2)
+    const child = blank('child', 3)
+    const flowSteps = [trigger(1), block, child]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com')
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      flow,
+      flowSteps,
+      new Set(['child']),
+    )
+
+    expect(stepPatchMocks.deleteCalls).toEqual([])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('child') },
+    ])
+  })
+
+  it('re-derives a later block correctly after an earlier blank removal shifts positions', async () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const blankA = blank('blankA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const childB = plain('childB', 5)
+    const flowSteps = [trigger(1), ifThenA, blankA, ifThenB, childB]
+    getLdFlagValueMock.mockResolvedValue(true)
+    const flow = fakeFlow('owner@example.com', [
+      trigger(1),
+      ifThenA,
+      { ...ifThenB, position: 3 },
+      { ...childB, position: 4 },
+    ])
+
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, flowSteps)
+
+    expect(stepPatchMocks.deleteCalls).toEqual(['blankA'])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'ifThenA', patch: pinPatch('ifThenA') },
+      { id: 'ifThenB', patch: pinPatch('childB') },
+    ])
   })
 })

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -10,6 +10,7 @@ import {
   remapIfThenEndStepIdsOnDuplicate,
   remapIfThenEndStepIdsOnDuplicateBranch,
 } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
@@ -300,6 +301,9 @@ export async function pinEndStep(
     })
 }
 
+// Mirrors packages/frontend/src/config/flags.ts's IF_THEN_THEN_FEATURE_FLAG.
+const IF_THEN_THEN_LD_FLAG_KEY = 'feature_if_then_then'
+
 /**
  * Deletes a V1 block's leftover blank placeholder members and closes the
  * position gaps they leave, highest position first so each target's own
@@ -378,6 +382,71 @@ export async function deriveV1EndStepDroppingBlankMembers(
       refetchedSteps.find((step) => step.id === ifThenStep.id),
     ),
     cleaned: true,
+  }
+}
+
+/**
+ * Opportunistically pins every legacy (V1) if-then block in a flow to its
+ * current derived extent, when the flag is on for the flow owner. Once
+ * pinned, the existing V2 repair logic protects the block forever after, so
+ * this only ever needs to run once per block.
+ *
+ * IMPORTANT: a region-confinement violation on a pre-existing block throws
+ * here too. This is an accepted risk on prod data, not a bug to soften.
+ */
+export async function upgradeIfThenV1BlocksIfEnabled(
+  trx: Transaction,
+  flow: Flow,
+  flowSteps: ValidationStep[],
+  excludeStepIds: Set<string> = new Set(),
+): Promise<void> {
+  const v1IfThens = flowSteps.filter(
+    (step) =>
+      isIfThenStep(step) && !isIfThenV2(step) && !excludeStepIds.has(step.id),
+  )
+  if (v1IfThens.length === 0) {
+    return
+  }
+
+  const owner = await flow
+    .$relatedQuery('user', trx)
+    .select('email')
+    .throwIfNotFound()
+  const isEnabled = await getLdFlagValue(
+    IF_THEN_THEN_LD_FLAG_KEY,
+    owner.email,
+    false,
+  )
+  if (!isEnabled) {
+    return
+  }
+
+  let currentSteps = flowSteps
+
+  for (const ifThenStep of v1IfThens) {
+    const liveIfThenStep = currentSteps.find(
+      (step) => step.id === ifThenStep.id,
+    )
+    const { endStep, cleaned } = await deriveV1EndStepDroppingBlankMembers(
+      trx,
+      flow,
+      currentSteps,
+      liveIfThenStep,
+      excludeStepIds,
+    )
+    if (cleaned) {
+      currentSteps = await flow
+        .$relatedQuery('steps', trx)
+        .orderBy('position', 'asc')
+    }
+
+    validateEndStepWrite({
+      flowSteps: currentSteps,
+      ifThenStepId: ifThenStep.id,
+      endStepId: endStep.id,
+      flowId: flow.id,
+    })
+    await pinEndStep(trx, ifThenStep.id, endStep.id)
   }
 }
 

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -16,6 +16,16 @@ import { generateMockCollaborator, generateMockUser } from './flow.mock'
 const REFRESH_PIPE_MESSAGE =
   'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.'
 
+// Defaults to false in every beforeEach below so pre-existing tests here
+// stay byte-identical. The opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
 describe('createStep mutation integration tests', async () => {
   let testFlow: Flow
   let existingSteps: Step[]
@@ -39,6 +49,7 @@ describe('createStep mutation integration tests', async () => {
   // Clean up (and seed) database before each test.
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Clear out all rows. Adjust deletion order if using foreign keys.
     await FlowConnections.query().delete()
@@ -673,6 +684,7 @@ describe('createStep endStepId write rules', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
     await FlowConnections.query().delete()
     await Step.query().delete()
     await Flow.query().delete()
@@ -1228,5 +1240,207 @@ describe('createStep endStepId write rules', () => {
 
     expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
     expect((await reload(newIfThen.id)).config.endStepId).toBe(newIfThen.id)
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    it('pins unrelated V1 if-then blocks elsewhere in the flow when the flag is on', async () => {
+      // Both if-thens are legacy. The new step lands before either block, so
+      // neither rule 1 nor rule 2 touches them. Any pin here comes only from
+      // the general opportunistic pass.
+      const [trigger, ifThenA, childA, ifThenB, childB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: trigger.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(childA.id)
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(childB.id)
+    })
+
+    it('composes with rule 1: upgrades other blocks in the same pass as the adjacent pin', async () => {
+      // Same fixture as the "rule 1: pins a legacy block when adding after
+      // it" test above, but with the flag on. Rule 1 still pins ifThenA as
+      // before. This pass separately pins the unrelated ifThenB, which
+      // rule 1 never touches.
+      const [, ifThenA, stepA, ifThenB, stepB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: stepA.id },
+            previousBlockId: ifThenA.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // rule 1's own adjacent pin, unchanged.
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+      // the opportunistic pass pins the other, unrelated block too.
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(stepB.id)
+    })
+
+    it('composes with rule 2: extends a still-legacy block on a plain tail-add', async () => {
+      // Same shape as "rule 2: extends an explicit block on a plain
+      // tail-add" above, but ifThenA starts marker-less (V1).
+      // IMPORTANT: the opportunistic pin must land before rule 2's
+      // tail-extend check, or rule 2 sees an unmarked block, skips, and the
+      // later pin locks onto the pre-insert extent, stranding the new step
+      // outside.
+      const [, ifThenA, stepA, ifThenB, stepB] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: stepA.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // ifThenA extends to include the new step rather than staying pinned
+      // to its pre-insert extent (stepA).
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(
+        (newStep as any).id,
+      )
+      // The unrelated block still gets pinned by the same opportunistic pass.
+      expect((await reload(ifThenB.id)).config.endStepId).toBe(stepB.id)
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      const [, ifThenA, , ifThenB, , trailing] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: trailing.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBeUndefined()
+      expect((await reload(ifThenB.id)).config.endStepId).toBeUndefined()
+    })
+
+    it('deletes a leftover V1 blank placeholder member when a real step is added ahead of it', async () => {
+      // The V1 branch initializer leaves a blank child (no appKey/key) as
+      // the block's only member. Inserting a real step between the if-then
+      // and that blank reproduces the original bug shape.
+      const [, ifThenStep, blankChild] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: null, appKey: null, type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: ifThenStep.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      // The blank placeholder is gone, and the block is pinned to the real
+      // step instead of surviving as a second (phantom) member.
+      await expect(reload(blankChild.id)).rejects.toThrow()
+      expect((await reload(ifThenStep.id)).config.endStepId).toBe(
+        (newStep as any).id,
+      )
+
+      const steps = await testFlow
+        .$relatedQuery('steps')
+        .orderBy('position', 'asc')
+      expect(steps.map((step) => step.position)).toEqual(
+        steps.map((_step, index) => index + 1),
+      )
+    })
+
+    it('keeps a leftover V1 blank placeholder member when the flag is off', async () => {
+      const [, ifThenStep, blankChild] = await seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: null, appKey: null, type: 'action' },
+      ])
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: ifThenStep.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((await reload(blankChild.id)).id).toBe(blankChild.id)
+      expect((await reload(ifThenStep.id)).config.endStepId).toBeUndefined()
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -15,6 +15,16 @@ import {
   generateMockUser,
 } from './flow.mock'
 
+// Defaults to false in beforeEach below so pre-existing tests here stay
+// byte-identical. The opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
 describe('deleteStep mutation', () => {
   let context: Context
   let testFlow: Flow
@@ -28,6 +38,7 @@ describe('deleteStep mutation', () => {
 
   beforeEach(async () => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Mock the patchLastUpdated method
     vi.spyOn(Flow.prototype, 'patchLastUpdated').mockImplementation(
@@ -473,6 +484,104 @@ describe('deleteStep mutation', () => {
       const repaired = steps.find((s) => s.id === ifThen.id)
       expect(repaired?.config.endStepId).toBe(s3.id)
       expect(steps.some((s) => s.key === 'mrfSubmission')).toBe(false)
+    })
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    let blockFlow: Flow
+    let blockFlowInput: { flow: { updatedAt: string } }
+
+    const addTrigger = (
+      key: 'catchRawWebhook' | 'newSubmission',
+      appKey: 'custom-api' | 'formsg',
+    ) =>
+      generateMockStep(context, key, appKey, 'trigger', blockFlow.id, 1, {}, {})
+
+    const addIfThen = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        blockFlow.id,
+        position,
+        { depth: '0' },
+        config,
+      )
+
+    const addPlain = (position: number, config: Record<string, any> = {}) =>
+      generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        blockFlow.id,
+        position,
+        { email: 'test@example.com' },
+        config,
+      )
+
+    const currentSteps = () =>
+      blockFlow.$relatedQuery('steps').orderBy('position', 'asc')
+
+    beforeEach(async () => {
+      blockFlow = await owner.$relatedQuery('flows').insertAndFetch({
+        name: 'Upgrade Flow',
+      })
+      blockFlowInput = { flow: { updatedAt: blockFlow.updatedAt } }
+    })
+
+    it('pins other legacy if-then blocks when deleting an unrelated step, and composes with repair', async () => {
+      // Both if-thens are legacy. `unrelated` (the step being deleted) is
+      // the last step in the flow, so it's part of ifThenB's V1 extent until
+      // the delete removes it.
+      // IMPORTANT: the existing repair logic (unmodified by this pass) then
+      // re-points ifThenB back to childB once `unrelated` is gone.
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const ifThenA = await addIfThen(2)
+      const childA = await addPlain(3)
+      const ifThenB = await addIfThen(4)
+      const childB = await addPlain(5)
+      const unrelated = await addPlain(6)
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await deleteStep(
+        null,
+        { input: { ids: [unrelated.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(steps.find((s) => s.id === ifThenA.id)?.config.endStepId).toBe(
+        childA.id,
+      )
+      expect(steps.find((s) => s.id === ifThenB.id)?.config.endStepId).toBe(
+        childB.id,
+      )
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      await addTrigger('catchRawWebhook', 'custom-api')
+      const ifThenA = await addIfThen(2)
+      await addPlain(3)
+      const ifThenB = await addIfThen(4)
+      await addPlain(5)
+      const unrelated = await addPlain(6)
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await deleteStep(
+        null,
+        { input: { ids: [unrelated.id], ...blockFlowInput } },
+        context,
+      )
+
+      const steps = await currentSteps()
+      expect(
+        steps.find((s) => s.id === ifThenA.id)?.config.endStepId,
+      ).toBeUndefined()
+      expect(
+        steps.find((s) => s.id === ifThenB.id)?.config.endStepId,
+      ).toBeUndefined()
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -8,6 +8,16 @@ import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
+// Defaults to false in beforeEach below so pre-existing tests here stay
+// byte-identical; the opportunistic-upgrade tests override it per case.
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
 
 const MOCK_STEPS = [
@@ -69,6 +79,7 @@ describe('updateStepPositions mutation', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     // Set up flow patch and fetch spy first
     flowPatchAndFetchSpy = vi.fn().mockReturnValue({
@@ -86,6 +97,11 @@ describe('updateStepPositions mutation', () => {
       active: false,
       $query: vi.fn().mockReturnValue({
         patchAndFetch: flowPatchAndFetchSpy,
+      }),
+      // Used by upgradeIfThenV1BlocksIfEnabled's re-fetch. MOCK_STEPS has no
+      // if-then steps, so it's a no-op regardless of what this returns.
+      $relatedQuery: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockResolvedValue(MOCK_STEPS),
       }),
       assertNotUpdatedSince: vi.fn(),
     }
@@ -376,6 +392,7 @@ describe('updateStepPositions endStepId repair', () => {
 
   beforeEach(async () => {
     vi.restoreAllMocks()
+    mocks.getLdFlagValue.mockResolvedValue(false)
 
     owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
     context = {
@@ -476,5 +493,69 @@ describe('updateStepPositions endStepId repair', () => {
 
     expect((await reload(legacy.id)).config.endStepId).toBeUndefined()
     expect(wasRepaired()).toBe(false)
+  })
+
+  describe('opportunistic if-then V1 upgrade', () => {
+    // Both if-thens are legacy. Dragging ifThenB's block to before ifThenA's
+    // reproduces the original bug: without pinning ifThenA's extent before
+    // the drag, re-deriving it afterward (once it's the last if-then) would
+    // silently balloon to include `trailing`.
+    async function seedTwoBlockFlow() {
+      return seedSteps([
+        { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+        { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      ])
+    }
+
+    const swapBlocksInput = (
+      ifThenB: Step,
+      childB: Step,
+      ifThenA: Step,
+      childA: Step,
+    ) => ({
+      stepPositions: [
+        { id: ifThenB.id, position: 2, type: 'action' as const },
+        { id: childB.id, position: 3, type: 'action' as const },
+        { id: ifThenA.id, position: 4, type: 'action' as const },
+        { id: childA.id, position: 5, type: 'action' as const },
+      ],
+      flow: flowInput(),
+    })
+
+    it('pins both legacy blocks to their pre-reorder extents so the drag does not absorb the trailing step', async () => {
+      const [, ifThenA, childA, ifThenB, childB, trailing] =
+        await seedTwoBlockFlow()
+      mocks.getLdFlagValue.mockResolvedValue(true)
+
+      await updateStepPositions(
+        null,
+        { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
+        context,
+      )
+
+      // ifThenA's block stays pinned to just childA. `trailing` is not
+      // absorbed into it, even though ifThenA is now the last if-then.
+      expect((await reload(ifThenA.id)).config.endStepId).toBe(childA.id)
+      expect((await reload(ifThenB.id)).config.endStepId).toBeDefined()
+      expect((await reload(trailing.id)).config.endStepId).toBeUndefined()
+    })
+
+    it('does not pin any V1 if-then block when the flag is off', async () => {
+      const [, ifThenA, childA, ifThenB, childB] = await seedTwoBlockFlow()
+      mocks.getLdFlagValue.mockResolvedValue(false)
+
+      await updateStepPositions(
+        null,
+        { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
+        context,
+      )
+
+      expect((await reload(ifThenA.id)).config.endStepId).toBeUndefined()
+      expect((await reload(ifThenB.id)).config.endStepId).toBeUndefined()
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -3,7 +3,10 @@ import { IStepConfig } from '@plumber/types'
 import { raw } from 'objection'
 
 import { fixupEndStepOnCreateStep } from '@/apps/toolbox/actions/if-then/infra/handle-create-step'
-import { extractSelfEndStepIntent } from '@/apps/toolbox/common/validate-end-step'
+import {
+  extractSelfEndStepIntent,
+  upgradeIfThenV1BlocksIfEnabled,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
@@ -114,6 +117,17 @@ const createStep: MutationResolvers['createStep'] = async (
       config: newStepConfig,
       version,
     })
+
+    // Opportunistically pins any other legacy if-then block, if the flag is
+    // on for the pipe owner.
+    // IMPORTANT: must run before validateEndStepOnCreateStep. Its rule 2
+    // (tail-extend) only recognizes a block as extendable once it's explicit
+    // V2, so pinning first lets a still-legacy tail-added block see its own
+    // fresh pin and extend, instead of staying unmarked and being skipped.
+    const preInsertSteps = (
+      await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+    ).filter((flowStep) => flowStep.id !== step.id)
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, preInsertSteps)
 
     // IMPORTANT: throws (and rolls back the whole creation) on any marker
     // violation.

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -2,7 +2,10 @@ import { raw } from 'objection'
 
 import { removeMrfSteps } from '@/apps/formsg/triggers/new-submission/remove-mrf-steps'
 import { expandIfThenBlockDeletions } from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
-import { repairEndStepsOnDeleteStep } from '@/apps/toolbox/common/validate-end-step'
+import {
+  repairEndStepsOnDeleteStep,
+  upgradeIfThenV1BlocksIfEnabled,
+} from '@/apps/toolbox/common/validate-end-step'
 import { hasStepReference } from '@/helpers/check-step-parameters'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
@@ -35,7 +38,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     // Loads the whole flow's steps (not just the requested ids), since the
     // integrity logic below needs the full set to expand a marked if-then to
     // its block range and repair surviving blocks after the delete.
-    const stepsBeforeDelete = await context.currentUser
+    let stepsBeforeDelete = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .whereIn(
@@ -60,6 +63,22 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
 
     const flow = steps[0].flow
     flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
+
+    // Opportunistically pins any other legacy if-then block, if the flag is
+    // on for the pipe owner. Runs before the delete so derivation reflects
+    // the true pre-delete state, excluding steps about to be deleted.
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      flow,
+      stepsBeforeDelete,
+      new Set(input.ids),
+    )
+    // Re-reads so any block just pinned above is reflected as V2 below.
+    // IMPORTANT: otherwise the repair pass wouldn't see its own
+    // freshly-written marker.
+    stepsBeforeDelete = await flow
+      .$relatedQuery('steps', trx)
+      .orderBy('position', 'asc')
 
     const { expandedIds, danglingIfThenIds } = expandIfThenBlockDeletions(
       stepsBeforeDelete,
@@ -106,7 +125,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
 
       // we delete and add a new trigger upon deletion to preserve past execution steps' context
-      await stepsToDelete[0].$query(trx).delete()
+      await steps[0].$query(trx).delete()
       await flow.$relatedQuery('steps', trx).insert({
         key: null,
         appKey: null,

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -2,7 +2,10 @@ import { IStep } from '@plumber/types'
 
 import { PartialModelObject, raw } from 'objection'
 
-import { repairEndStepsOnReorder } from '@/apps/toolbox/common/validate-end-step'
+import {
+  repairEndStepsOnReorder,
+  upgradeIfThenV1BlocksIfEnabled,
+} from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
@@ -43,7 +46,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     // Queries all steps of the impacted flow so block end steps can be
     // repaired after the reorder. The steps named in the request params
     // drive the position update itself.
-    const allSteps = await context.currentUser
+    let allSteps = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .whereIn(
@@ -99,6 +102,16 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
         'Failed to update: step positions are out of bounds.',
       )
     }
+
+    // Opportunistically pin any legacy if-then block in the flow to its
+    // current extent, if the if-then-then flag is on for the pipe owner, so
+    // its extent gets locked in before this reorder can silently change it.
+    await upgradeIfThenV1BlocksIfEnabled(trx, flow, allSteps)
+    // Re-reads (positions are still pre-patch) so any block just pinned
+    // above is reflected as V2 below.
+    // IMPORTANT: otherwise the repair pass wouldn't see its own
+    // freshly-written marker.
+    allSteps = await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
 
     // Patch each step individually with its new position
     for (const stepPosition of stepPositions) {


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates our backend to upgrade a pipe to If-Then v2 the user created, deleted or re-ordered a step. (NOTE: V1 -> V2 upgrade is not done when updating step config)

We need to upgrade at these points because we want to allow existing pipes with if-then v1 to use if-then v2 seamlessly, so we need to upgrade existing if-thens in-place. However, instead of upgrading individual if-then branches, we upgrade the entire pipe at once so we dont have to deal with "hybrid" if-then v1+v2 pipes, which are harder to reason about.

# Tests

See top of stack.