### PR TITLE
PLU-743: [IF-THEN-THEN-V2-2] Update MRF to support If-then V2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,6 +56,7 @@ Do **not** run these yourself unless the user asks — the human runs the dev se
 ## Conventions
 
 - **Backend test file naming**: `*.test.ts` = unit (no DB), `*.itest.ts` = integration (real Postgres/Redis/DynamoDB via testcontainers, single-threaded). Don't mix.
+- **Business-critical tests**: tests pinning down an explicit, user-specified business rule live in their own `*.critical.test.ts` / `*.critical.itest.ts` file, separate from general coverage. Give the file a header comment stating the rule(s) verbatim. A failing test there means the implementation regressed. Confirm with the user before loosening or deleting the assertion.
 - **Package manager**: only use `npm`. Never use `yarn`, `pnpm`, or other package managers.
 - **Installing packages**: always pass the `-E` (exact version) flag.
 - **Data parsing & validation**: prefer **Zod** whenever parsing or validating data whose shape isn't guaranteed at compile time — HTTP/API responses, form submissions, webhook and queue payloads, env vars, and any external JSON — over hand-written type guards or ad-hoc property checks.

--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission-previous-executable-step.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission-previous-executable-step.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { findPreviousExecutableStep } from '../../actions/mrf-submission/previous-executable-step'
+
+const trigger = { id: 'trigger', position: 1 }
+
+function plainStep(id: string, position: number) {
+  return { id, position }
+}
+
+function rejectBranchStep(id: string, position: number, mrfStepId: string) {
+  return {
+    id,
+    position,
+    config: { approval: { branch: 'reject' as const, stepId: mrfStepId } },
+  }
+}
+
+describe('findPreviousExecutableStep', () => {
+  it('returns the nearest preceding step', () => {
+    const nearest = plainStep('nearest', 3)
+    const flowSteps = [trigger, plainStep('earlier', 2), nearest]
+
+    expect(findPreviousExecutableStep(flowSteps, 4)).toEqual(nearest)
+  })
+
+  it('skips rejection-branch steps', () => {
+    const mrfStep = plainStep('mrf-2', 2)
+    const flowSteps = [
+      trigger,
+      mrfStep,
+      rejectBranchStep('reject-1', 3, 'mrf-2'),
+      rejectBranchStep('reject-2', 4, 'mrf-2'),
+    ]
+
+    expect(findPreviousExecutableStep(flowSteps, 5)).toEqual(mrfStep)
+  })
+
+  it('ignores steps at or after the given position', () => {
+    const flowSteps = [trigger, plainStep('current', 2), plainStep('later', 3)]
+
+    expect(findPreviousExecutableStep(flowSteps, 2)).toEqual(trigger)
+  })
+
+  it('does not rely on the input being ordered by position', () => {
+    const nearest = plainStep('nearest', 3)
+    const flowSteps = [nearest, trigger, plainStep('earlier', 2)]
+
+    expect(findPreviousExecutableStep(flowSteps, 4)).toEqual(nearest)
+  })
+
+  it('returns undefined when nothing precedes the given position', () => {
+    expect(findPreviousExecutableStep([plainStep('current', 1)], 1)).toBe(
+      undefined,
+    )
+  })
+
+  it('returns undefined when every preceding step is a rejection-branch step', () => {
+    const flowSteps = [rejectBranchStep('reject', 1, 'mrf-2')]
+
+    expect(findPreviousExecutableStep(flowSteps, 2)).toBe(undefined)
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.critical.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.critical.itest.ts
@@ -1,0 +1,490 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import type Context from '@/types/express/context'
+
+import action from '../../actions/mrf-submission/index'
+import {
+  createMrfActionStep as createMrfActionStepBase,
+  generateMockContext,
+  generateMockFlow,
+  generateMockStep,
+} from '../mrf.mock'
+
+const FLOW_ID = '00000000-0000-0000-0000-000000000001'
+
+/**
+ * BUSINESS-CRITICAL TESTS. This file pins down the business rules
+ * `hasExecutionReachedMe` (in `../../actions/mrf-submission/index.ts`) must
+ * satisfy for gating a new MRF sub-trigger on the "previous MRF region" (the
+ * steps between the previous mrf-submission/trigger and this one,
+ * exclusive/inclusive):
+ *
+ *   A. Must NOT continue if any step in the region failed execution.
+ *   B. Must NOT continue if a top-level only-continue-if (i.e. not inside an
+ *      if-then V2 block) in the region returned false.
+ *   C. Must continue only once every step in the region has either finished
+ *      execution, or was skipped by an if-then V2 block (or an
+ *      only-continue-if inside one).
+ *
+ * These were specified by the user, not inferred from the implementation. If
+ * a test tagged "Rule A/B/C" below starts failing, that almost always means
+ * the implementation regressed, not that the rule is wrong. STOP and confirm
+ * with the user before loosening or deleting a Rule-tagged assertion.
+ *
+ * General (non-rule) coverage for this action lives in `mrf-submission.itest.ts`.
+ */
+describe('mrf-submission action gating rules (integration)', () => {
+  let context: Context
+  let flow: Flow
+  let triggerStep: Step
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    await generateMockFlow(context, FLOW_ID)
+    flow = await Flow.query().findById(FLOW_ID)
+    triggerStep = await generateMockStep(
+      context,
+      'newSubmission',
+      'formsg',
+      'trigger',
+      FLOW_ID,
+      1,
+    )
+  })
+
+  function createMrfActionStep(
+    position: number,
+    overrides?: { approvalField?: string },
+  ) {
+    return createMrfActionStepBase({
+      context,
+      flowId: FLOW_ID,
+      position,
+      formWorkflowStepId: `workflow-step-${String(position).padStart(3, '0')}`,
+      fields: ['field-a'],
+      approvalField: overrides?.approvalField,
+    })
+  }
+
+  function createGlobalVariable(
+    step: Step,
+    execution: Execution,
+  ): IGlobalVariable {
+    return {
+      step: {
+        id: step.id,
+        appKey: step.appKey,
+        position: step.position,
+        parameters: step.parameters || {},
+      },
+      flow: {
+        id: flow.id,
+      },
+      app: {
+        name: 'formsg',
+      },
+      execution: {
+        id: execution.id,
+        testRun: false,
+      },
+      setActionItem: vi.fn(),
+      getLastExecutionStep: async (
+        options: Partial<{
+          sameExecution: boolean
+          testRunOnly?: boolean
+        }>,
+      ) => {
+        const result = await step.getLastExecutionStep({
+          executionId: options?.sameExecution ? execution.id : undefined,
+          testRunOnly: options?.testRunOnly,
+        })
+        return result?.toJSON()
+      },
+    } as unknown as IGlobalVariable
+  }
+
+  describe('run', () => {
+    // Rule A: the immediately preceding step failed.
+    it('should pause execution when previous execution step is failed', async () => {
+      const mrfStep = await createMrfActionStep(2)
+      const execution = await Execution.query().insertAndFetch({
+        flowId: FLOW_ID,
+        testRun: false,
+      })
+      // Trigger's execution step is failed
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: triggerStep.id,
+        status: 'failure',
+        dataOut: null,
+        appKey: 'formsg',
+      })
+
+      const $ = createGlobalVariable(mrfStep, execution)
+      const result = await action.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    // Rule A: a step earlier in the region failed, not just the immediately
+    // preceding one. Execution halts at the failure (the normal action
+    // worker never enqueues the step after a failed one), so the later,
+    // never-run step has no execution-step row of its own either -- this
+    // proves that absence is correctly read as "must not continue" rather
+    // than accidentally treated as "reached".
+    it('should pause execution when an earlier (non-immediate) step in the region failed', async () => {
+      const mrfStepA = await createMrfActionStep(2)
+      const failedStep = await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        FLOW_ID,
+        3,
+      )
+      // Positioned between the failure and mrfStepB, but never actually run:
+      // the normal action worker halts at failedStep and never enqueues it.
+      await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        FLOW_ID,
+        4,
+      )
+      const mrfStepB = await createMrfActionStep(5)
+
+      const execution = await Execution.query().insertAndFetch({
+        flowId: FLOW_ID,
+        testRun: false,
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: triggerStep.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStepA.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: failedStep.id,
+        status: 'failure',
+        dataOut: null,
+        appKey: 'postman',
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStepB.id,
+        status: 'success',
+        dataOut: {
+          workflowContent: {
+            submittedSteps: [
+              { isApproval: false, submittedAt: '2024-01-01T00:00:00.000Z' },
+            ],
+          },
+        },
+        appKey: 'formsg',
+      })
+
+      const $ = createGlobalVariable(mrfStepB, execution)
+      const result = await action.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    // Rule C (baseline, no if-then V2 block involved): nothing has finished
+    // yet, so this must not be misread as "reached".
+    it('should pause execution when previous execution step is missing', async () => {
+      const mrfStep = await createMrfActionStep(2)
+      const execution = await Execution.query().insertAndFetch({
+        flowId: FLOW_ID,
+        testRun: false,
+      })
+      // No execution step for the trigger at all
+
+      const $ = createGlobalVariable(mrfStep, execution)
+      const result = await action.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+  })
+
+  /**
+   * Rule C. Region confinement lets a block end right before an MRF step, so
+   * a FALSE condition can resume execution there with the block's last step
+   * never run. That "missing execution step" must not be read as "not
+   * reached yet".
+   */
+  describe('run - previous executable step inside an if-then V2 block', () => {
+    let mrfStep2: Step
+    let ifThenStep: Step
+    let blockChild: Step
+    let mrfStep3: Step
+    let execution: Execution
+
+    beforeEach(async () => {
+      mrfStep2 = await createMrfActionStep(2)
+      blockChild = await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        FLOW_ID,
+        4,
+      )
+      ifThenStep = await generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        FLOW_ID,
+        3,
+        {},
+        { endStepId: blockChild.id },
+      )
+      mrfStep3 = await createMrfActionStep(5)
+
+      execution = await Execution.query().insertAndFetch({
+        flowId: FLOW_ID,
+        testRun: false,
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: triggerStep.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStep2.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      // The next respondent has already submitted.
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStep3.id,
+        status: 'success',
+        dataOut: {
+          workflowContent: {
+            submittedSteps: [
+              { isApproval: false, submittedAt: '2024-01-01T00:00:00.000Z' },
+            ],
+          },
+        },
+        appKey: 'formsg',
+      })
+    })
+
+    async function insertIfThenExecutionStep(isConditionMet: boolean) {
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: ifThenStep.id,
+        status: 'success',
+        dataOut: { isConditionMet },
+        appKey: 'toolbox',
+      })
+    }
+
+    async function insertBlockChildExecutionStep() {
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: blockChild.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'postman',
+      })
+    }
+
+    it('should continue when the block was skipped by a FALSE condition', async () => {
+      await insertIfThenExecutionStep(false)
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toBeUndefined()
+    })
+
+    it('should continue when the block ran to its end', async () => {
+      await insertIfThenExecutionStep(true)
+      await insertBlockChildExecutionStep()
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toBeUndefined()
+    })
+
+    it('should pause execution while a TRUE block is still running', async () => {
+      await insertIfThenExecutionStep(true)
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    it('should pause execution before the if-then itself has run', async () => {
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    it('should pause execution when the if-then failed', async () => {
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: ifThenStep.id,
+        status: 'failure',
+        dataOut: { isConditionMet: false },
+        appKey: 'toolbox',
+      })
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    it('should continue when an only-continue-if inside the block aborted it', async () => {
+      // Add an only-continue-if inside the block, between the if-then and its
+      // last child.
+      await mrfStep3.$query().patch({ position: 6 })
+      await blockChild.$query().patch({ position: 5 })
+      const onlyContinueIfStep = await generateMockStep(
+        context,
+        'onlyContinueIf',
+        'toolbox',
+        'action',
+        FLOW_ID,
+        4,
+      )
+      await insertIfThenExecutionStep(true)
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: onlyContinueIfStep.id,
+        status: 'success',
+        dataOut: { result: false },
+        appKey: 'toolbox',
+      })
+
+      const $ = createGlobalVariable(
+        await Step.query().findById(mrfStep3.id),
+        execution,
+      )
+
+      expect(await action.run($)).toBeUndefined()
+    })
+  })
+
+  /**
+   * Rule B. A top-level only-continue-if (not guarded by an if-then V2
+   * block) stops the whole execution on a FALSE condition instead of
+   * skipping forward. Its own execution step is still recorded as a normal
+   * success, so that success must not be misread as "reached, keep going".
+   */
+  describe('run - previous executable step is an unguarded only-continue-if', () => {
+    let onlyContinueIfStep: Step
+    let mrfStep3: Step
+    let execution: Execution
+
+    beforeEach(async () => {
+      const mrfStep2 = await createMrfActionStep(2)
+      onlyContinueIfStep = await generateMockStep(
+        context,
+        'onlyContinueIf',
+        'toolbox',
+        'action',
+        FLOW_ID,
+        3,
+      )
+      mrfStep3 = await createMrfActionStep(4)
+
+      execution = await Execution.query().insertAndFetch({
+        flowId: FLOW_ID,
+        testRun: false,
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: triggerStep.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStep2.id,
+        status: 'success',
+        dataOut: {},
+        appKey: 'formsg',
+      })
+      // The next respondent has already submitted, independently of what the
+      // only-continue-if decided.
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: mrfStep3.id,
+        status: 'success',
+        dataOut: {
+          workflowContent: {
+            submittedSteps: [
+              { isApproval: false, submittedAt: '2024-01-01T00:00:00.000Z' },
+            ],
+          },
+        },
+        appKey: 'formsg',
+      })
+    })
+
+    it('should pause execution when it resolved FALSE (stop-execution)', async () => {
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: onlyContinueIfStep.id,
+        status: 'success',
+        dataOut: { result: false },
+        appKey: 'toolbox',
+      })
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toEqual({
+        nextStep: { command: 'pause-execution' },
+      })
+    })
+
+    it('should continue when it resolved TRUE', async () => {
+      await ExecutionStep.query().insert({
+        executionId: execution.id,
+        stepId: onlyContinueIfStep.id,
+        status: 'success',
+        dataOut: { result: true },
+        appKey: 'toolbox',
+      })
+
+      const $ = createGlobalVariable(mrfStep3, execution)
+
+      expect(await action.run($)).toBeUndefined()
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.itest.ts
@@ -19,6 +19,9 @@ import {
 
 const FLOW_ID = '00000000-0000-0000-0000-000000000001'
 
+// The business-critical gating-rule tests for `hasExecutionReachedMe`
+// (previous-region failure/skip/stop handling) live in
+// `mrf-submission.critical.itest.ts`, not here.
 describe('mrf-submission action (integration)', () => {
   let context: Context
   let flow: Flow
@@ -90,45 +93,6 @@ describe('mrf-submission action (integration)', () => {
   }
 
   describe('run', () => {
-    it('should pause execution when previous execution step is failed', async () => {
-      const mrfStep = await createMrfActionStep(2)
-      const execution = await Execution.query().insertAndFetch({
-        flowId: FLOW_ID,
-        testRun: false,
-      })
-      // Trigger's execution step is failed
-      await ExecutionStep.query().insert({
-        executionId: execution.id,
-        stepId: triggerStep.id,
-        status: 'failure',
-        dataOut: null,
-        appKey: 'formsg',
-      })
-
-      const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
-
-      expect(result).toEqual({
-        nextStep: { command: 'pause-execution' },
-      })
-    })
-
-    it('should pause execution when previous execution step is missing', async () => {
-      const mrfStep = await createMrfActionStep(2)
-      const execution = await Execution.query().insertAndFetch({
-        flowId: FLOW_ID,
-        testRun: false,
-      })
-      // No execution step for the trigger at all
-
-      const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
-
-      expect(result).toEqual({
-        nextStep: { command: 'pause-execution' },
-      })
-    })
-
     it('should pause execution when no webhook yet (getLastExecutionStep returns null)', async () => {
       const mrfStep = await createMrfActionStep(2)
       const execution = await Execution.query().insertAndFetch({

--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.test.ts
@@ -217,31 +217,48 @@ describe('mrf-submission action', () => {
   })
 
   describe('run', () => {
-    function setupRunMocks() {
-      // Chain mocks for Step.query().where().andWhere()...
-      const stepChain = {
-        andWhere: vi.fn().mockReturnThis(),
-        andWhereRaw: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        first: vi.fn(),
-      }
-      mocks.stepQueryWhere.mockReturnValue(stepChain)
+    const PREVIOUS_STEP = { id: 'prev-step-id', position: 1 }
 
-      // Chain mocks for ExecutionStep.query().where().andWhere()...
+    /**
+     * Both query chains resolve on `orderBy`, so that's where the mocked rows
+     * are attached.
+     */
+    function setupRunMocks({
+      flowSteps = [PREVIOUS_STEP],
+      executionSteps = [],
+    }: {
+      flowSteps?: unknown[]
+      executionSteps?: unknown[]
+    } = {}) {
+      const flowStepsChain = {
+        orderBy: vi.fn().mockResolvedValue(flowSteps),
+      }
+      mocks.stepQueryWhere.mockReturnValue(flowStepsChain)
+
       const executionStepChain = {
-        andWhere: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        first: vi.fn(),
+        whereIn: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockResolvedValue(executionSteps),
       }
       mocks.executionStepQueryWhere.mockReturnValue(executionStepChain)
 
-      return { stepChain, executionStepChain }
+      // Chain mock for the rejection-branch lookup, which is still one query.
+      const rejectStepChain = {
+        andWhere: vi.fn().mockReturnThis(),
+        andWhereRaw: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        first: vi.fn().mockResolvedValue(null),
+      }
+
+      return { flowStepsChain, executionStepChain, rejectStepChain }
+    }
+
+    function ranSuccessfully(stepId: string) {
+      return { stepId, isFailed: false }
     }
 
     it('should throw when previous executable step is not found', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue(null)
+      setupRunMocks({ flowSteps: [] })
 
       await expect(action.run($)).rejects.toThrow(
         'Previous executable step not found',
@@ -250,9 +267,7 @@ describe('mrf-submission action', () => {
 
     it('should pause execution when previous execution step is not found', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue(null)
+      setupRunMocks({ executionSteps: [] })
 
       const result = await action.run($)
 
@@ -263,9 +278,9 @@ describe('mrf-submission action', () => {
 
     it('should pause execution when previous execution step is failed', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: true })
+      setupRunMocks({
+        executionSteps: [{ stepId: PREVIOUS_STEP.id, isFailed: true }],
+      })
 
       const result = await action.run($)
 
@@ -276,9 +291,7 @@ describe('mrf-submission action', () => {
 
     it('should pause execution when current execution step webhook has not arrived - the next respondent has not submitted yet', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      setupRunMocks({ executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)] })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue(
         null,
       )
@@ -292,9 +305,7 @@ describe('mrf-submission action', () => {
 
     it('should throw when submitted steps are invalid', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      setupRunMocks({ executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)] })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -310,9 +321,7 @@ describe('mrf-submission action', () => {
 
     it('should throw when submitted step is not found', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      setupRunMocks({ executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)] })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -328,9 +337,7 @@ describe('mrf-submission action', () => {
 
     it('should continue when mrf step does not require approval', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      setupRunMocks({ executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)] })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -351,9 +358,7 @@ describe('mrf-submission action', () => {
 
     it('should continue when mrf step is approved', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-      stepChain.first.mockResolvedValue({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      setupRunMocks({ executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)] })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -373,13 +378,33 @@ describe('mrf-submission action', () => {
       expect(result).toBeUndefined()
     })
 
+    it('should use the latest execution step of a retried previous step', async () => {
+      const $ = createMockGlobalVariable()
+      // Ordered created_at desc by the query, so the retry's success comes first.
+      setupRunMocks({
+        executionSteps: [
+          ranSuccessfully(PREVIOUS_STEP.id),
+          { stepId: PREVIOUS_STEP.id, isFailed: true },
+        ],
+      })
+      ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
+        dataOut: {
+          workflowContent: {
+            submittedSteps: [{ isApproval: false, submittedAt: '2024-01-01' }],
+          },
+        },
+      })
+
+      const result = await action.run($)
+
+      expect(result).toBeUndefined()
+    })
+
     it('should jump to rejection branch step when rejected', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-
-      // First call: find previous executable step
-      stepChain.first.mockResolvedValueOnce({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      const { flowStepsChain, rejectStepChain } = setupRunMocks({
+        executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)],
+      })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -394,15 +419,10 @@ describe('mrf-submission action', () => {
         },
       })
 
-      // Second call: find rejection branch step
-      const rejectStepChain = {
-        andWhere: vi.fn().mockReturnThis(),
-        andWhereRaw: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        first: vi.fn().mockResolvedValue({ id: 'reject-step-id' }),
-      }
+      // Second Step.query(): find the rejection branch step
+      rejectStepChain.first.mockResolvedValue({ id: 'reject-step-id' })
       mocks.stepQueryWhere
-        .mockReturnValueOnce(stepChain)
+        .mockReturnValueOnce(flowStepsChain)
         .mockReturnValueOnce(rejectStepChain)
 
       const result = await action.run($)
@@ -417,10 +437,9 @@ describe('mrf-submission action', () => {
 
     it('should stop execution when rejected but no rejection branch exists', async () => {
       const $ = createMockGlobalVariable()
-      const { stepChain, executionStepChain } = setupRunMocks()
-
-      stepChain.first.mockResolvedValueOnce({ id: 'prev-step-id' })
-      executionStepChain.first.mockResolvedValue({ isFailed: false })
+      const { flowStepsChain, rejectStepChain } = setupRunMocks({
+        executionSteps: [ranSuccessfully(PREVIOUS_STEP.id)],
+      })
       ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
         dataOut: {
           workflowContent: {
@@ -435,21 +454,78 @@ describe('mrf-submission action', () => {
         },
       })
 
-      // Second call: no rejection branch found
-      const rejectStepChain = {
-        andWhere: vi.fn().mockReturnThis(),
-        andWhereRaw: vi.fn().mockReturnThis(),
-        orderBy: vi.fn().mockReturnThis(),
-        first: vi.fn().mockResolvedValue(null),
-      }
+      // Second Step.query(): no rejection branch found
       mocks.stepQueryWhere
-        .mockReturnValueOnce(stepChain)
+        .mockReturnValueOnce(flowStepsChain)
         .mockReturnValueOnce(rejectStepChain)
 
       const result = await action.run($)
 
       expect(result).toEqual({
         nextStep: { command: 'stop-execution' },
+      })
+    })
+
+    it('should continue when the previous executable step was skipped by a FALSE if-then V2 block', async () => {
+      const $ = createMockGlobalVariable()
+      const ifThenStep = {
+        id: 'if-then-id',
+        position: 1,
+        appKey: 'toolbox',
+        key: 'ifThen',
+        config: { endStepId: 'prev-step-id' },
+      }
+      // The block's only child is the previous executable step, so it has no
+      // execution step of its own — the if-then's FALSE result is the proof.
+      setupRunMocks({
+        flowSteps: [ifThenStep, { ...PREVIOUS_STEP, position: 2 }],
+        executionSteps: [
+          {
+            stepId: ifThenStep.id,
+            isFailed: false,
+            dataOut: { isConditionMet: false },
+          },
+        ],
+      })
+      ;($.getLastExecutionStep as ReturnType<typeof vi.fn>).mockResolvedValue({
+        dataOut: {
+          workflowContent: {
+            submittedSteps: [{ isApproval: false, submittedAt: '2024-01-01' }],
+          },
+        },
+      })
+
+      const result = await action.run($)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should pause execution while a TRUE if-then V2 block is still running', async () => {
+      const $ = createMockGlobalVariable()
+      const ifThenStep = {
+        id: 'if-then-id',
+        position: 1,
+        appKey: 'toolbox',
+        key: 'ifThen',
+        config: { endStepId: 'prev-step-id' },
+      }
+      // Condition met, so the block is running and its last step has not
+      // finished — the workflow must not move past this MRF step yet.
+      setupRunMocks({
+        flowSteps: [ifThenStep, { ...PREVIOUS_STEP, position: 2 }],
+        executionSteps: [
+          {
+            stepId: ifThenStep.id,
+            isFailed: false,
+            dataOut: { isConditionMet: true },
+          },
+        ],
+      })
+
+      const result = await action.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'pause-execution' },
       })
     })
   })

--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -1,5 +1,10 @@
 import type { IGlobalVariable, IRawAction } from '@plumber/types'
 
+import {
+  didConditionalStepSkip,
+  getParentConditionalSteps,
+} from '@/apps/toolbox/common/block-execution'
+import { isOnlyContinueIfStep } from '@/apps/toolbox/common/constants'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import ExecutionStep from '@/models/execution-step'
@@ -12,6 +17,80 @@ import {
   parsedMrfWorkflowStepSchema,
   submittedStepsSchema,
 } from '../../common/types'
+
+import { findPreviousExecutableStep } from './previous-executable-step'
+
+/**
+ * A retried step can have several execution-step rows; only the latest one counts.
+ */
+async function getLatestExecutionStepsByStepId(
+  executionId: string,
+  stepIds: string[],
+): Promise<Map<string, ExecutionStep>> {
+  const executionSteps = await ExecutionStep.query()
+    .where('execution_id', executionId)
+    .whereIn('step_id', stepIds)
+    .orderBy('created_at', 'desc')
+
+  const latestByStepId = new Map<string, ExecutionStep>()
+  for (const executionStep of executionSteps) {
+    if (!latestByStepId.has(executionStep.stepId)) {
+      latestByStepId.set(executionStep.stepId, executionStep)
+    }
+  }
+  return latestByStepId
+}
+
+/**
+ * Checks whether the current execution has executed steps up until this
+ * sub-trigger.
+ *
+ * This is to handle MRF submissions arriving too early (i.e. before steps in
+ * before this sub-trigger could finish running).
+ */
+async function hasExecutionReachedMe(
+  executionId: string,
+  flowSteps: Step[],
+  previousExecutableStep: Step,
+): Promise<boolean> {
+  const parentConditionalSteps = getParentConditionalSteps(
+    flowSteps,
+    previousExecutableStep,
+  )
+  const latestExecutionSteps = await getLatestExecutionStepsByStepId(
+    executionId,
+    [
+      previousExecutableStep.id,
+      ...parentConditionalSteps.map((step) => step.id),
+    ],
+  )
+
+  const previousExecutableExecutionStep = latestExecutionSteps.get(
+    previousExecutableStep.id,
+  )
+  // Defense in depth: never proceed past an immediately preceding failed step.
+  if (previousExecutableExecutionStep?.isFailed) {
+    return false
+  }
+  if (previousExecutableExecutionStep) {
+    // A top-level only-continue-if (i.e. not guarded by an enclosing if-then
+    // V2 block) stops the whole execution on a FALSE condition instead of
+    // skipping forward, so its own success record must not be read as
+    // "reached" here.
+    const isUnguardedStop =
+      parentConditionalSteps.length === 0 &&
+      isOnlyContinueIfStep(previousExecutableStep) &&
+      didConditionalStepSkip(
+        previousExecutableStep,
+        previousExecutableExecutionStep,
+      )
+    return !isUnguardedStop
+  }
+
+  return parentConditionalSteps.some((step) =>
+    didConditionalStepSkip(step, latestExecutionSteps.get(step.id)),
+  )
+}
 
 function validateMrfStep($: IGlobalVariable): ParsedMrfWorkflowStep {
   const { mrf } = $.step.parameters as unknown as {
@@ -116,12 +195,13 @@ const action: IRawAction = {
      * Find the previous executable trigger/action step in the workflow
      * that should be already executed in order for this current step to proceed
      */
-    const previousExecutableStep = await Step.query()
+    const flowSteps = await Step.query()
       .where('flow_id', $.flow.id)
-      .andWhere('position', '<', $.step.position)
-      .andWhereRaw(`config -> 'approval' IS NULL`) // exclude steps in reject branch
-      .orderBy('position', 'desc')
-      .first()
+      .orderBy('position', 'asc')
+    const previousExecutableStep = findPreviousExecutableStep(
+      flowSteps,
+      $.step.position,
+    )
     if (!previousExecutableStep) {
       throw new StepError(
         'Previous executable step not found',
@@ -129,21 +209,19 @@ const action: IRawAction = {
       )
     }
 
-    const previousExecutableExecutionStep = await ExecutionStep.query()
-      .where('step_id', previousExecutableStep.id)
-      .andWhere('execution_id', $.execution.id)
-      .orderBy('created_at', 'desc')
-      .first()
-
     if (
-      !previousExecutableExecutionStep ||
-      previousExecutableExecutionStep.isFailed
+      !(await hasExecutionReachedMe(
+        $.execution.id,
+        flowSteps,
+        previousExecutableStep,
+      ))
     ) {
       // end and do nothing
       logger.info({
         event:
           'mrf-submission - previous executable execution step not found or failed',
         executionId: $.execution.id,
+        previousExecutableStepId: previousExecutableStep.id,
       })
       return {
         nextStep: {

--- a/packages/backend/src/apps/formsg/actions/mrf-submission/previous-executable-step.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/previous-executable-step.ts
@@ -1,0 +1,26 @@
+import type { IStep } from '@plumber/types'
+
+// The minimal step shape this lookup reads, to enable unit tests to pass
+// mocked objects instead of real Objection `Step`s.
+export type MrfFlowStep = Partial<Pick<IStep, 'config'>> &
+  Pick<IStep, 'id' | 'position'>
+
+/**
+ * Finds the pipe step ordered before an MRF submission sub-trigger.
+ *
+ * IMPORTANT: The returned step may not have actually executed: it may
+ * sit inside an if-then V2 block that a FALSE condition. It is important to
+ * pair this with `getParentConditionalSteps`.
+ */
+export function findPreviousExecutableStep<FlowStep extends MrfFlowStep>(
+  flowSteps: FlowStep[],
+  mrfStepPosition: number,
+): FlowStep | undefined {
+  return flowSteps
+    .filter((step) => step.position < mrfStepPosition && !step.config?.approval)
+    .reduce<FlowStep | undefined>(
+      (nearest, step) =>
+        !nearest || step.position > nearest.position ? step : nearest,
+      undefined,
+    )
+}

--- a/packages/backend/src/apps/toolbox/__tests__/common/block-execution.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/block-execution.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  didConditionalStepSkip,
+  getParentConditionalSteps,
+} from '../../common/block-execution'
+
+const trigger = { id: 'trigger', position: 1, appKey: 'formsg', key: 'newSub' }
+
+function ifThenV2(id: string, position: number, endStepId: string) {
+  return {
+    id,
+    position,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    config: { endStepId },
+  }
+}
+
+function ifThenV1(id: string, position: number) {
+  return { id, position, appKey: 'toolbox', key: 'ifThen', config: {} }
+}
+
+function onlyContinueIf(id: string, position: number) {
+  return { id, position, appKey: 'toolbox', key: 'onlyContinueIf' }
+}
+
+function plainStep(id: string, position: number) {
+  return {
+    id,
+    position,
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+  }
+}
+
+describe('getParentConditionalSteps', () => {
+  it('returns the block if-then for a step inside its block', () => {
+    const ifThen = ifThenV2('if-then', 2, 'child')
+    const child = plainStep('child', 3)
+    const flowSteps = [trigger, ifThen, child]
+
+    expect(getParentConditionalSteps(flowSteps, child)).toEqual([ifThen])
+  })
+
+  it('includes every only-continue-if inside the block, ordered by position', () => {
+    const ifThen = ifThenV2('if-then', 2, 'last-child')
+    const firstOci = onlyContinueIf('oci-1', 3)
+    const middleChild = plainStep('child', 4)
+    const secondOci = onlyContinueIf('oci-2', 5)
+    const lastChild = plainStep('last-child', 6)
+    const flowSteps = [
+      trigger,
+      ifThen,
+      firstOci,
+      middleChild,
+      secondOci,
+      lastChild,
+    ]
+
+    expect(getParentConditionalSteps(flowSteps, lastChild)).toEqual([
+      ifThen,
+      firstOci,
+      secondOci,
+    ])
+  })
+
+  it('excludes an only-continue-if that sits outside the block', () => {
+    const ifThen = ifThenV2('if-then', 2, 'child')
+    const child = plainStep('child', 3)
+    const outsideOci = onlyContinueIf('oci', 4)
+    const flowSteps = [trigger, ifThen, child, outsideOci]
+
+    expect(getParentConditionalSteps(flowSteps, child)).toEqual([ifThen])
+  })
+
+  it('returns the if-then for the block endStep itself', () => {
+    const ifThen = ifThenV2('if-then', 2, 'end')
+    const child = plainStep('child', 3)
+    const endStep = plainStep('end', 4)
+    const flowSteps = [trigger, ifThen, child, endStep]
+
+    expect(getParentConditionalSteps(flowSteps, endStep)).toEqual([ifThen])
+  })
+
+  it('picks only the containing block when a flow has several', () => {
+    const firstIfThen = ifThenV2('if-then-1', 2, 'child-1')
+    const firstChild = plainStep('child-1', 3)
+    const secondIfThen = ifThenV2('if-then-2', 4, 'child-2')
+    const secondChild = plainStep('child-2', 5)
+    const flowSteps = [
+      trigger,
+      firstIfThen,
+      firstChild,
+      secondIfThen,
+      secondChild,
+    ]
+
+    expect(getParentConditionalSteps(flowSteps, secondChild)).toEqual([
+      secondIfThen,
+    ])
+  })
+
+  it.each([
+    {
+      label: 'a step before every block',
+      flowSteps: () => {
+        const before = plainStep('before', 2)
+        return {
+          flowSteps: [trigger, before, ifThenV2('if-then', 3, 'child')],
+          step: before,
+        }
+      },
+    },
+    {
+      label: 'a step after the block endStep',
+      flowSteps: () => {
+        const after = plainStep('after', 4)
+        return {
+          flowSteps: [
+            trigger,
+            ifThenV2('if-then', 2, 'child'),
+            plainStep('child', 3),
+            after,
+          ],
+          step: after,
+        }
+      },
+    },
+    {
+      label: 'the block if-then itself',
+      flowSteps: () => {
+        const ifThen = ifThenV2('if-then', 2, 'child')
+        return {
+          flowSteps: [trigger, ifThen, plainStep('child', 3)],
+          step: ifThen,
+        }
+      },
+    },
+    {
+      label: 'an empty (self-referencing) block',
+      flowSteps: () => {
+        const ifThen = ifThenV2('if-then', 2, 'if-then')
+        return { flowSteps: [trigger, ifThen], step: ifThen }
+      },
+    },
+    {
+      label: 'a step inside an if-then V1 extent (no marker)',
+      flowSteps: () => {
+        const child = plainStep('child', 3)
+        return {
+          flowSteps: [trigger, ifThenV1('if-then', 2), child],
+          step: child,
+        }
+      },
+    },
+    {
+      label: 'a dangling marker',
+      flowSteps: () => {
+        const child = plainStep('child', 3)
+        return {
+          flowSteps: [trigger, ifThenV2('if-then', 2, 'deleted'), child],
+          step: child,
+        }
+      },
+    },
+    {
+      label: 'a marker pointing before the if-then',
+      flowSteps: () => {
+        const later = plainStep('later', 4)
+        return {
+          flowSteps: [
+            trigger,
+            plainStep('earlier', 2),
+            ifThenV2('if-then', 3, 'earlier'),
+            later,
+          ],
+          step: later,
+        }
+      },
+    },
+  ])('returns nothing for $label', ({ flowSteps }) => {
+    const { flowSteps: steps, step } = flowSteps()
+    expect(getParentConditionalSteps(steps, step)).toEqual([])
+  })
+})
+
+describe('didConditionalStepSkip', () => {
+  it.each([
+    {
+      label: 'an if-then whose condition was not met',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: { isFailed: false, dataOut: { isConditionMet: false } },
+    },
+    {
+      label: 'an only-continue-if whose condition was not met',
+      step: onlyContinueIf('oci', 3),
+      executionStep: { isFailed: false, dataOut: { result: false } },
+    },
+  ])('is true for $label', ({ step, executionStep }) => {
+    expect(didConditionalStepSkip(step, executionStep)).toBe(true)
+  })
+
+  it.each([
+    {
+      label: 'an if-then whose condition was met',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: { isFailed: false, dataOut: { isConditionMet: true } },
+    },
+    {
+      label: 'an only-continue-if whose condition was met',
+      step: onlyContinueIf('oci', 3),
+      executionStep: { isFailed: false, dataOut: { result: true } },
+    },
+    {
+      label: 'a failed if-then',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: { isFailed: true, dataOut: { isConditionMet: false } },
+    },
+    {
+      label: 'a step that has not run',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: undefined,
+    },
+    {
+      label: 'an if-then with no dataOut',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: { isFailed: false, dataOut: null },
+    },
+    {
+      label: 'a stringified condition result',
+      step: ifThenV2('if-then', 2, 'child'),
+      executionStep: { isFailed: false, dataOut: { isConditionMet: 'false' } },
+    },
+    {
+      label: 'a step that is not conditional',
+      step: plainStep('child', 3),
+      executionStep: { isFailed: false, dataOut: { isConditionMet: false } },
+    },
+  ])('is false for $label', ({ step, executionStep }) => {
+    expect(didConditionalStepSkip(step, executionStep)).toBe(false)
+  })
+})

--- a/packages/backend/src/apps/toolbox/common/block-execution.ts
+++ b/packages/backend/src/apps/toolbox/common/block-execution.ts
@@ -1,0 +1,91 @@
+import type { IJSONObject, IStep } from '@plumber/types'
+
+import {
+  BLOCK_END_STEP_ID,
+  isIfThenStep,
+  isIfThenV2,
+  isOnlyContinueIfStep,
+} from './constants'
+
+// Minimal shape so unit-test fixtures can pass plain objects instead of real
+// Objection Step rows.
+export type BlockScopedStep = Partial<
+  Pick<IStep, 'appKey' | 'key' | 'config'>
+> &
+  Pick<IStep, 'id' | 'position'>
+
+// Minimal shape so unit-test fixtures can pass plain objects instead of real
+// ExecutionStep rows.
+export interface ConditionalExecutionRecord {
+  isFailed?: boolean
+  dataOut?: IJSONObject | null
+}
+
+/**
+ * The if-then V2 block whose range `(ifThen, endStep]` contains `step`, or null
+ * if none does. Blocks are depth-0 and pairwise disjoint, so at most one match
+ * is possible.
+ */
+function findEnclosingIfThenV2Block(
+  flowSteps: BlockScopedStep[],
+  step: BlockScopedStep,
+): { ifThenStep: BlockScopedStep; endStep: BlockScopedStep } | null {
+  for (const candidate of flowSteps) {
+    if (!isIfThenV2(candidate) || candidate.position >= step.position) {
+      continue
+    }
+    const endStep = flowSteps.find(
+      (flowStep) => flowStep.id === candidate.config?.[BLOCK_END_STEP_ID],
+    )
+    if (endStep && step.position <= endStep.position) {
+      return { ifThenStep: candidate, endStep }
+    }
+  }
+  return null
+}
+
+/**
+ * The if-then and only-continue-if steps guarding the if-then V2 block that
+ * contains `step`. Typically passed to `didConditionalStepSkip` next, to check
+ * whether `step` was actually skipped rather than run.
+ */
+export function getParentConditionalSteps(
+  allFlowSteps: BlockScopedStep[],
+  step: BlockScopedStep,
+): BlockScopedStep[] {
+  const block = findEnclosingIfThenV2Block(allFlowSteps, step)
+  if (!block) {
+    return []
+  }
+
+  return allFlowSteps
+    .filter(
+      (flowStep) =>
+        flowStep.id === block.ifThenStep.id ||
+        (isOnlyContinueIfStep(flowStep) &&
+          flowStep.position > block.ifThenStep.position &&
+          flowStep.position <= block.endStep.position),
+    )
+    .sort((first, second) => first.position - second.position)
+}
+
+/**
+ * True when this conditional step's recorded run resolved a step to jump to,
+ * i.e. its condition was FALSE. Reads the dataOut its own action writes:
+ * if-then `{ isConditionMet }`, only-continue-if `{ result }`.
+ */
+export function didConditionalStepSkip(
+  step: BlockScopedStep,
+  executionStep: ConditionalExecutionRecord | null | undefined,
+): boolean {
+  if (!executionStep || executionStep.isFailed) {
+    return false
+  }
+  if (isIfThenStep(step)) {
+    return executionStep.dataOut?.isConditionMet === false
+  }
+  if (isOnlyContinueIfStep(step)) {
+    return executionStep.dataOut?.result === false
+  }
+  return false
+}


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates MRF to support If-then V2 blocks. We want to handle some tricky edge cases where an If-Then V2 is right before an MRF sub-trigger. This results in hair such as steps inside the block being skipped, only-continue-if inside the block, only continue if _before_ that If-then v2 block, etc.

At a high level, we want to implement these rules:

1. Any step in the previous MRF region failed execution. (Previous MRF region = steps with position < the current mrf-submission action but > the previous mrf-submission action or formsg trigger)
2. A top-level Only-Continue-If in the previous MRF region returned false. (Top-level = not part of an If-then v2. We can assume v1 is out of scope.)
3. Every step in the previous region has either finished execution (i.e. has an execution-step entry) _or_ was skipped by if-then v2, or an Only-Continue-IF within that if-then v2 block.

# Tests

See top of stack.