### PR TITLE
PLU-743: [IF-THEN-THEN-V2-3] Add validation rules for endStepId

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -1,0 +1,363 @@
+import type { IStepConfig } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import logger from '@/helpers/logger'
+
+import { validateEndStepWrite } from '../../common/validate-end-step'
+
+type Fixture = {
+  id: string
+  appKey?: string
+  key?: string
+  position: number
+  config: IStepConfig
+}
+
+const trigger = (position: number): Fixture => ({
+  id: `trigger${position}`,
+  appKey: 'formsg',
+  key: 'newSubmission',
+  position,
+  config: {},
+})
+
+const plain = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'postman',
+  key: 'sendTransactionalEmail',
+  position,
+  config,
+})
+
+const ifThen = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'toolbox',
+  key: 'ifThen',
+  position,
+  config,
+})
+
+const mrfSubmission = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'formsg',
+  key: 'mrfSubmission',
+  position,
+  config: {},
+})
+
+const FLOW_ID = 'flow1'
+
+const REJECTION_BRANCH = { branch: 'reject', stepId: 'mrf' } as const
+
+describe('validateEndStepWrite', () => {
+  let loggerErrorSpy: MockInstance
+
+  beforeEach(() => {
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+  })
+
+  it('accepts a valid marker over a run of plain steps', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3), plain('s4', 4)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a self-referencing empty block', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts adjacent (non-overlapping) blocks', () => {
+    const blockB = ifThen('blockB', 2)
+    const blockC = ifThen('blockC', 4, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      plain('s3', 3),
+      blockC,
+      plain('s5', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'blockB',
+        endStepId: 's3',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects a target that is not an if-then', () => {
+    const flowSteps = [trigger(1), plain('notIfThen', 2), plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'notIfThen',
+        endStepId: 's3',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'target-not-if-then',
+      }),
+    )
+  })
+
+  it('rejects a target that is missing from the flow', () => {
+    const flowSteps = [trigger(1), ifThen('block', 2)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'ghost',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'target-not-if-then',
+      }),
+    )
+  })
+
+  it('accepts a block confined to one MRF rejection branch', () => {
+    const rejection = { approval: REJECTION_BRANCH }
+    const block = ifThen('block', 3, rejection)
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('child', 4, rejection),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'child',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a rejection-branch block reaching out of its branch', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('child', 4, { approval: REJECTION_BRANCH }),
+      plain('topLevel', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'topLevel',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects a block spanning two different rejection branches', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('otherBranchChild', 4, {
+        approval: { branch: 'reject', stepId: 'otherMrf' },
+      }),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'otherBranchChild',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('accepts an empty (self-referencing) block in a rejection branch', () => {
+    const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
+    const flowSteps = [trigger(1), mrfSubmission('mrf', 2), block]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'block',
+        flowId: FLOW_ID,
+      }),
+    ).not.toThrow()
+    expect(loggerErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an endStep that is not in the flow', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [trigger(1), block, plain('s3', 3)]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 'nowhere',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'end-step-not-in-flow',
+      }),
+    )
+  })
+
+  it('rejects an endStep positioned before the if-then', () => {
+    const block = ifThen('block', 3)
+    const flowSteps = [trigger(1), plain('s2', 2), block]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's2',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'end-step-before-self',
+      }),
+    )
+  })
+
+  it('rejects an mrfSubmission step inside the block region', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [
+      trigger(1),
+      block,
+      mrfSubmission('mrf', 3),
+      plain('s4', 4),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'mrf-step-in-region',
+      }),
+    )
+  })
+
+  it('rejects a top-level block reaching into a rejection branch', () => {
+    const block = ifThen('block', 2)
+    const flowSteps = [
+      trigger(1),
+      block,
+      plain('approvalChild', 3, {
+        approval: { branch: 'reject', stepId: 'x' },
+      }),
+      plain('s4', 4),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'block',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'approval-branch-crossed',
+      }),
+    )
+  })
+
+  it('rejects overlapping (nested) new-style blocks', () => {
+    const blockB = ifThen('blockB', 2)
+    const blockC = ifThen('blockC', 3, { endStepId: 's5' })
+    const flowSteps = [
+      trigger(1),
+      blockB,
+      blockC,
+      plain('s4', 4),
+      plain('s5', 5),
+    ]
+
+    expect(() =>
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: 'blockB',
+        endStepId: 's4',
+        flowId: FLOW_ID,
+      }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'overlapping-blocks',
+      }),
+    )
+  })
+})

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -24,7 +24,7 @@ export const BLOCK_END_STEP_ID = 'endStepId'
 
 // Not IStep itself: the execution context's $.step is trimmed (no config), and
 // unit-test fixtures pass partials — neither is a full IStep.
-type StepLike = Partial<Pick<IStep, 'appKey' | 'key' | 'config'>>
+export type StepLike = Partial<Pick<IStep, 'appKey' | 'key' | 'config'>>
 
 export function isIfThenStep(step: StepLike | null | undefined): boolean {
   return (

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -1,0 +1,146 @@
+import type { IStep } from '@plumber/types'
+
+import logger from '@/helpers/logger'
+
+import {
+  BLOCK_END_STEP_ID,
+  isIfThenStep,
+  isIfThenV2,
+  type StepLike,
+} from './constants'
+
+// Loose enough for unit tests to pass partial objects instead of full Step
+// rows.
+type ValidationStep = StepLike & Pick<IStep, 'id' | 'position'>
+
+interface EndStepWriteValidationArgs {
+  // IMPORTANT: must already reflect the mutation's own insert/patch, ordered
+  // by position ascending.
+  flowSteps: ValidationStep[]
+  ifThenStepId: string
+  endStepId: string
+  flowId: string
+}
+
+/**
+ * IMPORTANT: throws a plain Error, not BadUserInputError — these violations
+ * are prevented by the frontend, so hitting one means a bug, not bad input.
+ */
+function rejectEndStepWrite(
+  reason: string,
+  details: Record<string, unknown>,
+): never {
+  logger.error({ event: 'end-step-write-rejected', reason, ...details })
+  throw new Error(`endStepId write rejected: ${reason}`)
+}
+
+function isMrfSubmissionStep(step: ValidationStep): boolean {
+  return step.appKey === 'formsg' && step.key === 'mrfSubmission'
+}
+
+/**
+ * Which MRF rejection branch a step belongs to, or null for the main flow.
+ * `config.approval` is only ever written for rejection branches (its `branch`
+ * is typed `'reject'`), so its `stepId` — the approval step the branch hangs
+ * off — identifies the branch on its own.
+ */
+function getRejectionBranchId(step: ValidationStep): string | null {
+  return step.config?.approval?.stepId ?? null
+}
+
+/**
+ * Enforces every endStepId write invariant; throws and logs
+ * `end-step-write-rejected` on violation, rolling back the mutation.
+ *
+ * Exported for unit coverage — mutations should go through
+ * `validateEndStepOn{Create,Update}Step` below instead.
+ */
+export function validateEndStepWrite({
+  flowSteps,
+  ifThenStepId,
+  endStepId,
+  flowId,
+}: EndStepWriteValidationArgs): void {
+  const ifThenStep = flowSteps.find((step) => step.id === ifThenStepId)
+
+  // Target must be a toolbox/ifThen present in this flow.
+  if (!ifThenStep || !isIfThenStep(ifThenStep)) {
+    rejectEndStepWrite('target-not-if-then', { ifThenStepId, flowId })
+  }
+
+  // endStep must exist in the same flow.
+  const endStep = flowSteps.find((step) => step.id === endStepId)
+  if (!endStep) {
+    rejectEndStepWrite('end-step-not-in-flow', {
+      ifThenStepId,
+      endStepId,
+      flowId,
+    })
+  }
+
+  // endStep must be at or after the if-then (self-ref is the empty block).
+  if (endStep.position < ifThenStep.position) {
+    rejectEndStepWrite('end-step-before-self', {
+      ifThenStepId,
+      endStepId,
+      endStepPosition: endStep.position,
+      ifThenPosition: ifThenStep.position,
+      flowId,
+    })
+  }
+
+  // IMPORTANT: a block that crosses this boundary would jump execution into
+  // or out of a branch on FALSE.
+  const blockRejectionBranchId = getRejectionBranchId(ifThenStep)
+  for (const step of flowSteps) {
+    if (
+      step.position <= ifThenStep.position ||
+      step.position > endStep.position
+    ) {
+      continue
+    }
+    if (isMrfSubmissionStep(step)) {
+      rejectEndStepWrite('mrf-step-in-region', {
+        ifThenStepId,
+        endStepId,
+        offendingStepId: step.id,
+        flowId,
+      })
+    }
+    if (getRejectionBranchId(step) !== blockRejectionBranchId) {
+      rejectEndStepWrite('approval-branch-crossed', {
+        ifThenStepId,
+        endStepId,
+        offendingStepId: step.id,
+        blockRejectionBranchId,
+        offendingRejectionBranchId: getRejectionBranchId(step),
+        flowId,
+      })
+    }
+  }
+
+  // Nesting is never legitimate (depth === 0), so no two ranges may overlap.
+  for (const other of flowSteps) {
+    if (other.id === ifThenStepId || !isIfThenV2(other)) {
+      continue
+    }
+    const otherEnd = flowSteps.find(
+      (step) => step.id === other.config?.[BLOCK_END_STEP_ID],
+    )
+    // Skip pre-existing dangling markers — out of scope for this write.
+    if (!otherEnd) {
+      continue
+    }
+    const overlaps =
+      ifThenStep.position <= otherEnd.position &&
+      other.position <= endStep.position
+    if (overlaps) {
+      rejectEndStepWrite('overlapping-blocks', {
+        ifThenStepId,
+        endStepId,
+        otherIfThenStepId: other.id,
+        flowId,
+      })
+    }
+  }
+}

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -706,6 +706,10 @@ input StepConfigInput {
   stepName: String
   approval: StepApprovalConfigInput
   templateConfig: StepTemplateConfigInput
+  # System-owned marker: id of the last step (inclusive) inside a block
+  # (if-then V2 today, possibly for-each later). Only the if-then initializer
+  # writes it, via updateStep.
+  endStepId: String
 }
 
 input UpdateStepInput {
@@ -826,6 +830,7 @@ type StepConfig {
   templateConfig: StepTemplateConfig
   stepName: String
   approval: StepApprovalConfig
+  endStepId: String
 }
 
 type StepTemplateConfig {


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Adds validation rules when updating `endStepId`to ensure we don't land in an invalid state. This:

- Is going to be ainly used for publish-time checks
- Acts as future safeguards because this feature has a blast radius across many other big things (e.g. MRF, only continue if, etc.)
- Helps the AI code better

# Tests

See top of stack.