### PR TITLE
PLU-743: [IF-THEN-THEN-V2-4] Support creating If-then V2 in backend

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  deriveIfThenV1EndStep,
+  findBlankPlaceholderMemberIds,
+} from '../../../../actions/if-then/infra/end-step-utils'
+
+type Fixture = {
+  id: string
+  appKey?: string
+  key?: string
+  parameters?: Record<string, any>
+  position: number
+}
+
+const trigger = (position: number): Fixture => ({
+  id: `trigger${position}`,
+  appKey: 'formsg',
+  key: 'newSubmission',
+  position,
+})
+
+const plain = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'postman',
+  key: 'sendTransactionalEmail',
+  position,
+})
+
+const ifThen = (
+  id: string,
+  position: number,
+  extra: Partial<Fixture> = {},
+): Fixture => ({
+  id,
+  appKey: 'toolbox',
+  key: 'ifThen',
+  parameters: { depth: '0' },
+  position,
+  ...extra,
+})
+
+const mrfSubmission = (id: string, position: number): Fixture => ({
+  id,
+  appKey: 'formsg',
+  key: 'mrfSubmission',
+  position,
+})
+
+// A leftover blank child from the V1 branch initializer.
+const blank = (id: string, position: number): Fixture => ({
+  id,
+  position,
+})
+
+describe('deriveIfThenV1EndStep', () => {
+  it('derives the extent of a 2-branch block up to the step before the next if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const stepA = plain('stepA', 3)
+    const ifThenB = ifThen('ifThenB', 4)
+    const stepB = plain('stepB', 5)
+    const steps = [trigger(1), ifThenA, stepA, ifThenB, stepB]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+  })
+
+  it('derives extents for each branch of a 3-branch block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const ifThenB = ifThen('ifThenB', 4)
+    const ifThenC = ifThen('ifThenC', 6)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      ifThenB,
+      plain('stepB', 5),
+      ifThenC,
+      plain('stepC', 7),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+    expect(deriveIfThenV1EndStep(steps, ifThenB).id).toBe('stepB')
+    expect(deriveIfThenV1EndStep(steps, ifThenC).id).toBe('stepC')
+  })
+
+  it('extends to the end of the flow when there is no following if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      plain('stepB', 4),
+      plain('stepC', 5),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepC')
+  })
+
+  it('returns the if-then itself (self-ref) for an empty block abutting the next if-then', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const ifThenB = ifThen('ifThenB', 3)
+    const steps = [trigger(1), ifThenA, ifThenB, plain('stepB', 4)]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
+  })
+
+  it('treats a following (reject-branch) if-then as an MRF boundary', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const rejectIfThen = ifThen('rejectIfThen', 5, {
+      parameters: { depth: '0' },
+    })
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      mrfSubmission('mrf', 4),
+      rejectIfThen,
+      plain('stepAfter', 6),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mrf')
+  })
+
+  it('does not treat a deeper (nested) if-then as a boundary (mirrors V1 depth scan)', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const nested = ifThen('nested', 4, { parameters: { depth: '1' } })
+    const ifThenB = ifThen('ifThenB', 6)
+    const steps = [
+      trigger(1),
+      ifThenA,
+      plain('stepA', 3),
+      nested,
+      plain('stepB', 5),
+      ifThenB,
+      plain('stepC', 7),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepB')
+  })
+})
+
+describe('findBlankPlaceholderMemberIds', () => {
+  it('finds a lone blank child that is the whole block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const child = blank('child', 3)
+    const steps = [trigger(1), ifThenA, child]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, child)).toEqual([
+      'child',
+    ])
+  })
+
+  it('finds a blank member alongside real ones, ignoring the real ones', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const child = blank('child', 4)
+    const steps = [trigger(1), ifThenA, real, child]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, child)).toEqual([
+      'child',
+    ])
+  })
+
+  it('returns every blank member when there are more than one', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const firstBlank = blank('firstBlank', 3)
+    const real = plain('real', 4)
+    const secondBlank = blank('secondBlank', 5)
+    const steps = [trigger(1), ifThenA, firstBlank, real, secondBlank]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, secondBlank)).toEqual([
+      'firstBlank',
+      'secondBlank',
+    ])
+  })
+
+  it('returns an empty array for a fully-configured block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const steps = [trigger(1), ifThenA, real]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, real)).toEqual([])
+  })
+
+  it('returns an empty array for an empty (self-referencing) block', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const steps = [trigger(1), ifThenA]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, ifThenA)).toEqual([])
+  })
+
+  it('ignores a blank step outside the block range', () => {
+    const ifThenA = ifThen('ifThenA', 2)
+    const real = plain('real', 3)
+    const outsideBlank = blank('outsideBlank', 4)
+    const steps = [trigger(1), ifThenA, real, outsideBlank]
+
+    expect(findBlankPlaceholderMemberIds(steps, ifThenA, real)).toEqual([])
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/handle-create-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/handle-create-step.test.ts
@@ -1,0 +1,182 @@
+import type { IStepConfig } from '@plumber/types'
+
+import { raw, Transaction } from 'objection'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fixupEndStepOnCreateStep } from '@/apps/toolbox/actions/if-then/infra/handle-create-step'
+import { BLOCK_END_STEP_ID } from '@/apps/toolbox/common/constants'
+import type Flow from '@/models/flow'
+import type Step from '@/models/step'
+
+const stepPatchMocks = vi.hoisted(() => ({
+  patchCalls: [] as { id: string; patch: unknown }[],
+  deleteCalls: [] as string[],
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: (id: string) => ({
+        patch: (patch: unknown) => {
+          stepPatchMocks.patchCalls.push({ id, patch })
+          return Promise.resolve()
+        },
+        delete: () => {
+          stepPatchMocks.deleteCalls.push(id)
+          return Promise.resolve()
+        },
+      }),
+    }),
+  },
+}))
+
+type Fixture = {
+  id: string
+  appKey?: string
+  key?: string
+  position: number
+  config: IStepConfig
+}
+
+const trigger = (position: number): Fixture => ({
+  id: `trigger${position}`,
+  appKey: 'formsg',
+  key: 'newSubmission',
+  position,
+  config: {},
+})
+
+const plain = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'postman',
+  key: 'sendTransactionalEmail',
+  position,
+  config,
+})
+
+const ifThen = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
+  id,
+  appKey: 'toolbox',
+  key: 'ifThen',
+  position,
+  config,
+})
+
+const FLOW_ID = 'flow1'
+
+describe('fixupEndStepOnCreateStep', () => {
+  const trx = {} as Transaction
+
+  const flowPositionPatchMocks = {
+    patchCalls: [] as { threshold: number; patch: unknown }[],
+  }
+
+  // `stepsAfterBlankRemoval` stands in for what a real DB re-fetch would
+  // return after the blank-cleanup deletes and compacts positions.
+  // The mock returns `initialSteps` for the first fetch, then this for every
+  // fetch after.
+  function fakeFlow(
+    initialSteps: Fixture[],
+    stepsAfterBlankRemoval: Fixture[] = initialSteps,
+  ): Flow {
+    const orderByMock = vi
+      .fn()
+      .mockResolvedValueOnce(initialSteps)
+      .mockResolvedValue(stepsAfterBlankRemoval)
+    return {
+      id: FLOW_ID,
+      $relatedQuery: vi.fn(() => ({
+        orderBy: orderByMock,
+        where: vi.fn((_column: string, _operator: string, value: number) => ({
+          patch: vi.fn((patch: unknown) => {
+            flowPositionPatchMocks.patchCalls.push({
+              threshold: value,
+              patch,
+            })
+            return Promise.resolve()
+          }),
+        })),
+      })),
+    } as unknown as Flow
+  }
+
+  const pinPatch = (endStepId: string) => ({
+    config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+      JSON.stringify(endStepId),
+    ]),
+  })
+
+  const shiftPatch = () => ({ position: raw('position - 1') })
+
+  // A leftover blank child from the V1 branch initializer.
+  const blank = (id: string, position: number): Fixture => ({
+    id,
+    position,
+    config: {},
+  })
+
+  beforeEach(() => {
+    stepPatchMocks.patchCalls.length = 0
+    stepPatchMocks.deleteCalls.length = 0
+    flowPositionPatchMocks.patchCalls.length = 0
+  })
+
+  it('deletes a leftover V1 blank placeholder before pinning a block reached via add-after-block', async () => {
+    const block = ifThen('block', 2)
+    const blankChild = blank('blankChild', 3)
+    const newStep = plain('newStep', 4)
+    const flow = fakeFlow(
+      [trigger(1), block, blankChild, newStep],
+      [trigger(1), block, { ...newStep, position: 3 }],
+    )
+
+    await fixupEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: 'block',
+      previousStep: { id: 'blankChild' } as unknown as Step,
+      newStep: { id: 'newStep' } as unknown as Step,
+      wantsSelfEndStep: false,
+    })
+
+    // The placeholder is deleted, so the block (with no other member left)
+    // self-references instead of adopting the deleted placeholder as its
+    // endStep.
+    expect(stepPatchMocks.deleteCalls).toEqual(['blankChild'])
+    expect(flowPositionPatchMocks.patchCalls).toEqual([
+      { threshold: 3, patch: shiftPatch() },
+    ])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('block') },
+    ])
+  })
+
+  it('pins directly to a real last member, with no cleanup, when there is no blank placeholder', async () => {
+    const block = ifThen('block', 2)
+    const real = plain('real', 3)
+    const newStep = plain('newStep', 4)
+    const flow = fakeFlow([trigger(1), block, real, newStep])
+
+    await fixupEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: 'block',
+      previousStep: { id: 'real' } as unknown as Step,
+      newStep: { id: 'newStep' } as unknown as Step,
+      wantsSelfEndStep: false,
+    })
+
+    expect(stepPatchMocks.deleteCalls).toEqual([])
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('real') },
+    ])
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/constants.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   BLOCK_END_STEP_ID,
+  isBlankPlaceholderStep,
+  isBlockStep,
+  isForEachStep,
   isIfThenStep,
   isIfThenV2,
   isOnlyContinueIfStep,
@@ -54,6 +57,68 @@ describe('toolbox constants', () => {
       { label: 'undefined step', step: undefined },
     ])('is false for $label', ({ step }) => {
       expect(isOnlyContinueIfStep(step)).toBe(false)
+    })
+  })
+
+  describe('isForEachStep', () => {
+    it('is true for a toolbox for-each step', () => {
+      expect(isForEachStep({ appKey: 'toolbox', key: 'forEach' })).toBe(true)
+    })
+
+    it.each([
+      { label: 'if-then', step: { appKey: 'toolbox', key: 'ifThen' } },
+      { label: 'non-toolbox app', step: { appKey: 'formsg', key: 'forEach' } },
+      { label: 'undefined step', step: undefined },
+    ])('is false for $label', ({ step }) => {
+      expect(isForEachStep(step)).toBe(false)
+    })
+  })
+
+  describe('isBlockStep', () => {
+    it.each([
+      { label: 'if-then', step: { appKey: 'toolbox', key: 'ifThen' } },
+      { label: 'for-each', step: { appKey: 'toolbox', key: 'forEach' } },
+    ])('is true for a block step: $label', ({ step }) => {
+      expect(isBlockStep(step)).toBe(true)
+    })
+
+    it.each([
+      {
+        label: 'only-continue-if',
+        step: { appKey: 'toolbox', key: 'onlyContinueIf' },
+      },
+      { label: 'plain action', step: { appKey: 'postman', key: 'sendEmail' } },
+      { label: 'undefined step', step: undefined },
+    ])('is false for a non-block step: $label', ({ step }) => {
+      expect(isBlockStep(step)).toBe(false)
+    })
+  })
+
+  describe('isBlankPlaceholderStep', () => {
+    it('is true when both appKey and key are missing', () => {
+      expect(isBlankPlaceholderStep({})).toBe(true)
+    })
+
+    it('is true when both appKey and key are null', () => {
+      expect(isBlankPlaceholderStep({ appKey: null, key: null })).toBe(true)
+    })
+
+    it.each([
+      { label: 'undefined step', step: undefined },
+      { label: 'null step', step: null },
+    ])('is true for $label', ({ step }) => {
+      expect(isBlankPlaceholderStep(step)).toBe(true)
+    })
+
+    it.each([
+      {
+        label: 'a fully-configured step',
+        step: { appKey: 'toolbox', key: 'ifThen' },
+      },
+      { label: 'appKey set but key missing', step: { appKey: 'toolbox' } },
+      { label: 'key set but appKey missing', step: { key: 'ifThen' } },
+    ])('is false for $label', ({ step }) => {
+      expect(isBlankPlaceholderStep(step)).toBe(false)
     })
   })
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import logger from '@/helpers/logger'
 
-import { validateEndStepWrite } from '../../common/validate-end-step'
+import {
+  extractSelfEndStepIntent,
+  validateEndStepWrite,
+} from '../../common/validate-end-step'
 
 type Fixture = {
   id: string
@@ -357,6 +360,53 @@ describe('validateEndStepWrite', () => {
       expect.objectContaining({
         event: 'end-step-write-rejected',
         reason: 'overlapping-blocks',
+      }),
+    )
+  })
+})
+
+describe('extractSelfEndStepIntent', () => {
+  let loggerErrorSpy: MockInstance
+
+  beforeEach(() => {
+    loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => null)
+  })
+
+  it('passes an absent key through unchanged', () => {
+    expect(extractSelfEndStepIntent({ stepName: 'kept' })).toEqual({
+      config: { stepName: 'kept' },
+      wantsSelfEndStep: false,
+    })
+  })
+
+  it('treats a null/undefined config as absent', () => {
+    expect(extractSelfEndStepIntent(null)).toEqual({
+      config: {},
+      wantsSelfEndStep: false,
+    })
+    expect(extractSelfEndStepIntent(undefined)).toEqual({
+      config: {},
+      wantsSelfEndStep: false,
+    })
+  })
+
+  it('strips the sentinel and signals self-ref intent', () => {
+    expect(
+      extractSelfEndStepIntent({ stepName: 'kept', endStepId: 'self' }),
+    ).toEqual({
+      config: { stepName: 'kept' },
+      wantsSelfEndStep: true,
+    })
+  })
+
+  it('rejects a real step id — the id does not exist yet at create time', () => {
+    expect(() =>
+      extractSelfEndStepIntent({ endStepId: 'some-other-step-id' }),
+    ).toThrow()
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'end-step-write-rejected',
+        reason: 'invalid-end-step-sentinel',
       }),
     )
   })

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -1,0 +1,66 @@
+import type { IStep } from '@plumber/types'
+
+import {
+  isBlankPlaceholderStep,
+  isIfThenStep,
+  type StepLike,
+} from '../../../common/constants'
+
+// Loose enough that unit tests can pass partial plain objects instead of full
+// Step rows.
+type ExtentStep = StepLike &
+  Pick<IStep, 'id' | 'position'> &
+  Partial<Pick<IStep, 'parameters'>>
+
+// Mirrors getIfThenV1StepIdToSkipTo's depth defaulting; nesting never shipped,
+// so this is dead-code defense.
+function parseDepth(step: ExtentStep): number {
+  const depth = parseInt(step.parameters?.depth as string)
+  return isNaN(depth) ? 0 : depth
+}
+
+/**
+ * Computes a V1 if-then block's derived extent (the last step, inclusive).
+ *
+ * IMPORTANT: this is a plain positional scan with no MRF awareness, so it can
+ * derive an extent that crosses an mrfSubmission or a rejection-branch
+ * boundary — region-confinement write validation is the safety net that
+ * refuses to pin one that does.
+ */
+export function deriveIfThenV1EndStep<T extends ExtentStep>(
+  flowSteps: T[],
+  ifThenStep: T,
+): T {
+  const startIndex = flowSteps.findIndex((step) => step.id === ifThenStep.id)
+  const currDepth = parseDepth(ifThenStep)
+
+  const nextBoundaryIndex = flowSteps.findIndex(
+    (step, index) =>
+      index > startIndex && isIfThenStep(step) && parseDepth(step) <= currDepth,
+  )
+
+  if (nextBoundaryIndex === -1) {
+    return flowSteps[flowSteps.length - 1]
+  }
+  return flowSteps[nextBoundaryIndex - 1]
+}
+
+/**
+ * Finds blank placeholder steps inside a V1 block's derived range, so the
+ * V1 -> V2 upgrade can drop them instead of pinning them into a V2 block's
+ * initial membership. V2 blocks start empty and never grow one on their own.
+ */
+export function findBlankPlaceholderMemberIds<T extends ExtentStep>(
+  flowSteps: T[],
+  ifThenStep: T,
+  endStep: T,
+): string[] {
+  return flowSteps
+    .filter(
+      (step) =>
+        step.position > ifThenStep.position &&
+        step.position <= endStep.position &&
+        isBlankPlaceholderStep(step),
+    )
+    .map((step) => step.id)
+}

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-create-step.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-create-step.ts
@@ -1,0 +1,143 @@
+import { Transaction } from 'objection'
+
+import {
+  BLOCK_END_STEP_ID,
+  isBlockStep,
+  isIfThenStep,
+  isIfThenV2,
+} from '@/apps/toolbox/common/constants'
+import {
+  deriveV1EndStepDroppingBlankMembers,
+  pinEndStep,
+  rejectEndStepWrite,
+  validateEndStepWrite,
+} from '@/apps/toolbox/common/validate-end-step'
+import Flow from '@/models/flow'
+import type Step from '@/models/step'
+
+import { deriveIfThenV1EndStep } from './end-step-utils'
+
+/**
+ * Maintains if-then endStepId markers when a step is created, in the same
+ * transaction as the insert.
+ *
+ * IMPORTANT: throws on any violation, rolling back the whole creation.
+ */
+export async function fixupEndStepOnCreateStep({
+  trx,
+  flow,
+  previousBlockId,
+  previousStep,
+  newStep,
+  wantsSelfEndStep,
+}: {
+  trx: Transaction
+  flow: Flow
+  previousBlockId: string | null | undefined
+  previousStep: Step
+  newStep: Step
+  wantsSelfEndStep: boolean
+}): Promise<void> {
+  const flowId = flow.id
+  const flowSteps = await flow
+    .$relatedQuery('steps', trx)
+    .orderBy('position', 'asc')
+
+  // Self-ref is independent of previousBlockId/tail-extend below: it's about
+  // the new step's own marker, not an existing block's.
+  if (wantsSelfEndStep) {
+    if (!isIfThenStep(newStep)) {
+      rejectEndStepWrite('self-end-step-on-non-if-then', {
+        newStepId: newStep.id,
+        flowId,
+      })
+    }
+    validateEndStepWrite({
+      flowSteps,
+      ifThenStepId: newStep.id,
+      endStepId: newStep.id,
+      flowId,
+    })
+    await pinEndStep(trx, newStep.id, newStep.id)
+  }
+
+  if (previousBlockId != null) {
+    const blockStep = flowSteps.find((step) => step.id === previousBlockId)
+    if (!blockStep || !isIfThenStep(blockStep)) {
+      rejectEndStepWrite('previous-block-not-if-then', {
+        previousBlockId,
+        flowId,
+      })
+    }
+
+    // Already marked: nothing to pin here, this check is just a bug tripwire.
+    if (isIfThenV2(blockStep)) {
+      const explicitEndStepId = blockStep.config[BLOCK_END_STEP_ID]
+      if (previousStep.id !== explicitEndStepId) {
+        rejectEndStepWrite('previous-step-not-block-end', {
+          previousBlockId,
+          previousStepId: previousStep.id,
+          endStepId: explicitEndStepId,
+          flowId,
+        })
+      }
+      return
+    }
+
+    // Excludes the new step from the extent scan so a plain add-after isn't
+    // absorbed into the block.
+    const preInsertSteps = flowSteps.filter((step) => step.id !== newStep.id)
+    const preBlockStep = preInsertSteps.find(
+      (step) => step.id === previousBlockId,
+    )
+    const derivedEndStep = deriveIfThenV1EndStep(preInsertSteps, preBlockStep)
+    if (previousStep.id !== derivedEndStep.id) {
+      rejectEndStepWrite('previous-step-not-block-end', {
+        previousBlockId,
+        previousStepId: previousStep.id,
+        endStepId: derivedEndStep.id,
+        flowId,
+      })
+    }
+
+    // Drops any leftover V1 blank placeholder member before pinning, same as
+    // the opportunistic upgrade pass. The new step is excluded from the
+    // re-derivation for the same reason as above.
+    const { endStep: finalEndStep, cleaned } =
+      await deriveV1EndStepDroppingBlankMembers(
+        trx,
+        flow,
+        preInsertSteps,
+        preBlockStep,
+        new Set([newStep.id]),
+      )
+    const finalFlowSteps = cleaned
+      ? await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+      : flowSteps
+
+    validateEndStepWrite({
+      flowSteps: finalFlowSteps,
+      ifThenStepId: blockStep.id,
+      endStepId: finalEndStep.id,
+      flowId,
+    })
+    await pinEndStep(trx, blockStep.id, finalEndStep.id)
+    return
+  }
+
+  if (!isBlockStep(newStep)) {
+    const blockToExtend = flowSteps.find(
+      (step) =>
+        isIfThenV2(step) && step.config[BLOCK_END_STEP_ID] === previousStep.id,
+    )
+    if (blockToExtend) {
+      validateEndStepWrite({
+        flowSteps,
+        ifThenStepId: blockToExtend.id,
+        endStepId: newStep.id,
+        flowId,
+      })
+      await pinEndStep(trx, blockToExtend.id, newStep.id)
+    }
+  }
+}

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -23,7 +23,8 @@ export enum TOOLBOX_ACTIONS {
 export const BLOCK_END_STEP_ID = 'endStepId'
 
 // Not IStep itself: the execution context's $.step is trimmed (no config), and
-// unit-test fixtures pass partials — neither is a full IStep.
+// unit-test fixtures pass partials — neither is a full IStep. Also reused as
+// a base for the slightly wider shapes elsewhere in the toolbox.
 export type StepLike = Partial<Pick<IStep, 'appKey' | 'key' | 'config'>>
 
 export function isIfThenStep(step: StepLike | null | undefined): boolean {
@@ -39,6 +40,26 @@ export function isOnlyContinueIfStep(
     step?.appKey === TOOLBOX_APP_KEY &&
     step?.key === TOOLBOX_ACTIONS.ONLY_CONTINUE_IF
   )
+}
+
+export function isForEachStep(step: StepLike | null | undefined): boolean {
+  return (
+    step?.appKey === TOOLBOX_APP_KEY && step?.key === TOOLBOX_ACTIONS.FOR_EACH
+  )
+}
+
+export function isBlockStep(step: StepLike | null | undefined): boolean {
+  return isIfThenStep(step) || isForEachStep(step)
+}
+
+// The if-then V1 branch initializer's blank placeholder child is the only
+// legitimate step with neither an app nor an event.
+// IMPORTANT: createStep requires both fields together, so a step is never
+// mid-configuration with just one of them unset.
+export function isBlankPlaceholderStep(
+  step: StepLike | null | undefined,
+): boolean {
+  return !step?.appKey && !step?.key
 }
 
 // IMPORTANT: presence (Object.hasOwn), not value, distinguishes an if-then V2

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -1,6 +1,14 @@
-import type { IStep } from '@plumber/types'
+import type { IStep, IStepConfig } from '@plumber/types'
 
+import { raw, Transaction } from 'objection'
+
+import {
+  deriveIfThenV1EndStep,
+  findBlankPlaceholderMemberIds,
+} from '@/apps/toolbox/actions/if-then/infra/end-step-utils'
 import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
 
 import {
   BLOCK_END_STEP_ID,
@@ -26,7 +34,7 @@ interface EndStepWriteValidationArgs {
  * IMPORTANT: throws a plain Error, not BadUserInputError — these violations
  * are prevented by the frontend, so hitting one means a bug, not bad input.
  */
-function rejectEndStepWrite(
+export function rejectEndStepWrite(
   reason: string,
   details: Record<string, unknown>,
 ): never {
@@ -142,5 +150,130 @@ export function validateEndStepWrite({
         flowId,
       })
     }
+  }
+}
+
+// The real id doesn't exist until after insert, so this is the only value a
+// create-step config.endStepId may carry; anything else is a bug, not a
+// legitimate write (it would let a client redefine another block's boundary
+// at create time).
+export const SELF_END_STEP_SENTINEL = 'self'
+
+/**
+ * Splits a create-step config into the config to insert and whether the
+ * client asked to self-reference the new step's own marker.
+ */
+export function extractSelfEndStepIntent(
+  config: IStepConfig | null | undefined,
+): {
+  config: IStepConfig
+  wantsSelfEndStep: boolean
+} {
+  const sanitized = { ...(config ?? {}) }
+  if (!Object.hasOwn(sanitized, BLOCK_END_STEP_ID)) {
+    return { config: sanitized, wantsSelfEndStep: false }
+  }
+
+  const value = sanitized[BLOCK_END_STEP_ID]
+  delete sanitized[BLOCK_END_STEP_ID]
+  if (value !== SELF_END_STEP_SENTINEL) {
+    rejectEndStepWrite('invalid-end-step-sentinel', { value })
+  }
+  return { config: sanitized, wantsSelfEndStep: true }
+}
+
+// Uses jsonb_set so this only touches endStepId, not the rest of config.
+export async function pinEndStep(
+  trx: Transaction,
+  ifThenStepId: string,
+  endStepId: string,
+): Promise<void> {
+  await Step.query(trx)
+    .findById(ifThenStepId)
+    .patch({
+      config: raw(`jsonb_set(config, '{${BLOCK_END_STEP_ID}}', ?::jsonb)`, [
+        JSON.stringify(endStepId),
+      ]),
+    })
+}
+
+/**
+ * Deletes a V1 block's leftover blank placeholder members and closes the
+ * position gaps they leave, highest position first so each target's own
+ * recorded position stays valid for the ones still to come.
+ *
+ * DB-only. The caller re-derives its own view of the flow afterward.
+ */
+async function deleteBlankPlaceholderMembers(
+  trx: Transaction,
+  flow: Flow,
+  currentSteps: ValidationStep[],
+  blankMemberIds: string[],
+): Promise<void> {
+  const targets = currentSteps
+    .filter((step) => blankMemberIds.includes(step.id))
+    .sort((a, b) => b.position - a.position)
+
+  for (const target of targets) {
+    await Step.query(trx).findById(target.id).delete()
+    await flow
+      .$relatedQuery('steps', trx)
+      .where('position', '>', target.position)
+      .patch({ position: raw('position - 1') })
+  }
+}
+
+/**
+ * Derives `ifThenStep`'s current V1 extent after dropping any leftover
+ * blank placeholder members (see `isBlankPlaceholderStep`) instead of
+ * pinning them into the block's initial V2 membership. A V2 block starts
+ * empty and has no equivalent concept, so a survivor here would break its
+ * empty/populated conventions.
+ *
+ * IMPORTANT: `excludeStepIds` (e.g. create-step's own just-inserted step) is
+ * excluded from both the derivation and the blank-member scan, so a plain
+ * add-after isn't absorbed into a block whose end just shifted from a
+ * deletion here.
+ *
+ * IMPORTANT: deleting a member shifts every later step's position, so
+ * `cleaned` signals the caller's own step list is now stale and must be
+ * re-fetched.
+ */
+export async function deriveV1EndStepDroppingBlankMembers(
+  trx: Transaction,
+  flow: Flow,
+  currentSteps: ValidationStep[],
+  ifThenStep: ValidationStep,
+  excludeStepIds: Set<string>,
+): Promise<{ endStep: ValidationStep; cleaned: boolean }> {
+  const endStep = deriveIfThenV1EndStep(currentSteps, ifThenStep)
+
+  const blankMemberIds = findBlankPlaceholderMemberIds(
+    currentSteps,
+    ifThenStep,
+    endStep,
+  ).filter((id) => !excludeStepIds.has(id))
+
+  if (blankMemberIds.length === 0) {
+    return { endStep, cleaned: false }
+  }
+
+  await deleteBlankPlaceholderMembers(trx, flow, currentSteps, blankMemberIds)
+  logger.info({
+    event: 'if-then-v1-blank-members-removed',
+    ifThenStepId: ifThenStep.id,
+    removedStepIds: blankMemberIds,
+    flowId: flow.id,
+  })
+
+  const refetchedSteps = (
+    await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
+  ).filter((step) => !excludeStepIds.has(step.id))
+  return {
+    endStep: deriveIfThenV1EndStep(
+      refetchedSteps,
+      refetchedSteps.find((step) => step.id === ifThenStep.id),
+    ),
+    cleaned: true,
   }
 }

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -638,3 +638,595 @@ describe('createStep mutation integration tests', async () => {
     })
   })
 })
+
+describe('createStep endStepId write rules', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let flowTimestamp: string
+
+  const flowInput = () => ({ id: testFlow.id, updatedAt: flowTimestamp })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    await FlowConnections.query().delete()
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'endStep Test Flow',
+      updatedBy: owner.id,
+    })
+    flowTimestamp = String(new Date(testFlow.updatedAt).getTime())
+
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      ...testFlow,
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('rule 1: pins a legacy block when adding after it (lazy upgrade)', async () => {
+    const [, ifThenA, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((newStep as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 1: deletes a leftover V1 blank placeholder before pinning a block reached via add-after-block', async () => {
+    const [, ifThenA, blankChild] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: null, appKey: null, type: 'action' },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: blankChild.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    // The placeholder is deleted, and the block (having no other member
+    // left) self-references instead of absorbing the placeholder as its
+    // endStep.
+    await expect(reload(blankChild.id)).rejects.toThrow()
+    const reloadedIfThenA = await reload(ifThenA.id)
+    expect(reloadedIfThenA.config.endStepId).toBe(ifThenA.id)
+    // IMPORTANT: reloaded, not the mutation's own return value — the
+    // cleanup's position shift runs after the insert this resolver's
+    // response was captured from, so the response's own `position` is
+    // stale by one.
+    const reloadedNewStep = await reload((newStep as any).id)
+    expect(reloadedNewStep.position).toBe(reloadedIfThenA.position + 1)
+
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+    expect(steps.map((step) => step.position)).toEqual(
+      steps.map((_step, index) => index + 1),
+    )
+  })
+
+  it('rule 1: adds after an explicit block without changing its marker', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, other] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((await reload(other.id)).position).toBe(newStep.position + 1)
+  })
+
+  it('rule 1: rolls back when previousStep is not the block endStep', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, other] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: other.id },
+            previousBlockId: ifThenA.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(4)
+  })
+
+  it('rule 1: rolls back when the block would reach out of its rejection branch', async () => {
+    // The derived extent runs past the branch boundary to the end of the flow,
+    // so the write must be rejected.
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      {
+        key: 'ifThen',
+        appKey: 'toolbox',
+        type: 'action',
+        config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenApproval, stepA] = seeded
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: stepA.id },
+            previousBlockId: ifThenApproval.id,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(3)
+  })
+
+  it('rule 1: pins a rejection-branch block when adding after it', async () => {
+    // ifThenB bounds ifThenA's derived extent to stepA, keeping it inside the
+    // branch.
+    const rejection = {
+      approval: { branch: 'reject' as const, stepId: 'someApprovalStep' },
+    }
+    const [, , ifThenA, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'mrfSubmission', appKey: 'formsg', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+      {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        type: 'action',
+        config: rejection,
+      },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+          config: rejection,
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect(newStep.position).toBe(stepA.position + 1)
+    expect((newStep as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 2: extends an explicit block on a plain tail-add', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(newStep.id)
+  })
+
+  it('rule 2: extends an empty (self-ref) block on the first inside-add', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: ifThenA.id } })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThenA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(newStep.id)
+  })
+
+  it('rule 2: extends an empty block inside a rejection branch', async () => {
+    // Simulates the if-then V2 initializer's empty-block-then-first-child
+    // sequence inside a rejection branch.
+    const rejection = {
+      approval: { branch: 'reject' as const, stepId: 'someApprovalStep' },
+    }
+    const [, , ifThenA, existing] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'mrfSubmission', appKey: 'formsg', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action', config: rejection },
+      {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        type: 'action',
+        config: rejection,
+      },
+    ])
+    await ifThenA.$query().patch({
+      config: { ...rejection, endStepId: ifThenA.id },
+    })
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: ifThenA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+          config: rejection,
+        },
+      },
+      context,
+    )
+
+    const block = await reload(ifThenA.id)
+    expect(block.config.endStepId).toBe(newStep.id)
+    // IMPORTANT: preserves the approval marker and doesn't swallow the
+    // pre-existing step during the pin.
+    expect(block.config.approval).toEqual(rejection.approval)
+    expect(newStep.position).toBeLessThan((await reload(existing.id)).position)
+  })
+
+  it('rule 2: does NOT extend when the new step is an if-then', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newIfThen = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'ifThen',
+          appKey: 'toolbox',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect((newIfThen as any).config.endStepId).toBeUndefined()
+  })
+
+  it('rule 2: no-op for a mid-range insert (endStep stays last by id)', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, ifThenA, stepA, stepB] = seeded
+    await ifThenA.$query().patch({ config: { endStepId: stepB.id } })
+
+    await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepB.id)
+  })
+
+  it('rule 3: no-op inside-add on a legacy block (stays lazy)', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, , stepA] = seeded
+
+    await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          parameters: {},
+        },
+      },
+      context,
+    )
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps.every((step) => step.config.endStepId === undefined)).toBe(
+      true,
+    )
+  })
+
+  it('rejects a real step id in config.endStepId on create', async () => {
+    const seeded = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    const [, existing] = seeded
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: existing.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+            config: { endStepId: 'client-supplied-id', stepName: 'kept' },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(2)
+  })
+
+  it('self-refs a fresh if-then via the sentinel', async () => {
+    const [, existing] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: existing.id },
+          key: 'ifThen',
+          appKey: 'toolbox',
+          parameters: {},
+          config: { endStepId: 'self' },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(newStep.id)).config.endStepId).toBe(newStep.id)
+  })
+
+  it('rejects the sentinel on a non-if-then step', async () => {
+    const [, existing] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await expect(
+      createStep(
+        null,
+        {
+          input: {
+            flow: flowInput(),
+            previousStep: { id: existing.id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+            config: { endStepId: 'self' },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const steps = await testFlow.$relatedQuery('steps')
+    expect(steps).toHaveLength(2)
+  })
+
+  it('preserves approval config through a self-ref write', async () => {
+    const rejection = {
+      approval: { branch: 'reject' as const, stepId: 'someApprovalStep' },
+    }
+    const [, , existing] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'mrfSubmission', appKey: 'formsg', type: 'action' },
+      {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        type: 'action',
+        config: rejection,
+      },
+    ])
+
+    const newStep = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: existing.id },
+          key: 'ifThen',
+          appKey: 'toolbox',
+          parameters: {},
+          config: { ...rejection, endStepId: 'self' },
+        },
+      },
+      context,
+    )
+
+    const reloaded = await reload(newStep.id)
+    expect(reloaded.config.endStepId).toBe(newStep.id)
+    expect(reloaded.config.approval).toEqual(rejection.approval)
+  })
+
+  it('self-refs a new block created via previousBlockId, alongside pinning the block it follows', async () => {
+    const [, ifThenA, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
+
+    const newIfThen = await createStep(
+      null,
+      {
+        input: {
+          flow: flowInput(),
+          previousStep: { id: stepA.id },
+          previousBlockId: ifThenA.id,
+          key: 'ifThen',
+          appKey: 'toolbox',
+          parameters: {},
+          config: { endStepId: 'self' },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThenA.id)).config.endStepId).toBe(stepA.id)
+    expect((await reload(newIfThen.id)).config.endStepId).toBe(newIfThen.id)
+  })
+})

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,6 +2,8 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import { fixupEndStepOnCreateStep } from '@/apps/toolbox/actions/if-then/infra/handle-create-step'
+import { extractSelfEndStepIntent } from '@/apps/toolbox/common/validate-end-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
@@ -82,8 +84,11 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .throwIfNotFound()
 
+    const { config: newStepConfig, wantsSelfEndStep } =
+      extractSelfEndStepIntent(input.config as IStepConfig)
+
     const validationResult = await validateApprovalConfig(
-      input.config as IStepConfig,
+      newStepConfig,
       previousStep,
     )
     if (!validationResult.isApprovalConfigValid) {
@@ -106,8 +111,19 @@ const createStep: MutationResolvers['createStep'] = async (
       position: validationResult.newStepPosition,
       parameters: input.parameters,
       connectionId: input.connection?.id,
-      config: input.config as IStepConfig,
+      config: newStepConfig,
       version,
+    })
+
+    // IMPORTANT: throws (and rolls back the whole creation) on any marker
+    // violation.
+    await fixupEndStepOnCreateStep({
+      trx,
+      flow,
+      previousBlockId: input.previousBlockId,
+      previousStep,
+      newStep: step,
+      wantsSelfEndStep,
     })
 
     // NOTE: add flow connection to the flow_connections table

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -691,6 +691,9 @@ input CreateStepInput {
   parameters: JSONObject
   previousStep: PreviousStepInput
   config: StepConfigInput
+  # The if-then block the new step is being added after.
+  # IMPORTANT: presence triggers a server-side lazy upgrade / marker pin.
+  previousBlockId: ID
 }
 
 input StepApprovalConfigInput {


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates `createStep` mutation to support creating If-Then V2 blocks (by adding support for `endStepId`).

# Tests

See top of stack.