### PR TITLE
PLU-743: [IF-THEN-THEN-V2-5] Make updateStep support endStepId

### DIFF
--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-update-step.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-update-step.ts
@@ -1,0 +1,36 @@
+import { Transaction } from 'objection'
+
+import { BLOCK_END_STEP_ID } from '@/apps/toolbox/common/constants'
+import { validateEndStepWrite } from '@/apps/toolbox/common/validate-end-step'
+import Step from '@/models/step'
+
+/**
+ * Derives a client-supplied config.endStepId on updateStep into the config
+ * fragment for the caller to merge into its own patch.
+ *
+ * Accepted only when the key is present — an absent key is preserved by the
+ * caller's config spread. Throws (rolling back the transaction) on an invalid
+ * target.
+ */
+export async function getEndStepConfigForUpdateStep({
+  trx,
+  step,
+  inputConfig,
+  flowId,
+}: {
+  trx: Transaction
+  step: Step
+  inputConfig: { [BLOCK_END_STEP_ID]?: string | null } | null | undefined
+  flowId: string
+}): Promise<{ [BLOCK_END_STEP_ID]?: string }> {
+  if (!inputConfig || !Object.hasOwn(inputConfig, BLOCK_END_STEP_ID)) {
+    return {}
+  }
+
+  const endStepId = inputConfig[BLOCK_END_STEP_ID] as string
+  const flowSteps = await Step.query(trx)
+    .where('flow_id', flowId)
+    .orderBy('position', 'asc')
+  validateEndStepWrite({ flowSteps, ifThenStepId: step.id, endStepId, flowId })
+  return { [BLOCK_END_STEP_ID]: endStepId }
+}

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -858,3 +858,179 @@ describe('updateStep mutation', () => {
     })
   })
 })
+
+// Real-DB integration tests, kept separate from the mock-based suite above so
+// writes hit real flow steps and can actually roll back.
+describe('updateStep endStepId config merge', () => {
+  let testFlow: Flow
+  let owner: User
+  let context: Context
+  let flowTimestamp: string
+
+  const flowInput = () => ({ id: testFlow.id, updatedAt: flowTimestamp })
+
+  async function seedSteps(
+    specs: Array<{
+      key: string | null
+      appKey: string | null
+      type: 'trigger' | 'action'
+      config?: Record<string, any>
+      parameters?: Record<string, any>
+    }>,
+  ): Promise<Step[]> {
+    return testFlow.$relatedQuery('steps').insertAndFetch(
+      specs.map((spec, index) => ({
+        key: spec.key,
+        appKey: spec.appKey,
+        type: spec.type,
+        position: index + 1,
+        parameters: spec.parameters ?? {},
+        config: spec.config ?? {},
+      })),
+    ) as unknown as Promise<Step[]>
+  }
+
+  const reload = async (id: string): Promise<Step> =>
+    Step.query().findById(id).throwIfNotFound()
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+
+    owner = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: owner,
+      res: null,
+      isAdminOperation: false,
+    } as unknown as Context
+
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
+      name: 'endStep Update Flow',
+      updatedBy: owner.id,
+    })
+    flowTimestamp = String(new Date(testFlow.updatedAt).getTime())
+
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      ...testFlow,
+      updatedAt: testFlow.updatedAt,
+    } as any)
+  })
+
+  it('writes a self-referencing endStepId onto a new-style if-then', async () => {
+    const [, ifThen] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+    ])
+
+    await updateStep(
+      null,
+      {
+        input: {
+          id: ifThen.id,
+          flow: flowInput(),
+          key: 'ifThen',
+          appKey: 'toolbox',
+          connection: {},
+          parameters: {},
+          config: { endStepId: ifThen.id },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(ifThen.id)
+  })
+
+  it('preserves an existing marker through a condition edit (merge)', async () => {
+    const [, ifThen, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'ifThen', appKey: 'toolbox', type: 'action' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+    await ifThen.$query().patch({
+      config: { endStepId: stepA.id, stepName: 'orig' },
+    })
+
+    await updateStep(
+      null,
+      {
+        input: {
+          id: ifThen.id,
+          flow: flowInput(),
+          key: 'ifThen',
+          appKey: 'toolbox',
+          connection: {},
+          parameters: { conditions: [{ rows: [] }] },
+        },
+      },
+      context,
+    )
+
+    expect((await reload(ifThen.id)).config.endStepId).toBe(stepA.id)
+  })
+
+  it('rolls back an endStepId write on a non-if-then step', async () => {
+    const [, postmanStep] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await expect(
+      updateStep(
+        null,
+        {
+          input: {
+            id: postmanStep.id,
+            flow: flowInput(),
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            connection: {},
+            parameters: {},
+            config: { endStepId: postmanStep.id },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    expect((await reload(postmanStep.id)).config.endStepId).toBeUndefined()
+  })
+
+  it('rolls back an endStepId write on an approval-bearing if-then', async () => {
+    const [, ifThen, stepA] = await seedSteps([
+      { key: 'newSubmission', appKey: 'formsg', type: 'trigger' },
+      {
+        key: 'ifThen',
+        appKey: 'toolbox',
+        type: 'action',
+        config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      },
+      { key: 'sendTransactionalEmail', appKey: 'postman', type: 'action' },
+    ])
+
+    await expect(
+      updateStep(
+        null,
+        {
+          input: {
+            id: ifThen.id,
+            flow: flowInput(),
+            key: 'ifThen',
+            appKey: 'toolbox',
+            connection: {},
+            parameters: {},
+            config: { endStepId: stepA.id },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+
+    const reloaded = await reload(ifThen.id)
+    expect(reloaded.config.endStepId).toBeUndefined()
+    expect(reloaded.config.approval).toEqual({
+      branch: 'reject',
+      stepId: 'someApprovalStep',
+    })
+  })
+})

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,5 +1,6 @@
 import { IAction } from '@/../../types'
 import apps from '@/apps'
+import { getEndStepConfigForUpdateStep } from '@/apps/toolbox/actions/if-then/infra/handle-update-step'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import {
   addFlowConnection,
@@ -84,6 +85,15 @@ const updateStep: MutationResolvers['updateStep'] = async (
     const stepName = input?.config?.stepName ?? step?.config?.stepName
     const existingConfig = step?.config ?? {}
 
+    // Returns {} when absent so the config spread below preserves any existing
+    // marker; throws (rolls back) on an invalid target.
+    const endStepConfig = await getEndStepConfigForUpdateStep({
+      trx,
+      step,
+      inputConfig: input.config,
+      flowId: input.flow.id,
+    })
+
     let parameters = input.parameters
     let version = step.version
 
@@ -113,6 +123,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
           ...existingConfig,
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
           ...(stepName !== undefined ? { stepName } : {}),
+          ...endStepConfig,
         },
       })
       .withGraphFetched({


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Updates `updateStep` mutation to support `endStepId`parameter.

> [!NOTE]
> This is only used for the empty top-level steps - we need this to support converrting that empty step to If-Then V2. This should be very, very rare - likely only people with very old pipes before we did our UI refresh.

# Tests

See top of stack.