### PR TITLE
PLU-869 fix(scheduler): Check step requiring reselect of already-defaulted fields

### DIFF
--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -22,6 +22,7 @@ const trigger: IRawTrigger = {
       type: 'boolean-radio' as const,
       description: 'Should this workflow start on Saturday and Sunday?',
       required: true,
+      value: false,
       // flip the order of the default options
       options: [
         {

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -29,6 +29,7 @@ const trigger: IRawTrigger = {
           value: false,
         },
       ],
+      value: false,
     },
   ],
   getDataOutMetadata,

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -8,7 +8,10 @@ import FlowSubstep from '@/components/FlowSubstep'
 import Form from '@/components/Form'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsProvider } from '@/contexts/StepExecutions'
-import { generateValidationSchema } from '@/helpers/editor'
+import {
+  generateValidationSchema,
+  withDefaultParameters,
+} from '@/helpers/editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
@@ -45,13 +48,18 @@ export default function Step(props: StepProps): React.ReactElement | null {
     [substeps],
   )
 
+  const stepWithDefaultParameters = useMemo(
+    () => withDefaultParameters(step, substeps),
+    [step, substeps],
+  )
+
   return (
     <>
       <Flex w="100%" flexDir="column">
         <StepExecutionsProvider currentStep={step}>
           <Form
             key={`${step.id}-${resetTimestamp}`}
-            defaultValues={step}
+            defaultValues={stepWithDefaultParameters}
             onSubmit={handleSubmit}
             resolver={stepValidationSchema}
           >

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -44,6 +44,40 @@ function isValidArgValue(value: IJSONValue): boolean {
   return value != null && value !== ''
 }
 
+// Field definitions can specify a static `value` to pre-select (e.g. a
+// boolean-radio defaulting to "No"). That default only reaches react-hook-form
+// via each input's own `defaultValue` prop, which registers asynchronously
+// after mount — too late for validation that runs on the form's initial
+// render (see FlowSubstep's initial `isValid` state). Backfilling here, into
+// the `defaultValues` passed to `useForm`, makes the default available
+// synchronously from the very first render.
+export function withDefaultParameters(
+  step: IStep,
+  substeps: ISubstep[],
+): IStep {
+  const defaultParameters: IJSONObject = {}
+
+  for (const substep of substeps ?? []) {
+    for (const arg of substep.arguments ?? []) {
+      if (arg.value !== undefined && step.parameters[arg.key] === undefined) {
+        defaultParameters[arg.key] = arg.value as IJSONValue
+      }
+    }
+  }
+
+  if (Object.keys(defaultParameters).length === 0) {
+    return step
+  }
+
+  return {
+    ...step,
+    parameters: {
+      ...defaultParameters,
+      ...step.parameters,
+    },
+  }
+}
+
 export function validateSubstep(substep: ISubstep, step: IStep): boolean {
   if (!substep) {
     return true


### PR DESCRIPTION
## TL;DR

Scheduler's "Trigger on weekends?" field required a manual reselect before `Check step` would enable, even though it already defaulted to "No". Fixes [PLU-869](https://linear.app/ogp/issue/PLU-869/scheduler-requires-reselecting-yesno-before-checking-step).

## What changed?

- Added the missing `value: false` default to Scheduler's `triggersOnWeekend` field (`every-day`, `every-hour` triggers).
- Fixed the actual root cause in the frontend: a field's schema `value` only reached react-hook-form via each input's own `defaultValue` prop, which registers asynchronously on mount — too late for `FlowSubstep`'s required-field validation, which runs synchronously on the very first render and only re-validates on a subsequent field *change*. This is why the button stayed disabled until the user clicked something, even on an already-defaulted field.
- Added `withDefaultParameters` (`packages/frontend/src/helpers/editor.ts`) to backfill each argument's schema `value` into the `defaultValues` object passed to `useForm` (wired in `EditorRightDrawer/Step.tsx`), so defaults are present synchronously from the first render.
- This also fixes the same latent issue for other apps with a static field default that wasn't previously surfaced as a bug report (e.g. `delay-until`'s `allowPastDate`, `tiles`' `returnLastRow`/`returnLastRowFirst`, `slack`'s `sortBy`/`sortDirection`, etc.) — verified no runtime behavior change for the handful of optional fields affected (`telegram-bot`'s `disableNotification`, `slack`'s `botName`, `formsg`'s `nricFilter`): each already treats an unset parameter identically to its documented default.

## Tests (manual)

- [ ] Add a new "Schedule daily" or "Schedule hourly" trigger step to a pipe, leave "Trigger on weekends?" untouched (default "No") — confirm `Check step` is enabled immediately, without clicking the radio first.
- [ ] Repeat for a Delay action ("How should we handle dates in the past?") and a Tiles find-row action — confirm `Check step` enables immediately on a fresh step.
- [ ] Confirm test-running and saving these steps without touching the defaulted field persists the expected default value (e.g. `triggersOnWeekend: false`) and behaves as expected on a real run.
- [ ] Confirm explicitly changing a defaulted field still works and persists correctly.

## Deploy notes

None — pure frontend/backend field-definition change, no migrations or infra changes.
