### PR TITLE
chore(mcp): add secret key/api key detection

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -16,9 +16,11 @@ import {
 } from '@/hooks/useChatStream'
 import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicker'
 import DynamicPicker from '@/pages/AiBuilder/components/ChatInterface/DynamicPicker'
+import SecretKeyWarningDialog from '@/pages/AiBuilder/components/ChatInterface/SecretKeyWarningDialog'
 import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
 import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
+import { containsSecretKey } from '@/pages/AiBuilder/helpers'
 
 interface PromptInputProps {
   isStreaming: boolean
@@ -104,6 +106,8 @@ export default function PromptInput({
   >({})
   const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0)
   const [reviewMode, setReviewMode] = useState(false)
+  const [showSecretKeyWarning, setShowSecretKeyWarning] = useState(false)
+  const secretKeyDialogCancelRef = useRef<HTMLButtonElement>(null)
 
   // Reset state whenever a new clarification arrives
   useEffect(() => {
@@ -112,16 +116,30 @@ export default function PromptInput({
     setReviewMode(false)
   }, [clarification])
 
+  const doSend = () => {
+    sendMessage(input)
+    setInput('')
+    setSelectedAnswers({})
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }
+
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault()
-    if (input?.trim() && !isStreaming) {
-      sendMessage(input)
-      setInput('')
-      setSelectedAnswers({})
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto'
-      }
+    if (!input?.trim() || isStreaming) {
+      return
     }
+    if (containsSecretKey(input)) {
+      setShowSecretKeyWarning(true)
+      return
+    }
+    doSend()
+  }
+
+  const handleSendAnyway = () => {
+    setShowSecretKeyWarning(false)
+    doSend()
   }
 
   const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -373,6 +391,13 @@ export default function PromptInput({
           )}
         </Box>
       )}
+
+      <SecretKeyWarningDialog
+        cancelRef={secretKeyDialogCancelRef}
+        isOpen={showSecretKeyWarning}
+        onClose={() => setShowSecretKeyWarning(false)}
+        onSendAnyway={handleSendAnyway}
+      />
     </Box>
   )
 }

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/SecretKeyWarningDialog.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/SecretKeyWarningDialog.tsx
@@ -1,0 +1,58 @@
+import { RefObject } from 'react'
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+} from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+interface SecretKeyWarningDialogProps {
+  cancelRef: RefObject<HTMLButtonElement>
+  isOpen: boolean
+  onClose: () => void
+  onSendAnyway: () => void
+}
+
+export default function SecretKeyWarningDialog({
+  cancelRef,
+  isOpen,
+  onClose,
+  onSendAnyway,
+}: SecretKeyWarningDialogProps) {
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            This message appears to contain a secret key
+          </AlertDialogHeader>
+          <AlertDialogBody>
+            Secret keys and API keys should only be entered via the app&apos;s
+            own connection setup, never in chat — chat messages are sent to the
+            AI. Are you sure you want to send this?
+          </AlertDialogBody>
+          <AlertDialogFooter>
+            <Button
+              colorScheme="neutral"
+              variant="clear"
+              ref={cancelRef}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button colorScheme="critical" onClick={onSendAnyway} ml={3}>
+              Send anyway
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -103,6 +103,73 @@ export const extractLastFormUrl = (messages: Message[]): string | undefined => {
   return undefined
 }
 
+// Same base64 charset check as the backend's parseSecretKeyFormat (see
+// formsg/auth/verify-credentials.ts) and AddFormsgConnectionModal's own
+// SECRET_KEY_REGEX.
+const FORMSG_SECRET_KEY_CHARSET_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
+
+// A FormSG secret key is the base64 encoding of a 32-byte NaCl key. Checking
+// the decoded byte length (not just the base64 charset) keeps ordinary
+// words/IDs from false-positiving, since they're extremely unlikely to
+// decode to exactly 32 bytes.
+const isFormsgSecretKey = (token: string): boolean => {
+  if (!FORMSG_SECRET_KEY_CHARSET_REGEX.test(token)) {
+    return false
+  }
+  try {
+    return atob(token).length === 32
+  } catch {
+    return false
+  }
+}
+
+// GatherSG's instant-workflow trigger has an `encryptionKey` field (see
+// encryptionKeySchema in gathersg/triggers/new-instant-workflow/schema.ts):
+// 12-20 non-whitespace characters, at least one digit, one uppercase letter,
+// and one special character.
+const GATHERSG_ENCRYPTION_KEY_REGEX =
+  /^(?=.*[0-9])(?=.*[A-Z])(?=.*[^A-Za-z0-9\s])\S{12,20}$/
+
+// LetterSG, Postman-SMS, and PaySG API keys are a literal env prefix followed
+// by a random token (see lettersg/common/api.ts's 'test_'/'live_' check,
+// postman-sms/common/constants.ts's 'key_test_'/'key_live_' prefixes, and
+// paysg/common/api.ts's 'paysg_live_'/'paysg_stag_' prefixes). None of these
+// apps enforce a minimum key length server-side, so this matches on the
+// prefix alone (plus at least one character after it) rather than guessing
+// at a suffix length — accepting that ordinary words sharing a prefix (e.g.
+// "test_case") will also match, since this is a soft warning, not a block.
+const PREFIXED_API_KEY_REGEX =
+  /^(?:key_test_|key_live_|paysg_live_|paysg_stag_|test_|live_)[A-Za-z0-9_-]+$/
+
+// Telegram bot tokens aren't validated by Plumber's own schema (it's treated
+// as free text), but the real tokens Telegram itself issues always follow
+// this shape: a numeric bot id, a colon, then a 35-character alphanumeric
+// string — e.g. "123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ1234567890abc".
+const TELEGRAM_BOT_TOKEN_REGEX = /^\d{6,10}:[A-Za-z0-9_-]{35}$/
+
+const SECRET_KEY_DETECTORS = [
+  isFormsgSecretKey,
+  (token: string) => GATHERSG_ENCRYPTION_KEY_REGEX.test(token),
+  (token: string) => PREFIXED_API_KEY_REGEX.test(token),
+  (token: string) => TELEGRAM_BOT_TOKEN_REGEX.test(token),
+]
+
+// Scans the message token-by-token (splitting on whitespace) against known
+// secret/API key shapes from across the apps Plumber integrates with (FormSG,
+// GatherSG, LetterSG, Postman-SMS, PaySG, Telegram), rather than requiring
+// the whole message to be just the key — a user might paste it alongside
+// other text (e.g. "here's my key: <pasted value>" or a key on its own line
+// within a longer message). Used to warn before a user accidentally pastes a
+// secret/API key into the chat composer instead of the app's own connection
+// setup, since chat text is sent to the LLM.
+export const containsSecretKey = (text: string): boolean =>
+  text
+    .split(/\s+/)
+    .some(
+      (token) =>
+        token && SECRET_KEY_DETECTORS.some((isMatch) => isMatch(token)),
+    )
+
 // deduplicate messages by id
 // there may be duplicates when the messages are combined
 export const deduplicateMessages = (messages: Message[]) => {

--- a/packages/frontend/src/pages/AiBuilder/helpers/secretKeyDetection.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/secretKeyDetection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { containsSecretKey } from '../helpers'
+
+// A real base64 encoding of a random 32-byte value — FormSG secret key shape.
+const SAMPLE_FORMSG_KEY = 'qCRJMYOtgLI3QWdNWwK52u8LTfPQCvRXU/Vm/O7DY/E='
+// A 16-byte value — same charset, wrong decoded length.
+const SAMPLE_16_BYTE_BASE64 = 'VlWnOLhEVbPHTWd4ufTlEg=='
+// GatherSG encryptionKey shape: 12-20 chars, digit + uppercase + special char.
+const SAMPLE_GATHERSG_KEY = 'K3y!secret99'
+// LetterSG / Postman-SMS / PaySG API key shapes.
+const SAMPLE_LETTERSG_KEY = 'live_a1b2c3d4e5f6g7h8'
+const SAMPLE_POSTMAN_SMS_KEY = 'key_test_a1b2c3d4e5f6g7h8'
+const SAMPLE_PAYSG_KEY = 'paysg_live_a1b2c3d4e5f6g7h8'
+// Telegram bot token shape: numeric bot id, colon, 35-char alphanumeric string.
+const SAMPLE_TELEGRAM_TOKEN = '123456789:AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDD'
+
+describe('containsSecretKey', () => {
+  describe('FormSG secret key', () => {
+    it('detects a message that is nothing but the key', () => {
+      expect(containsSecretKey(SAMPLE_FORMSG_KEY)).toBe(true)
+    })
+
+    it('detects the key pasted alongside other text on the same line', () => {
+      expect(containsSecretKey(`here's my key: ${SAMPLE_FORMSG_KEY}`)).toBe(
+        true,
+      )
+    })
+
+    it('detects the key on its own line within a longer message', () => {
+      expect(
+        containsSecretKey(
+          `Can you help me set this up?\n${SAMPLE_FORMSG_KEY}\nThanks!`,
+        ),
+      ).toBe(true)
+    })
+
+    it('returns false for a base64-charset string that decodes to the wrong byte length', () => {
+      expect(containsSecretKey(SAMPLE_16_BYTE_BASE64)).toBe(false)
+    })
+  })
+
+  describe('GatherSG encryption key', () => {
+    it('detects a key with a digit, an uppercase letter, and a special character', () => {
+      expect(containsSecretKey(SAMPLE_GATHERSG_KEY)).toBe(true)
+    })
+
+    it('returns false when shorter than 12 characters', () => {
+      expect(containsSecretKey('K3y!x')).toBe(false)
+    })
+
+    it('returns false when missing a special character', () => {
+      expect(containsSecretKey('Key3secret9x')).toBe(false)
+    })
+  })
+
+  describe('LetterSG / Postman-SMS / PaySG API keys', () => {
+    it('detects a LetterSG-shaped key (live_ prefix)', () => {
+      expect(containsSecretKey(SAMPLE_LETTERSG_KEY)).toBe(true)
+    })
+
+    it('detects a Postman-SMS-shaped key (key_test_ prefix)', () => {
+      expect(containsSecretKey(SAMPLE_POSTMAN_SMS_KEY)).toBe(true)
+    })
+
+    it('detects a PaySG-shaped key (paysg_live_ prefix)', () => {
+      expect(containsSecretKey(SAMPLE_PAYSG_KEY)).toBe(true)
+    })
+
+    it('detects a short key, since none of these apps enforce a minimum length (real LetterSG test fixture shape)', () => {
+      expect(containsSecretKey('test_v1_123456')).toBe(true)
+    })
+
+    it('also matches an ordinary word sharing the same prefix — accepted false positive, since this is a soft warning', () => {
+      expect(containsSecretKey('test_case')).toBe(true)
+    })
+
+    it('returns false for the bare prefix with nothing after it', () => {
+      expect(containsSecretKey('test_')).toBe(false)
+    })
+  })
+
+  describe('Telegram bot token', () => {
+    it('detects a bot-id:35-char-token pair', () => {
+      expect(containsSecretKey(SAMPLE_TELEGRAM_TOKEN)).toBe(true)
+    })
+
+    it('returns false when the suffix is not exactly 35 characters', () => {
+      expect(containsSecretKey('123456789:tooshort')).toBe(false)
+    })
+
+    it('returns false for an unrelated colon-separated pair', () => {
+      expect(containsSecretKey('Q: what time works?')).toBe(false)
+    })
+  })
+
+  it('returns false for ordinary chat text', () => {
+    expect(
+      containsSecretKey('Suggest workflows I can build with this form.'),
+    ).toBe(false)
+  })
+
+  it('returns false for a form/connection id', () => {
+    expect(containsSecretKey('654ab1234abc1a012345f1e0')).toBe(false)
+  })
+
+  it('returns false for an empty or whitespace-only message', () => {
+    expect(containsSecretKey('')).toBe(false)
+    expect(containsSecretKey('   ')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What?

Warns the user before sending a chat message in AI Builder that looks like a secret key or API key, since chat text is sent straight to the LLM.

## Why?

Users can accidentally paste their FormSG secret key (or another app's API key) into the AI Builder chat composer instead of the app's own connection setup — e.g. copying it from a downloaded file and pasting it into the wrong input. Once sent, that text is part of the conversation and gets forwarded to the LLM. This adds a confirmation step that catches the common case (copy-paste-and-submit) before the message actually goes out.

## What changed?

- `packages/frontend/src/pages/AiBuilder/helpers.ts`: added `containsSecretKey`, which scans a message token-by-token (splitting on whitespace, since a key might be pasted alongside other text rather than as the entire message) against known secret/API key shapes:
  - **FormSG**: base64, decodes to exactly 32 bytes (same check as the backend's `parseSecretKeyFormat`).
  - **GatherSG**: 12–20 chars with at least one digit, one uppercase letter, and one special character (matches `encryptionKeySchema`).
  - **LetterSG / Postman-SMS / PaySG**: literal env prefix (`test_`/`live_`, `key_test_`/`key_live_`, `paysg_live_`/`paysg_stag_`) followed by at least one more character. No minimum suffix length — none of these three apps enforce one server-side (Zod schemas are just a `max` cap), so this intentionally trades a few false positives on ordinary words sharing a prefix (e.g. "test_case") for not missing legitimately short keys.
  - **Telegram**: `<6-10 digit bot id>:<35-char token>` — the real shape Telegram itself issues, even though Plumber's own schema treats the bot token as free text.
- `packages/frontend/src/pages/AiBuilder/components/ChatInterface/SecretKeyWarningDialog.tsx` (new): an `AlertDialog` ("This message appears to contain a secret key" / Cancel / Send anyway), following the same pattern as the existing `DeleteConfirmationDialog`.
- `packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx`: `handleSubmit` now checks `containsSecretKey(input)` before sending — if it matches, the dialog opens and blocks the send until the user explicitly confirms "Send anyway" or cancels to edit the message.

This is a warning, not a hard block — there's always a "Send anyway" escape hatch, since detection can't be perfectly precise (especially for the apps with no server-side length constraint).

## Not covered

GatherSG's and Telegram's own connection-level `apiKey`/bot `token` fields, and GatherSG's plain `apiKey`, are validated as free text with no real format constraint beyond a length cap — there's no reliable signal to detect these without an unacceptably high false-positive rate on ordinary chat text.

## Tests

`packages/frontend/src/pages/AiBuilder/helpers/secretKeyDetection.test.ts` — covers each app's shape (true positives), format edge cases (wrong byte length, missing character class, non-35-char Telegram suffix), and confirms the accepted false-positive trade-off for the prefix-only apps.

## Deploy notes

None — frontend-only change, no migrations or config changes.
