### PR TITLE
[BUG-BASH-1] fix: send clarification answers instantly, add back/next review nav

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
@@ -1,5 +1,11 @@
-import { type FormEvent, type KeyboardEvent, useRef, useState } from 'react'
-import { FaArrowCircleUp } from 'react-icons/fa'
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { FaArrowCircleUp, FaChevronLeft, FaChevronRight } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
 import { Box, Button, Flex, Icon, Text, Textarea } from '@chakra-ui/react'
 import { Badge } from '@opengovsg/design-system-react'
@@ -10,12 +16,11 @@ interface ChoicePickerProps {
   clarification: ClarificationQuestion[]
   currentQuestionIdx: number
   selectedAnswers: Record<number, string>
-  reviewMode: boolean
   isStreaming: boolean
   onOptionClick: (optionIdx: number) => void
   onFreeTextSubmit: (text: string) => void
-  onConfirm: () => void
-  onReset: () => void
+  onBack: () => void
+  onNext: () => void
   cancelStream: () => void
 }
 
@@ -23,12 +28,11 @@ export default function ChoicePicker({
   clarification,
   currentQuestionIdx,
   selectedAnswers,
-  reviewMode,
   isStreaming,
   onOptionClick,
   onFreeTextSubmit,
-  onConfirm,
-  onReset,
+  onBack,
+  onNext,
   cancelStream,
 }: ChoicePickerProps) {
   const [input, setInput] = useState('')
@@ -36,73 +40,12 @@ export default function ChoicePicker({
 
   const currentQ = clarification[currentQuestionIdx] ?? clarification[0]
   const isMulti = clarification.length > 1
-
-  if (reviewMode) {
-    return (
-      <Box w="full" maxW="4xl">
-        <Box
-          bg="white"
-          border="1px"
-          borderColor="gray.200"
-          borderRadius="16px"
-          boxShadow="0 2px 4px rgba(0,0,0,0.1)"
-          p={4}
-          w="full"
-        >
-          <Flex direction="column" gap={3}>
-            {clarification.map((q, i) => (
-              <Box key={i}>
-                <Text fontSize="sm" color="gray.500">
-                  {q.question}
-                </Text>
-                <Text fontWeight="medium" color="gray.900">
-                  {selectedAnswers[i] ?? '—'}
-                </Text>
-              </Box>
-            ))}
-          </Flex>
-
-          <Flex
-            justify="space-between"
-            align="center"
-            mt={4}
-            pt={3}
-            borderTop="1px"
-            borderColor="gray.100"
-          >
-            <Button
-              variant="link"
-              size="sm"
-              color="gray.500"
-              onClick={onReset}
-              isDisabled={isStreaming}
-              fontWeight="normal"
-            >
-              Change answers
-            </Button>
-            {isStreaming ? (
-              <Icon
-                as={FaCircleStop}
-                fontSize="24px"
-                color="red.500"
-                cursor="pointer"
-                onClick={cancelStream}
-                _hover={{ color: 'red.600' }}
-              />
-            ) : (
-              <Icon
-                as={FaArrowCircleUp}
-                fontSize="24px"
-                color="primary.500"
-                cursor="pointer"
-                onClick={onConfirm}
-              />
-            )}
-          </Flex>
-        </Box>
-      </Box>
-    )
-  }
+  const isLast = currentQuestionIdx === clarification.length - 1
+  const currentAnswer = selectedAnswers[currentQuestionIdx]
+  // Back/next in the header only page through already-answered questions to
+  // review or change one — they can't skip ahead past what's been answered.
+  const canGoBack = isMulti && currentQuestionIdx > 0
+  const canGoNext = isMulti && !isLast && currentAnswer !== undefined
 
   const handleResize = (e?: FormEvent<HTMLTextAreaElement>) => {
     const target = e?.currentTarget || textareaRef.current
@@ -113,6 +56,17 @@ export default function ChoicePicker({
     target.style.height = 'auto'
     target.style.height = Math.min(target.scrollHeight, maxHeight) + 'px'
   }
+
+  // Restore a free-text answer when navigating back to this question. If the
+  // saved answer matches one of the listed options, it's already shown via
+  // the highlighted button above, so leave the text box empty.
+  useEffect(() => {
+    const isFreeTextAnswer =
+      currentAnswer !== undefined && !currentQ.options.includes(currentAnswer)
+    setInput(isFreeTextAnswer ? currentAnswer : '')
+    requestAnimationFrame(() => handleResize())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentQuestionIdx])
 
   const handleSubmit = () => {
     if (!input.trim() || isStreaming) {
@@ -146,43 +100,64 @@ export default function ChoicePicker({
         <Flex justify="space-between" align="center" mb={2}>
           <Text>{currentQ.question}</Text>
           {isMulti && (
-            <Text fontSize="sm" color="gray.400" ml={3}>
-              {currentQuestionIdx + 1} / {clarification.length}
-            </Text>
+            <Flex align="center" gap={2} ml={3} flexShrink={0}>
+              <Icon
+                as={FaChevronLeft}
+                fontSize="12px"
+                color={canGoBack ? 'gray.500' : 'gray.200'}
+                cursor={canGoBack && !isStreaming ? 'pointer' : 'default'}
+                onClick={canGoBack && !isStreaming ? onBack : undefined}
+                aria-label="Previous question"
+              />
+              <Text fontSize="sm" color="gray.400" whiteSpace="nowrap">
+                {currentQuestionIdx + 1} / {clarification.length}
+              </Text>
+              <Icon
+                as={FaChevronRight}
+                fontSize="12px"
+                color={canGoNext ? 'gray.500' : 'gray.200'}
+                cursor={canGoNext && !isStreaming ? 'pointer' : 'default'}
+                onClick={canGoNext && !isStreaming ? onNext : undefined}
+                aria-label="Next question"
+              />
+            </Flex>
           )}
         </Flex>
 
         {currentQ.options.length > 0 && (
           <Flex direction="column" gap={2} maxH="360px" overflowY="auto">
-            {currentQ.options.map((opt, optIdx) => (
-              <Button
-                key={optIdx}
-                variant="outline"
-                justifyContent="flex-start"
-                h="auto"
-                py={2}
-                isDisabled={isStreaming}
-                onClick={() => onOptionClick(optIdx)}
-                borderColor="gray.200"
-                bg="white"
-                color="gray.800"
-                _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
-                _active={{ bg: 'primary.100' }}
-                gap={2}
-              >
-                <Badge
-                  colorScheme="secondary"
-                  variant="subtle"
-                  size="sm"
-                  flexShrink={0}
+            {currentQ.options.map((opt, optIdx) => {
+              const isSelected = opt === currentAnswer
+              return (
+                <Button
+                  key={optIdx}
+                  variant="outline"
+                  justifyContent="flex-start"
+                  h="auto"
+                  py={2}
+                  isDisabled={isStreaming}
+                  onClick={() => onOptionClick(optIdx)}
+                  borderColor={isSelected ? 'primary.500' : 'gray.200'}
+                  bg={isSelected ? 'primary.50' : 'white'}
+                  color="gray.800"
+                  _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
+                  _active={{ bg: 'primary.100' }}
+                  gap={2}
                 >
-                  {optIdx + 1}
-                </Badge>
-                <Text textAlign="left" whiteSpace="normal" color="gray.800">
-                  {opt}
-                </Text>
-              </Button>
-            ))}
+                  <Badge
+                    colorScheme="secondary"
+                    variant="subtle"
+                    size="sm"
+                    flexShrink={0}
+                  >
+                    {optIdx + 1}
+                  </Badge>
+                  <Text textAlign="left" whiteSpace="normal" color="gray.800">
+                    {opt}
+                  </Text>
+                </Button>
+              )
+            })}
           </Flex>
         )}
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -105,7 +105,6 @@ export default function PromptInput({
     Record<number, string>
   >({})
   const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0)
-  const [reviewMode, setReviewMode] = useState(false)
   const [showSecretKeyWarning, setShowSecretKeyWarning] = useState(false)
   const secretKeyDialogCancelRef = useRef<HTMLButtonElement>(null)
 
@@ -113,7 +112,6 @@ export default function PromptInput({
   useEffect(() => {
     setSelectedAnswers({})
     setCurrentQuestionIdx(0)
-    setReviewMode(false)
   }, [clarification])
 
   const doSend = () => {
@@ -183,39 +181,53 @@ export default function PromptInput({
     el.value = original
   }, [placeholder, input])
 
+  // Builds the combined Q:/A: message from an explicit answers map (rather
+  // than reading `selectedAnswers` state) since state from the same tick
+  // as the last answer isn't guaranteed to have landed yet.
+  const sendAnswers = (answers: Record<number, string>) => {
+    if (!clarification) {
+      return
+    }
+    const combined = clarification
+      .map((q, i) => `Q: ${q.question}\nA: ${answers[i]}`)
+      .join('\n\n')
+    sendMessage(combined)
+    setSelectedAnswers({})
+    setCurrentQuestionIdx(0)
+  }
+
+  // Single-select: answering always advances immediately, or sends
+  // immediately if this was the last question — there's no separate
+  // confirm/send step, matching a plain single-select picker.
   const handleAnswer = (answer: string) => {
     if (isStreaming || !clarification) {
       return
     }
 
     const newAnswers = { ...selectedAnswers, [currentQuestionIdx]: answer }
-    setSelectedAnswers(newAnswers)
 
     const isLast = currentQuestionIdx === clarification.length - 1
     if (isLast) {
-      setReviewMode(true)
+      sendAnswers(newAnswers)
     } else {
+      setSelectedAnswers(newAnswers)
       setCurrentQuestionIdx((prev) => prev + 1)
     }
   }
 
-  const handleConfirm = () => {
+  // Back/next only move which already-answered question is in view, to
+  // review or change an earlier answer — they never trigger a send.
+  const handleBack = () => {
+    setCurrentQuestionIdx((prev) => Math.max(0, prev - 1))
+  }
+
+  const handleNext = () => {
     if (!clarification) {
       return
     }
-    const combined = clarification
-      .map((q, i) => `Q: ${q.question}\nA: ${selectedAnswers[i]}`)
-      .join('\n\n')
-    sendMessage(combined)
-    setSelectedAnswers({})
-    setCurrentQuestionIdx(0)
-    setReviewMode(false)
-  }
-
-  const handleReset = () => {
-    setSelectedAnswers({})
-    setCurrentQuestionIdx(0)
-    setReviewMode(false)
+    setCurrentQuestionIdx((prev) =>
+      Math.min(clarification.length - 1, prev + 1),
+    )
   }
 
   const handleOptionClick = (optionIdx: number) => {
@@ -260,12 +272,11 @@ export default function PromptInput({
         clarification={clarification}
         currentQuestionIdx={currentQuestionIdx}
         selectedAnswers={selectedAnswers}
-        reviewMode={reviewMode}
         isStreaming={isStreaming}
         onOptionClick={handleOptionClick}
         onFreeTextSubmit={handleAnswer}
-        onConfirm={handleConfirm}
-        onReset={handleReset}
+        onBack={handleBack}
+        onNext={handleNext}
         cancelStream={cancelStream}
       />
     )


### PR DESCRIPTION
## TL;DR

Answering a clarification question in the AI Builder chat now sends immediately instead of requiring an extra confirm click, and multi-question blocks get a back/next control to review or change an earlier answer first.

## What changed?

- Single-select answering (click an option, or submit free text) advances to the next question immediately, or sends the combined answer immediately if it was the last question — no separate review/confirm step.
- Removed the old review screen ("Change answers" + a separate confirm icon), which required a second click even for a single-question block, and which no longer serves a purpose now that answering is instant.
- Added a back/next control in the picker's header (next to the `i / N` question counter) for multi-question blocks, so the user can revisit an earlier question and pick a different answer before the block completes. Forward navigation only reaches questions already answered — it can't skip ahead.
- Fixed a gap found while building this: free-text answers weren't restored into the text box when navigating back to a previously-answered question (only option-based answers were visible, via a highlighted button). The text box now repopulates from the saved answer when it doesn't match one of the question's listed options.

## Tests (manual)

- [ ] Single-question clarification block (e.g. the new "Ready to create this pipe?" confirmation): clicking an option sends immediately.
- [ ] Multi-question block: click through options, confirm it sends automatically on the last answer with no extra click.
- [ ] Multi-question block: after answering question 2, use the back arrow to return to question 1, pick a different option, confirm the highlighted option updates and the counter/back-forward state is correct.
- [ ] Multi-question block with a free-text question: answer it via the text box, navigate away and back, confirm the typed answer is restored in the box.
- [ ] Streaming state: confirm back/next/option buttons are disabled while a response is streaming, same as before.

## Deploy notes

Frontend-only change, no backend/schema/migration impact. No feature flag.
