### PR TITLE
[BUG-BASH-3] fix: remove unused get_dynamic_data tool

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -22,11 +22,6 @@ vi.mock('@/services/mcp/create-step', () => ({
 vi.mock('@/services/mcp/delete-step', () => ({
   deleteStepService: vi.fn().mockResolvedValue({ id: 'f1', steps: [] }),
 }))
-vi.mock('@/services/mcp/get-dynamic-data', () => ({
-  getDynamicDataService: vi
-    .fn()
-    .mockResolvedValue([{ name: 'Channel', value: 'C123' }]),
-}))
 vi.mock('@/services/mcp/get-form-schema', () => ({
   getFormSchemaService: vi.fn().mockResolvedValue({
     formId: 'a'.repeat(24),
@@ -48,7 +43,6 @@ import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
-import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import { getFormSchemaService } from '@/services/mcp/get-form-schema'
 import { registerConnectionService } from '@/services/mcp/register-connection'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
@@ -68,7 +62,6 @@ describe('createMcpBridgeTools', () => {
       'update_step_parameters',
       'create_step',
       'delete_step',
-      'get_dynamic_data',
       'execute_step',
       'get_form_schema',
       'register_connection',
@@ -137,24 +130,6 @@ describe('createMcpBridgeTools', () => {
       user: mockUser,
       pipeId: 'flow-1',
       stepId: 'step-1',
-    })
-  })
-
-  it('get_dynamic_data calls getDynamicDataService with camelCase args', async () => {
-    const tools = createMcpBridgeTools(mockUser, mockTraceId)
-    await tools.get_dynamic_data.execute(
-      {
-        step_id: 'step-1',
-        key: 'listChannels',
-        parameters: { tableId: 'xyz' },
-      },
-      { toolCallId: 'get_dynamic_data', messages: [] },
-    )
-    expect(vi.mocked(getDynamicDataService)).toHaveBeenCalledWith({
-      user: mockUser,
-      stepId: 'step-1',
-      key: 'listChannels',
-      parameters: { tableId: 'xyz' },
     })
   })
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -17,7 +17,6 @@ import {
   executeStepService,
   type McpExecuteStepResult,
 } from '@/services/mcp/execute-step'
-import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import {
   getFormSchemaService,
   type McpFormSchemaResult,
@@ -217,39 +216,6 @@ export function createMcpBridgeTools(
         })
         onPipeChange?.(pipe_id)
         return flow
-      },
-    }),
-
-    get_dynamic_data: tool({
-      description:
-        'Fetch live options for a dynamic dropdown field on a configured step (e.g. list channels, list tables, list files). Requires the step to have a connection set up. For cascading selections (e.g. list columns for a chosen table), pass the dependency value in parameters.',
-      inputSchema: z.object({
-        step_id: z
-          .string()
-          .describe('ID of the step whose dynamic data to fetch'),
-        key: z
-          .string()
-          .describe(
-            'Dynamic data key declared by the app (e.g. "listChannels", "listTables"). Check isDynamic fields from list_apps to find valid keys.',
-          ),
-        parameters: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe(
-            'Optional parameter overrides for cascading selections (e.g. { "tableId": "..." } to list columns for a specific table).',
-          ),
-      }),
-      execute: async ({
-        step_id,
-        key,
-        parameters,
-      }): Promise<Array<{ name: string; value: string }>> => {
-        return getDynamicDataService({
-          user,
-          stepId: step_id,
-          key,
-          parameters: parameters as IJSONObject | undefined,
-        })
       },
     }),
 

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -143,7 +143,6 @@ const messagePartSchema = z.discriminatedUnion('type', [
   toolPart('tool-update_step_parameters'),
   toolPart('tool-create_step'),
   toolPart('tool-delete_step'),
-  toolPart('tool-get_dynamic_data'),
   toolPart('tool-get_form_schema'),
   toolPart('tool-execute_step'),
   toolPart('tool-register_connection'),


### PR DESCRIPTION
## TL;DR

Remove the unused `get_dynamic_data` MCP tool and its remaining references in the chat prompt.

## What changed?

- Deleted the `get_dynamic_data` tool definition from `mcp-bridge-tools.ts` (and its now-unused `getDynamicDataService` import).
- Removed the `tool-get_dynamic_data` entry from the chat message part schema.
- Removed the corresponding mock/import/test case from `mcp-bridge-tools.test.ts`.
- Cleaned up the four `get_dynamic_data` mentions in the local Langfuse `chat` prompt copy (`docs/plans/prompts/chat_v149.md`, gitignored) — the tool row in the Tool Reference table and the "do not call" instructions in the `isDynamic` field and `DYNAMIC_PICKER_DATA` sections.

## Why?

`get_dynamic_data` was wired into the model's tool set but the live chat prompt already told the model never to call it — the actual dynamic-picker UX (`DYNAMIC_PICKER_DATA` HTML-comment blocks parsed server-side, rendered by `DynamicPicker.tsx`, fetched via `POST /api/dynamic-data`) was built as a separate mechanism in the same sprint and fully superseded it. Keeping a tool the model is told never to use is dead surface area — this removes it so `DynamicPicker` is unambiguously the only path, and tidies the prompt so it doesn't reference a tool that no longer exists.

The prompt-side edit was reconciled in`chat_v149.md`

## Tests (manual)

- [ ] `npm run test packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts` passes (24/24, verified locally)
- [ ] `npm run -w backend lint` and `tsc --noEmit` clean (verified locally)
- [ ] In the AI Builder chat UI, confirm dynamic-dropdown fields (e.g. Slack channel picker, Tiles table/column picker) still resolve correctly via `DynamicPicker`

## Deploy notes

None — no schema, migration, or config changes. The Langfuse `chat` prompt update is a separate manual step outside this PR.