### PR TITLE
[BUG-BASH-4] fix: expose grouped-multirow and boolean-radio field schemas to LLM

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -74,7 +74,7 @@ export function createMcpBridgeTools(
 
     create_pipe: tool({
       description:
-        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation. For toolbox/ifThen steps, include parameters with branchName and conditions in the step.',
+        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation. For toolbox/ifThen and toolbox/onlyContinueIf steps, include parameters with conditions (and branchName for ifThen) in the step — see the parameters field for the conditions shape.',
       inputSchema: z.object({
         name: z.string().describe('Human-readable name for the pipe'),
         steps: z
@@ -95,7 +95,7 @@ export function createMcpBridgeTools(
                 .record(z.string(), z.unknown())
                 .optional()
                 .describe(
-                  'Initial parameter values for this step. For toolbox/ifThen steps pass branchName and conditions here.',
+                  'Initial parameter values for this step. For toolbox/ifThen and toolbox/onlyContinueIf steps, conditions is an array of OR-groups, each { rows: [...] }, where each row is { field, is: "is"|"not", condition, text }, e.g. conditions: [{ rows: [{ field: "{{1.status}}", is: "is", condition: "equals", text: "done" }] }]. ifThen additionally requires branchName.',
                 ),
             }),
           )

--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -152,6 +152,53 @@ vi.mock('@/apps', () => ({
               required: false,
               hiddenIf: { op: 'always_true' },
             },
+            {
+              key: 'conditions',
+              label: 'Conditions',
+              type: 'grouped-multirow',
+              required: true,
+              description: 'OR-groups of AND-ed conditions',
+              maxGroups: 10,
+              maxRowsPerGroup: 10,
+              subFields: [
+                {
+                  key: 'field',
+                  label: 'Field',
+                  type: 'string',
+                  required: true,
+                },
+                {
+                  key: 'text',
+                  label: 'Value',
+                  type: 'string',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    gathersg: {
+      key: 'gathersg',
+      name: 'GatherSG',
+      triggers: [],
+      actions: [
+        {
+          key: 'tagOrUntagCase',
+          name: 'Tag or Untag Case',
+          description: 'Tag or untag a case',
+          arguments: [
+            {
+              key: 'shouldTag',
+              label: 'Tag or Untag',
+              type: 'boolean-radio',
+              required: true,
+              options: [
+                { label: 'Tag', value: true },
+                { label: 'Untag', value: false },
+              ],
+            },
           ],
         },
       ],
@@ -179,8 +226,8 @@ describe('listAppsService', () => {
 
   it('returns visible apps with triggers and actions', async () => {
     const apps = await listAppsService(user)
-    // toolbox excluded by default; formsg + slack + tiles returned
-    expect(apps).toHaveLength(3)
+    // toolbox excluded by default; formsg + slack + tiles + gathersg returned
+    expect(apps).toHaveLength(4)
     const formsg = apps.find((a) => a.key === 'formsg')
     expect(formsg?.triggers).toHaveLength(1)
     expect(formsg?.actions).toHaveLength(0)
@@ -285,8 +332,40 @@ describe('listAppsService', () => {
       const apps = await listAppsService(user)
       const toolbox = apps.find((a) => a.key === 'toolbox')
       const fieldKeys = toolbox?.actions[0].fields.map((f) => f.key)
-      expect(fieldKeys).toEqual(['branchName'])
+      expect(fieldKeys).toEqual(['branchName', 'conditions'])
       expect(fieldKeys).not.toContain('depth')
+    })
+  })
+
+  describe('grouped-multirow fields', () => {
+    it('serializes subFields, maxGroups, and maxRowsPerGroup', async () => {
+      mocks.getAllLdFlags.mockResolvedValue({ app_toolbox: true })
+      const apps = await listAppsService(user)
+      const toolbox = apps.find((a) => a.key === 'toolbox')
+      const conditionsField = toolbox?.actions[0].fields.find(
+        (f) => f.key === 'conditions',
+      )
+      expect(conditionsField?.maxGroups).toBe(10)
+      expect(conditionsField?.maxRowsPerGroup).toBe(10)
+      expect(conditionsField?.subFields).toHaveLength(2)
+      expect(conditionsField?.subFields?.map((f) => f.key)).toEqual([
+        'field',
+        'text',
+      ])
+    })
+  })
+
+  describe('boolean-radio fields', () => {
+    it('serializes custom options with stringified values', async () => {
+      const apps = await listAppsService(user)
+      const gathersg = apps.find((a) => a.key === 'gathersg')
+      const shouldTagField = gathersg?.actions[0].fields.find(
+        (f) => f.key === 'shouldTag',
+      )
+      expect(shouldTagField?.options).toEqual([
+        { label: 'Tag', value: 'true' },
+        { label: 'Untag', value: 'false' },
+      ])
     })
   })
 

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -1,6 +1,7 @@
 import type {
   IMcpApp,
   IMcpAppField,
+  IMcpFieldOption,
   IRawAction,
   IRawTrigger,
   IUser,
@@ -26,6 +27,12 @@ function serializeFields(
   return fields.filter((f) => !isHiddenFromAi(f)).map(serializeField)
 }
 
+function mapOptions(
+  options: { label: string; value: unknown }[],
+): IMcpFieldOption[] {
+  return options.map((o) => ({ label: o.label, value: String(o.value) }))
+}
+
 function serializeField(
   field: NonNullable<IRawTrigger['arguments']>[number],
 ): IMcpAppField {
@@ -39,10 +46,7 @@ function serializeField(
 
   if (field.type === 'dropdown') {
     if (field.options?.length && !field.source) {
-      base.options = field.options.map((o) => ({
-        label: o.label,
-        value: String(o.value),
-      }))
+      base.options = mapOptions(field.options)
     } else if (field.source?.arguments?.length) {
       const keyArg = field.source.arguments.find((a) => a.name === 'key')
       if (keyArg) {
@@ -60,11 +64,26 @@ function serializeField(
     }
   }
 
+  if (field.type === 'boolean-radio' && field.options?.length) {
+    base.options = mapOptions(field.options)
+  }
+
   if (
-    (field.type === 'multirow' || field.type === 'multirow-multicol') &&
+    (field.type === 'multirow' ||
+      field.type === 'multirow-multicol' ||
+      field.type === 'grouped-multirow') &&
     field.subFields.length
   ) {
     base.subFields = serializeFields(field.subFields)
+  }
+
+  if (field.type === 'grouped-multirow') {
+    if (field.maxGroups !== undefined) {
+      base.maxGroups = field.maxGroups
+    }
+    if (field.maxRowsPerGroup !== undefined) {
+      base.maxRowsPerGroup = field.maxRowsPerGroup
+    }
   }
 
   return base

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -38,7 +38,7 @@ function serializeField(
 ): IMcpAppField {
   const base: IMcpAppField = {
     key: field.key,
-    label: field.label,
+    label: field.label ?? field.placeholder,
     type: field.type,
     description: field.description,
     required: field.required ?? false,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1363,6 +1363,8 @@ export interface IMcpAppField {
   dynamicDataKey?: string
   dynamicDataParameters?: Record<string, string>
   subFields?: IMcpAppField[]
+  maxGroups?: number
+  maxRowsPerGroup?: number
 }
 
 export interface IMcpAppAction {


### PR DESCRIPTION
## Stack Context

This stack (`trunk/mcp-tools`) hardens the MCP AI-builder bridge tools used by the chat workflow builder. This PR fixes a schema-exposure bug in the `list_apps`/`create_pipe`/`update_step_parameters` surface that was causing the LLM to misconfigure toolbox conditional steps.

## What?

- `packages/backend/src/services/mcp/apps.ts`: `serializeField` now attaches `subFields`/`maxGroups`/`maxRowsPerGroup` for `grouped-multirow` fields, and `options` for `boolean-radio` fields with custom labels.
- `packages/types/index.d.ts`: added `maxGroups`/`maxRowsPerGroup` to `IMcpAppField`.
- `packages/backend/src/helpers/mcp-bridge-tools.ts`: `create_pipe`'s descriptions now mention `onlyContinueIf` (previously only `ifThen`) and give a literal example of the `conditions: [{ rows: [...] }]` shape.
- Tests added/updated in `packages/backend/src/services/mcp/__tests__/apps.test.ts`.

## Why?

The LLM was failing to use `update_step_parameters` to configure the `if-then`/`only-continue-if` toolbox actions, sending the wrong parameter shape for `conditions`. Root cause: `serializeField` — the function that turns an app's field schema into what `list_apps` shows the LLM — only special-cased `multirow`/`multirow-multicol` for `subFields`. Both actions' `conditions` field is `type: 'grouped-multirow'`, so it fell through untouched: the LLM saw a bare `{key: "conditions", type: "grouped-multirow", ...}` with no row shape (`field`/`is`/`condition`/`text`) and no hint that groups need a `{ rows: [...] }` wrapper (the real, backend-validated shape enforced by `validateConditionGroupParameters`). Left to guess, it reconstructed the old flat legacy shape, which is rejected outright — the legacy→v2 migration doesn't rescue it since MCP-created steps start at the latest step version.

A broader audit of `serializeField` for the same class of bug also turned up `boolean-radio` fields with custom option labels (e.g. `gathersg`'s `tag-or-untag-case`, `{label: 'Tag', value: true}` / `{label: 'Untag', value: false}`) silently losing their label meaning, since the options-copying logic only ran inside the `dropdown` branch — fixed in the same pass since it's the identical root cause (schema info dropped during MCP serialization).

## Tests (manual)

- [ ] Ask the AI builder chat to add an if-then step with an OR condition (e.g. "if priority is High or Urgent, send an alert") and confirm `update_step_parameters` succeeds with the correct nested shape.
- [ ] Same for an only-continue-if step with multiple condition groups.
- [ ] Configure a GatherSG "Tag or untag case" step via chat and confirm the LLM sends the correct boolean value for "Tag" vs "Untag".

## Deploy notes

None — backend-only change to MCP tool schemas/descriptions, no migrations or infra changes.
