### PR TITLE
[BUG-BASH-5] fix: validate dynamic-data dependencies and remove picker free text

### DIFF
--- a/packages/backend/src/routes/api/dynamic-data.test.ts
+++ b/packages/backend/src/routes/api/dynamic-data.test.ts
@@ -2,11 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UserFacingError } from '@/errors/user-facing-error'
 
-vi.mock('@/services/mcp/get-dynamic-data', () => ({
+vi.mock('@/services/mcp/get-dynamic-data', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/mcp/get-dynamic-data')>()),
   getDynamicDataService: vi.fn(),
 }))
 
-import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+import {
+  DynamicDataPrerequisiteError,
+  getDynamicDataService,
+} from '@/services/mcp/get-dynamic-data'
 
 import router from './dynamic-data'
 
@@ -69,6 +73,28 @@ describe('POST /api/dynamic-data', () => {
 
     expect(res.status).toHaveBeenCalledWith(400)
     expect(res.json).toHaveBeenCalledWith({ error: 'Step not found' })
+  })
+
+  it('returns 400 with code prerequisite_missing for a DynamicDataPrerequisiteError', async () => {
+    vi.mocked(getDynamicDataService).mockRejectedValue(
+      new DynamicDataPrerequisiteError("Missing required value for 'tableId'"),
+    )
+    const res = makeRes()
+    const handler = getHandler()
+
+    await handler(
+      makeReq({ stepId: 'step-1', key: 'table' }) as unknown as Parameters<
+        typeof handler
+      >[0],
+      res as unknown as Parameters<typeof handler>[1],
+      vi.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Missing required value for 'tableId'",
+      code: 'prerequisite_missing',
+    })
   })
 
   it('returns 500 for an unexpected error', async () => {

--- a/packages/backend/src/routes/api/dynamic-data.ts
+++ b/packages/backend/src/routes/api/dynamic-data.ts
@@ -4,7 +4,10 @@ import { Router } from 'express'
 import { z } from 'zod/v4'
 
 import { UserFacingError } from '@/errors/user-facing-error'
-import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+import {
+  DynamicDataPrerequisiteError,
+  getDynamicDataService,
+} from '@/services/mcp/get-dynamic-data'
 import type { AuthenticatedRequest } from '@/types/express/context'
 
 const router = Router()
@@ -44,7 +47,11 @@ router.post('/', async (req: AuthenticatedRequest, res) => {
     })
     res.json({ data })
   } catch (error) {
-    if (error instanceof UserFacingError) {
+    if (error instanceof DynamicDataPrerequisiteError) {
+      res
+        .status(400)
+        .json({ error: error.message, code: 'prerequisite_missing' })
+    } else if (error instanceof UserFacingError) {
       res.status(400).json({ error: error.message })
     } else {
       res.status(500).json({ error: 'Internal server error' })

--- a/packages/backend/src/services/mcp/get-dynamic-data.ts
+++ b/packages/backend/src/services/mcp/get-dynamic-data.ts
@@ -1,9 +1,16 @@
-import type { IDynamicData, IJSONObject } from '@plumber/types'
+import type {
+  IDynamicData,
+  IField,
+  IJSONObject,
+  IRawAction,
+  IRawTrigger,
+} from '@plumber/types'
 
 import apps from '@/apps'
 import { UserFacingError } from '@/errors/user-facing-error'
 import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import globalVariable from '@/helpers/global-variable'
+import type Step from '@/models/step'
 import type User from '@/models/user'
 
 export interface GetDynamicDataInput {
@@ -11,6 +18,74 @@ export interface GetDynamicDataInput {
   stepId: string
   key: string
   parameters?: IJSONObject
+}
+
+// Missing connection or dependent parameter — route tags this with a `code`
+// so the frontend forwards the reason to the LLM instead of a generic error.
+export class DynamicDataPrerequisiteError extends UserFacingError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DynamicDataPrerequisiteError'
+  }
+}
+
+// Recurse into subFields — a dynamic-data key can be declared on a nested
+// field (e.g. M365 Excel's listTableColumns under columnValues[].subFields).
+function flattenFields(fields: IField[]): IField[] {
+  return fields.flatMap((field) =>
+    'subFields' in field && field.subFields
+      ? [field, ...flattenFields(field.subFields as IField[])]
+      : [field],
+  )
+}
+
+// A key's dependency params live on the field schema referencing it
+// (source.arguments' `parameters.X` entries), not on the IDynamicData command.
+function getDependencyParamNames(
+  rawTriggerOrAction: IRawAction | IRawTrigger | undefined,
+  key: string,
+): string[] {
+  const fields = flattenFields(rawTriggerOrAction?.arguments ?? [])
+  for (const field of fields) {
+    if (field.type !== 'dropdown' || !field.source?.arguments) {
+      continue
+    }
+    const keyArg = field.source.arguments.find((a) => a.name === 'key')
+    if (keyArg?.value !== key) {
+      continue
+    }
+    return field.source.arguments
+      .filter((a) => a.name.startsWith('parameters.'))
+      .map((a) => a.name.slice('parameters.'.length))
+  }
+  return []
+}
+
+// Throws naming whichever dependency parameter(s) aren't saved yet, instead
+// of resolvers silently returning an empty (and ambiguous) list.
+function assertDependenciesSaved(step: Step, key: string): void {
+  const app = apps[step.appKey ?? '']
+  const rawTriggerOrAction = (
+    step.type === 'trigger'
+      ? app?.triggers?.find((t) => t.key === step.key)
+      : app?.actions?.find((a) => a.key === step.key)
+  ) as IRawAction | IRawTrigger | undefined
+
+  const dependencyParamNames = getDependencyParamNames(rawTriggerOrAction, key)
+  const missing = dependencyParamNames.filter((name) => {
+    const value = (step.parameters as IJSONObject | undefined)?.[name]
+    return value === undefined || value === null || value === ''
+  })
+
+  if (missing.length > 0) {
+    throw new DynamicDataPrerequisiteError(
+      `Missing required value for ${missing
+        .map((m) => `'${m}'`)
+        .join(
+          ', ',
+        )} — save it via update_step_parameters before requesting this field's options.`,
+    )
+  }
 }
 
 // TODO: Consider extracting shared logic with the getDynamicData GraphQL resolver
@@ -40,7 +115,7 @@ export async function getDynamicDataService({
   const connection = step.connection
 
   if (app.auth && !connection) {
-    throw new UserFacingError('Step has no verified connection')
+    throw new DynamicDataPrerequisiteError('Step has no verified connection')
   }
 
   // Phase 1: caller is always the pipe owner; role substitution is never needed.
@@ -61,6 +136,8 @@ export async function getDynamicDataService({
       `Dynamic data key '${key}' not found for app '${step.appKey}'`,
     )
   }
+
+  assertDependenciesSaved(step, key)
 
   const $ = await globalVariable({
     connection: connection ?? undefined,

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -1,26 +1,18 @@
-import {
-  type FormEvent,
-  type KeyboardEvent,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
-import {
-  Box,
-  Button,
-  Flex,
-  Icon,
-  Input,
-  Spinner,
-  Text,
-  Textarea,
-} from '@chakra-ui/react'
+import { Box, Button, Flex, Icon, Input, Spinner, Text } from '@chakra-ui/react'
 
 interface DynamicPickerOption {
   name: string
   value: string
+}
+
+// Carries the backend's `{ error, code }` body for the catch handler below.
+class DynamicDataFetchError extends Error {
+  constructor(public status: number, message: string, public code?: string) {
+    super(message)
+  }
 }
 
 interface DynamicPickerProps {
@@ -31,6 +23,13 @@ interface DynamicPickerProps {
   isStreaming: boolean
   onSelect: (name: string, value: string) => void
   onSkip: () => void
+  /**
+   * Step/key mode only: called once when a fetch returns zero options, or a
+   * "prerequisite not saved" error — signals the LLM to self-troubleshoot.
+   * `reason`, when present, is the backend's diagnostic (e.g. which
+   * parameter is missing).
+   */
+  onNoOptionsFound?: (reason?: string) => void
   onAddConnection?: () => void
   /**
    * FormSG only: a form URL already shared in the conversation. When set,
@@ -50,6 +49,7 @@ export default function DynamicPicker({
   isStreaming,
   onSelect,
   onSkip,
+  onNoOptionsFound,
   onAddConnection,
   knownFormUrl,
   cancelStream,
@@ -61,8 +61,6 @@ export default function DynamicPicker({
   const [query, setQuery] = useState('')
   const [selectedOption, setSelectedOption] =
     useState<DynamicPickerOption | null>(null)
-  const [inputValue, setInputValue] = useState('')
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   const isAppKeyMode = Boolean(appKey)
@@ -101,9 +99,14 @@ export default function DynamicPicker({
         })
 
     fetchPromise
-      .then((res) => {
+      .then(async (res) => {
         if (!res.ok) {
-          throw new Error(`Fetch failed: ${res.status}`)
+          const body = await res.json().catch(() => null)
+          throw new DynamicDataFetchError(
+            res.status,
+            body?.error ?? '',
+            body?.code,
+          )
         }
         return res.json()
       })
@@ -116,12 +119,29 @@ export default function DynamicPicker({
         if (isAppKeyMode && data.length === 1 && appKey !== 'formsg') {
           onSelect(data[0].name, data[0].value)
         }
+
+        // Zero options is a real result — let the LLM self-troubleshoot.
+        if (!isAppKeyMode && data.length === 0) {
+          onNoOptionsFound?.()
+        }
       })
       .catch((err) => {
-        if ((err as Error).name !== 'AbortError') {
-          setOptions([])
-          setIsError(true)
+        if ((err as Error).name === 'AbortError') {
+          return
         }
+        setOptions([])
+
+        // Step isn't configured yet — forward the reason to the LLM.
+        if (
+          !isAppKeyMode &&
+          err instanceof DynamicDataFetchError &&
+          err.code === 'prerequisite_missing'
+        ) {
+          onNoOptionsFound?.(err.message || undefined)
+          return
+        }
+
+        setIsError(true)
       })
       .finally(() => {
         if (!controller.signal.aborted) {
@@ -138,37 +158,19 @@ export default function DynamicPicker({
 
   const hasOptions = !isLoading && options.length > 0
 
-  const handleResize = (e?: FormEvent<HTMLTextAreaElement>) => {
-    const target = e?.currentTarget || textareaRef.current
-    if (!target) {
-      return
-    }
-    target.style.height = 'auto'
-    target.style.height = Math.min(target.scrollHeight, 120) + 'px'
-  }
-
   const handleOptionClick = (opt: DynamicPickerOption) => {
     setSelectedOption(opt)
-    setInputValue(opt.name)
   }
 
   const handleSubmit = () => {
-    if (!inputValue.trim() || isStreaming) {
+    if (!selectedOption || isStreaming) {
       return
     }
-    onSelect(inputValue, selectedOption?.value ?? inputValue)
+    onSelect(selectedOption.name, selectedOption.value)
   }
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSubmit()
-    }
-  }
-
-  // Zero-connections empty state (appKey mode only)
-  const showEmptyState =
-    isAppKeyMode && !isLoading && !isError && options.length === 0
+  // Zero options — distinct from a fetch error.
+  const showEmptyState = !isLoading && !isError && options.length === 0
 
   // In-chat "Add new form" entry point — FormSG only, and only when the host
   // page provided a handler for it.
@@ -223,19 +225,25 @@ export default function DynamicPicker({
               <Spinner size="sm" color="primary.500" />
             </Flex>
           ) : showEmptyState ? (
-            canAddConnection ? (
-              <Button
-                variant="outline"
-                alignSelf="flex-start"
-                isDisabled={isStreaming}
-                onClick={onAddConnection}
-              >
-                Add your form
-              </Button>
+            isAppKeyMode ? (
+              canAddConnection ? (
+                <Button
+                  variant="outline"
+                  alignSelf="flex-start"
+                  isDisabled={isStreaming}
+                  onClick={onAddConnection}
+                >
+                  Add your form
+                </Button>
+              ) : (
+                <Text color="gray.500" fontSize="sm" px={2}>
+                  No connections found for this app — you can add one in
+                  Plumber&apos;s connection settings.
+                </Text>
+              )
             ) : (
               <Text color="gray.500" fontSize="sm" px={2}>
-                No connections found for this app — you can add one in
-                Plumber&apos;s connection settings.
+                No matching options were found for this field.
               </Text>
             )
           ) : hasOptions ? (
@@ -275,7 +283,7 @@ export default function DynamicPicker({
             <Text color="red.400" fontSize="sm">
               {isAppKeyMode
                 ? "Couldn't load connections. "
-                : "Couldn't load options — enter a value manually below, or "}
+                : "Couldn't load options. "}
               <Text
                 as="button"
                 type="button"
@@ -291,119 +299,10 @@ export default function DynamicPicker({
           ) : null}
         </Flex>
 
-        {/* Freetext input — hidden in appKey mode (connection IDs must be exact) */}
-        {!isAppKeyMode && (
-          <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
-            <Flex gap={2} align="flex-end">
-              <Textarea
-                ref={textareaRef}
-                value={inputValue}
-                onChange={(e) => {
-                  setInputValue(e.target.value)
-                  setSelectedOption(null)
-                }}
-                onKeyDown={handleKeyDown}
-                placeholder={
-                  hasOptions
-                    ? 'Or describe your answer…'
-                    : 'Enter a value manually…'
-                }
-                resize="none"
-                border="none"
-                bg="transparent"
-                p={0}
-                color="gray.900"
-                _placeholder={{ color: 'gray.400' }}
-                _focus={{ outline: 'none', boxShadow: 'none' }}
-                fontSize="md"
-                rows={1}
-                maxH="120px"
-                overflowY="auto"
-                onInput={handleResize}
-                isDisabled={isStreaming}
-              />
-              <Flex align="flex-end" flexShrink={0} h="24px">
-                {isStreaming ? (
-                  <Icon
-                    as={FaCircleStop}
-                    fontSize="24px"
-                    color="red.500"
-                    cursor="pointer"
-                    onClick={cancelStream}
-                    _hover={{ color: 'red.600' }}
-                  />
-                ) : (
-                  inputValue.trim() && (
-                    <Icon
-                      as={FaArrowCircleUp}
-                      fontSize="24px"
-                      color="primary.500"
-                      onClick={handleSubmit}
-                      cursor="pointer"
-                    />
-                  )
-                )}
-              </Flex>
-            </Flex>
-          </Box>
-        )}
-
-        {isAppKeyMode && (
-          <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
-            <Flex justify="space-between" align="center">
-              <Flex gap={4} align="center">
-                <Button
-                  variant="link"
-                  size="sm"
-                  color="gray.400"
-                  isDisabled={isStreaming}
-                  onClick={onSkip}
-                  fontWeight="normal"
-                >
-                  skip this step
-                </Button>
-                {canAddConnection && hasOptions && (
-                  <Button
-                    variant="link"
-                    size="sm"
-                    color="primary.500"
-                    isDisabled={isStreaming}
-                    onClick={onAddConnection}
-                    fontWeight="normal"
-                  >
-                    Add a new form
-                  </Button>
-                )}
-              </Flex>
-              <Flex align="center" h="24px">
-                {isStreaming ? (
-                  <Icon
-                    as={FaCircleStop}
-                    fontSize="24px"
-                    color="red.500"
-                    cursor="pointer"
-                    onClick={cancelStream}
-                    _hover={{ color: 'red.600' }}
-                  />
-                ) : (
-                  selectedOption && (
-                    <Icon
-                      as={FaArrowCircleUp}
-                      fontSize="24px"
-                      color="primary.500"
-                      onClick={handleSubmit}
-                      cursor="pointer"
-                    />
-                  )
-                )}
-              </Flex>
-            </Flex>
-          </Box>
-        )}
-
-        {!isAppKeyMode && (
-          <Box mt={2}>
-            <Flex justify="flex-end">
+        {/* Skip, submit-once-selected, add-a-new-form. No free text. */}
+        <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
+          <Flex justify="space-between" align="center">
+            <Flex gap={4} align="center">
               <Button
                 variant="link"
                 size="sm"
@@ -414,9 +313,43 @@ export default function DynamicPicker({
               >
                 skip this step
               </Button>
+              {canAddConnection && hasOptions && (
+                <Button
+                  variant="link"
+                  size="sm"
+                  color="primary.500"
+                  isDisabled={isStreaming}
+                  onClick={onAddConnection}
+                  fontWeight="normal"
+                >
+                  Add a new form
+                </Button>
+              )}
             </Flex>
-          </Box>
-        )}
+            <Flex align="center" h="24px">
+              {isStreaming ? (
+                <Icon
+                  as={FaCircleStop}
+                  fontSize="24px"
+                  color="red.500"
+                  cursor="pointer"
+                  onClick={cancelStream}
+                  _hover={{ color: 'red.600' }}
+                />
+              ) : (
+                selectedOption && (
+                  <Icon
+                    as={FaArrowCircleUp}
+                    fontSize="24px"
+                    color="primary.500"
+                    onClick={handleSubmit}
+                    cursor="pointer"
+                  />
+                )
+              )}
+            </Flex>
+          </Flex>
+        </Box>
       </Box>
     </Box>
   )

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -20,7 +20,10 @@ import SecretKeyWarningDialog from '@/pages/AiBuilder/components/ChatInterface/S
 import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
 import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
-import { containsSecretKey } from '@/pages/AiBuilder/helpers'
+import {
+  buildNoOptionsFoundMessage,
+  containsSecretKey,
+} from '@/pages/AiBuilder/helpers'
 
 interface PromptInputProps {
   isStreaming: boolean
@@ -255,6 +258,15 @@ export default function PromptInput({
         onSkip={() => {
           sendMessage(`Q: ${dynamicPicker.question}\nA: skip`)
         }}
+        onNoOptionsFound={
+          isAppKeyMode
+            ? undefined
+            : (reason) => {
+                sendMessage(
+                  buildNoOptionsFoundMessage(dynamicPicker.question, reason),
+                )
+              }
+        }
         onAddConnection={
           onAddConnection && isAppKeyMode
             ? () => onAddConnection({ question: dynamicPicker.question })

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text } from '@chakra-ui/react'
 import { Message } from '@/hooks/useChatStream'
 import {
   formatUserMessageForDisplay,
+  isNoOptionsSignalMessage,
   prepareAiText,
 } from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
@@ -69,6 +70,10 @@ const ChatMessage = memo(
     shouldShowToolbar: boolean
   }) => {
     if (message.isUser) {
+      // System cue for the LLM, not a real user reply — never rendered.
+      if (isNoOptionsSignalMessage(message.text)) {
+        return null
+      }
       return <UserMessage message={message} />
     }
     return (

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -89,6 +89,17 @@ export const stripFormIdPrefix = (label: string): string =>
 export const formatUserMessageForDisplay = (text: string): string =>
   text.replace(/ \(id: [\s\S]+?\)(?=[.\s]|$)/g, '').trim()
 
+// System signal for the LLM when a picker fetch has zero options — see
+// DynamicPicker's onNoOptionsFound. Never shown to the user (isNoOptionsSignalMessage).
+export const buildNoOptionsFoundMessage = (
+  question: string,
+  reason?: string,
+): string =>
+  `Q: ${question}\nA: [no options available${reason ? `: ${reason}` : ''}]`
+
+export const isNoOptionsSignalMessage = (text: string): boolean =>
+  text.includes('\nA: [no options available')
+
 // Matches FormSG share links across environments (form.gov.sg,
 // staging.form.gov.sg, …) ending in a 24-hex-char form ID.
 const FORM_URL_REGEX =


### PR DESCRIPTION
_Let_ _me_ _know_ _if_ _y_ou think this is overkill

## Stack Context

Part of the `mcp/*` stack hardening AI Builder's MCP tool layer. This PR fixes the chat `DynamicPicker` (used when the LLM asks the user to pick a live value — a Tile, an Excel table, a Slack channel, etc.) and the backend dynamic-data endpoint it calls.

## TL;DR

`DynamicPicker` silently accepted free-typed text as if it were a real selection, and the backend silently returned an empty option list whenever a field's dependency (a connection, or an earlier field like `tableId`/`fileId`) wasn't saved yet — giving the LLM no way to tell "there's genuinely nothing here" apart from "you forgot to save something first". This PR closes both gaps.

## What changed?

**Backend**

- `getDynamicDataService` now validates a dynamic-data key's declared dependency chain (cross-referencing the step's field schema, including nested `subFields`) before calling its resolver, instead of letting resolvers silently return `[]`.
- Missing connection or missing dependency parameter now throws a new `DynamicDataPrerequisiteError`. The `/api/dynamic-data` route tags this specific case with `code: 'prerequisite_missing'` in its 400 response, distinct from other errors (malformed request, unknown key, step not found) which stay generic.

**Frontend**

- `DynamicPicker` no longer has a free-text fallback — it only resolves via a picked option or explicit skip. The bottom action bar (skip / submit / add-a-new-form) is now a single unified block instead of two duplicated ones.
- Added `onNoOptionsFound`, fired when a fetch legitimately returns zero options, or when the backend returns `prerequisite_missing` — forwards the reason to the LLM as a synthetic chat message.
- That synthetic message is a system signal, not a real user reply, so it's hidden from the chat UI (`isNoOptionsSignalMessage` in `ChatMessage.tsx`) even though it's still sent to the model — it may carry a raw backend diagnostic (e.g. a parameter name) not meant for the user to see.

## Tests

- [ ] Configure a Tiles/Excel step whose column field depends on `tableId`/`fileId` without setting them first — confirm the picker shows an empty state instead of a free-text box, and the assistant explains what's missing instead of stalling.
- [ ] Configure a field with real live options — confirm typing in the search box only filters, and submission requires clicking an option (no more free-text submit).
- [ ] Confirm the hidden no-options signal message never appears as a chat bubble, but the assistant still responds appropriately to it.

## Deploy notes

None — no schema/infra changes, no feature flag.