### PR TITLE
chore(tools): add langfuse prompt fetcher script

### DIFF
--- a/tools/langfuse/get-prompt.mjs
+++ b/tools/langfuse/get-prompt.mjs
@@ -1,0 +1,115 @@
+/**
+ * Fetches a prompt from Langfuse and saves it to docs/plans/prompts/<name>_v<version>.md
+ *
+ * Usage:
+ *   node get-prompt.mjs <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>] [--env=<path-to-env-file>]
+ *
+ * --label and --version are mutually exclusive; defaults to --label=latest if neither is given.
+ *
+ * Examples:
+ *   node get-prompt.mjs chat
+ *   node get-prompt.mjs chat-summary --project=aiBuilder --label=latest
+ *   node get-prompt.mjs chat --version=154
+ *   node get-prompt.mjs chat --project=aiBuilder --label=latest --env=../../packages/backend/.env
+ */
+import { LangfuseClient } from '@langfuse/client'
+import { config } from 'dotenv'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function parseArgs(argv) {
+  const [promptName, ...rest] = argv
+  if (!promptName) {
+    throw new Error(
+      'Usage: node get-prompt.mjs <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>] [--env=<path>]',
+    )
+  }
+
+  const flags = {}
+  for (const arg of rest) {
+    const match = /^--([^=]+)=(.*)$/.exec(arg)
+    if (match) {
+      flags[match[1]] = match[2]
+    }
+  }
+
+  if (flags.label && flags.version) {
+    throw new Error('--label and --version are mutually exclusive')
+  }
+
+  return {
+    promptName,
+    project: flags.project ?? 'aiBuilder',
+    label: flags.label,
+    version: flags.version ? Number(flags.version) : undefined,
+    envPath: flags.env ?? join(__dirname, '../../packages/backend/.env'),
+    outDir: join(__dirname, '../../docs/plans/prompts'),
+  }
+}
+
+function buildLangfuseClient(project, env) {
+  const credentials =
+    project === 'aiBuilder'
+      ? {
+          publicKey: env.PAIR_ROME_AI_BUILDER_PUBLIC_KEY,
+          secretKey: env.PAIR_ROME_AI_BUILDER_SECRET_KEY,
+        }
+      : {
+          publicKey: env.PAIR_ROME_PAIR_ACTION_PUBLIC_KEY,
+          secretKey: env.PAIR_ROME_PAIR_ACTION_SECRET_KEY,
+        }
+
+  if (!credentials.publicKey || !credentials.secretKey) {
+    throw new Error(
+      `Missing Langfuse credentials for project "${project}" — check your env file`,
+    )
+  }
+
+  return new LangfuseClient({
+    timeout: 10000,
+    baseUrl: env.PAIR_ROME_BASE_URL,
+    additionalHeaders: {
+      'CF-Access-Client-Id': env.PAIR_ROME_CLOUDFLARE_ZERO_TRUST_CLIENT_KEY,
+      'CF-Access-Client-Secret': env.PAIR_ROME_CLOUDFLARE_ZERO_TRUST_SECRET_KEY,
+    },
+    ...credentials,
+  })
+}
+
+async function main() {
+  const { promptName, project, label, version, envPath, outDir } = parseArgs(
+    process.argv.slice(2),
+  )
+
+  const { parsed: env } = config({ path: envPath })
+  if (!env) {
+    throw new Error(`Could not load env file at ${envPath}`)
+  }
+
+  const query = version ? { version } : { label: label ?? 'latest' }
+  console.log('fetching prompt: ', promptName, query, project)
+
+  const client = buildLangfuseClient(project, env)
+  const prompt = await client.prompt.get(promptName, query)
+
+  console.log('fetched prompt version: ', prompt.version)
+
+  const content =
+    typeof prompt.prompt === 'string'
+      ? prompt.prompt
+      : JSON.stringify(prompt.prompt, null, 2)
+
+  mkdirSync(outDir, { recursive: true })
+  const outPath = join(outDir, `${promptName}_v${prompt.version}.md`)
+
+  writeFileSync(outPath, content, 'utf-8')
+  console.log(`Saved ${promptName} v${prompt.version} to ${outPath}`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/tools/langfuse/package-lock.json
+++ b/tools/langfuse/package-lock.json
@@ -1,0 +1,86 @@
+{
+  "name": "@plumber/langfuse-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@plumber/langfuse-tools",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@langfuse/client": "4.2.0",
+        "dotenv": "^16.0.3"
+      }
+    },
+    "node_modules/@langfuse/client": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-4.2.0.tgz",
+      "integrity": "sha512-3Ps+k0SdNwntZhUJMaxfImQ1A7iubxBae4xz3h7TMf5afBuTaJrrrgTrkUJVP+qSzyCa95wzerDPm/X4h5p5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^4.2.0",
+        "@langfuse/tracing": "^4.2.0",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/core": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-4.6.1.tgz",
+      "integrity": "sha512-DtQoKWHQh0I0MsJxcKrBQVKAJ3fea6+raXlISVY3NDMFG/zSKkdkNouQvUXQtSCHBbOFupHMBw8imM30lbhq3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/tracing": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-4.6.1.tgz",
+      "integrity": "sha512-Ld1bPU6RxzifgGEDtN70Og8u2eL906jtnnEnt62BEOcML8UUiMgzwAKZDBbIjF2midnfac7Xnho3s546fcCDtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^4.6.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    }
+  }
+}

--- a/tools/langfuse/package.json
+++ b/tools/langfuse/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@plumber/langfuse-tools",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@langfuse/client": "4.2.0",
+    "dotenv": "^16.0.3"
+  }
+}


### PR DESCRIPTION
## TL;DR

Adds a small CLI tool for developers to pull a prompt from Langfuse and save it locally, following the `<prompt-name>_v<version>.md` convention used in `docs/plans/prompts/`.

## What changed?

New standalone tool at `tools/langfuse/` (own `package.json`, matching the pattern of `tools/seeds` and `tools/load-tests`):

- `tools/langfuse/get-prompt.mjs` — fetches a prompt via `@langfuse/client` and writes it to `docs/plans/prompts/<promptName>_v<version>.md`.
- Reads Langfuse credentials from a `.env` file (defaults to `packages/backend/.env`), using the same env vars as `packages/backend/src/config/app.ts`'s `pair.rome` config (`PAIR_ROME_BASE_URL`, `PAIR_ROME_CLOUDFLARE_ZERO_TRUST_CLIENT_KEY`/`SECRET_KEY`, `PAIR_ROME_AI_BUILDER_PUBLIC_KEY`/`SECRET_KEY`, `PAIR_ROME_PAIR_ACTION_PUBLIC_KEY`/`SECRET_KEY`).

### How to use it

```bash
cd tools/langfuse
npm install

# Fetch the latest version of a prompt (defaults to --project=aiBuilder)
node get-prompt.mjs chat

# Fetch a specific labeled version
node get-prompt.mjs chat-summary --project=aiBuilder --label=latest

# Fetch an exact version number
node get-prompt.mjs chat --version=154

# Point at a different env file (e.g. staging)
node get-prompt.mjs chat --env=../../packages/backend/.env.staging
```

Flags:

| Flag | Default | Notes |
|---|---|---|
| `--project` | `aiBuilder` | `aiBuilder` or `pairAction` |
| `--label` | `latest` | Mutually exclusive with `--version` |
| `--version` | — | Fetch an exact prompt version; mutually exclusive with `--label` |
| `--env` | `../../packages/backend/.env` | Path to the env file with Langfuse credentials |

Output is saved to `docs/plans/prompts/<promptName>_v<version>.md` (created if it doesn't exist).

## Tests

- [ ] Ran `node get-prompt.mjs chat` locally against a real `.env` and confirmed the correct version was fetched and saved with the right filename
- [ ] Ran with `--version=<n>` and confirmed it fetches that exact version instead of the latest label
- [ ] Ran with a missing/invalid credential to confirm the error message doesn't leak secrets

## Deploy notes

None — this is a local developer tool, not shipped as part of the app or CI.
