### PR TITLE
[BUG-BASH-6] fix: raise AI Builder chat message limit and align limit checks

### DIFF
--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -155,12 +155,12 @@ describe('chatRequestSchema', () => {
       )
     })
 
-    it('should reject more than 50 messages', () => {
-      const messages = Array(51).fill(validMessage)
+    it('should reject more than 151 messages', () => {
+      const messages = Array(152).fill(validMessage)
       const result = chatRequestSchema.safeParse({ messages })
       expect(result.success).toBe(false)
       expect(result.error?.issues[0].message).toBe(
-        'Cannot send more than 50 messages',
+        'Cannot send more than 151 messages',
       )
     })
   })

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -48,7 +48,8 @@ import { parseClarificationBlock } from './parse-clarification-block'
 import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
 import { chatRequestSchema } from './schema'
 
-const MAX_MESSAGES = 50
+// Keep in sync with schema.ts and frontend/src/pages/AiBuilder/constants.ts.
+const MAX_MESSAGES = 150
 
 function emitTextAnnotations(text: string, writer: UIMessageStreamWriter) {
   const questions = parseClarificationBlock(text)
@@ -129,8 +130,9 @@ const handleChatStream = observe(
       // ModelMessages array. convertToModelMessages inflates the count because each
       // tool call round-trip becomes separate assistant + tool_result model messages,
       // which would trigger summary mode far too early on tool-heavy conversations.
-      // +1 accounts for the system message added below.
-      const isAtLimit = rawMessages.length + 1 >= MAX_MESSAGES
+      // Mirrors the frontend's hasReachedLimit check exactly (same field, same
+      // threshold) so both sides agree on which turn is the last one.
+      const isAtLimit = rawMessages.length >= MAX_MESSAGES
 
       // Get the prompt from Langfuse
       const prompt = await getPrompt(

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -18,8 +18,14 @@ const optionalTracingId = z
   })
   .optional()
 
-// Limits to protect API and LLM costs
-const MAX_MESSAGES = 50
+// Limits to protect API and LLM costs.
+// Keep in sync with index.ts and frontend/src/pages/AiBuilder/constants.ts.
+const MAX_MESSAGES = 150
+// Hard reject ceiling, with headroom above MAX_MESSAGES so a legitimate request
+// at the boundary (e.g. one carrying the one-time pipe-context-resync message)
+// is never rejected before isAtLimit (index.ts) gets a chance to trigger the
+// chat-summary prompt.
+const MAX_RAW_MESSAGES = MAX_MESSAGES + 1
 const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
 // Tool-use turns can produce many parts (step-start + tool-invocation per call + text),
 // so allow enough headroom for up to ~10 tool calls per assistant turn.
@@ -171,7 +177,10 @@ export const chatRequestSchema = z.object({
   messages: z
     .array(messageSchema)
     .min(1, 'Messages array must contain at least one message')
-    .max(MAX_MESSAGES, `Cannot send more than ${MAX_MESSAGES} messages`),
+    .max(
+      MAX_RAW_MESSAGES,
+      `Cannot send more than ${MAX_RAW_MESSAGES} messages`,
+    ),
   /**
    * Unique id for one AI Builder chat session, minted on the frontend. Used as the
    * Langfuse session id so all traces from one conversation group together.

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -38,5 +38,6 @@ export const PLACEHOLDER_MESSAGES = [
   "Share what you're trying to do and we'll help you figure out the best way to automate it",
 ]
 
-// Maximum number of messages allowed in a conversation (hard limit)
-export const MAX_MESSAGES = 50
+// Maximum number of messages allowed in a conversation (hard limit).
+// Keep in sync with backend/src/routes/api/chat/{schema,index}.ts.
+export const MAX_MESSAGES = 150


### PR DESCRIPTION
## TL;DR

Raises the AI Builder chat's hard message limit from 50 to 150, and fixes an alignment gap between the frontend's UI cutoff and the backend's chat-summary trigger so the summary is guaranteed to fire before the conversation is cut off.

## What changed?

- Bumped `MAX_MESSAGES` from 50 to 150 in all three places it's defined (`packages/backend/src/routes/api/chat/schema.ts`, `packages/backend/src/routes/api/chat/index.ts`, `packages/frontend/src/pages/AiBuilder/constants.ts`), with comments cross-referencing the other two so they don't drift out of sync again.
- Changed the backend's `isAtLimit` check from `rawMessages.length + 1 >= MAX_MESSAGES` to `rawMessages.length >= MAX_MESSAGES` — this now matches the frontend's `hasReachedLimit` check exactly (same field, same threshold), instead of an arbitrary "+1 for the system message" offset that didn't correspond to anything actually being counted.
- Split the backend's request-schema cap into two constants: `MAX_MESSAGES` (150, the shared "this is the limit" threshold) and `MAX_RAW_MESSAGES` (`MAX_MESSAGES + 1`), which is what the Zod schema actually validates against. The extra +1 headroom exists so a legitimate boundary-crossing request — e.g. one that also carries the one-time `pipe-context-resync` message injected after a page refresh — is never hard-rejected before the backend gets a chance to respond with the chat-summary prompt.
- Updated the one hardcoded-`50` unit test in `schema.test.ts` to match the new cap.

## Why?

The message limit was being hit much faster once tool calls entered the picture, and the model behind Pair Foundry (Claude Sonnet 4.5, 200K token context) has plenty of headroom for a much higher limit than 50.

While digging into this, we found the frontend's UI cutoff and the backend's chat-summary trigger weren't using the exact same threshold. In the worst case (a page refresh right at the boundary), that gap meant a request could exceed the backend's hard cap and get rejected outright with a 400, without the chat-summary turn ever firing. Aligning both sides on one exact number, and giving the hard-reject cap its own small margin, closes that gap so hitting the limit reliably produces a summary before the input is disabled — a single boundary, not a race.

## Tests

- [ ] Start a fresh AI Builder chat and send messages until the limit banner appears; confirm the last assistant turn is a chat-summary response (contains a continuation prompt) before the input is disabled.
- [ ] Refresh the page mid-conversation near the limit and confirm sending one more message still produces a summary rather than an error.
- [ ] `npm run -w backend test:unit` passes (schema validation tests updated for the new cap).

## Deploy notes

None — pure config/logic change, no migrations or infra changes.
