### PR TITLE
[mcp bug bash]: formsg fix

### DIFF
--- a/packages/backend/src/apps/formsg/common/check-live-mrf-status.ts
+++ b/packages/backend/src/apps/formsg/common/check-live-mrf-status.ts
@@ -1,0 +1,45 @@
+import axios from 'axios'
+
+import { FormEnv, getApiBaseUrl } from './form-env'
+
+const REQUEST_TIMEOUT_MS = 10_000
+
+interface PublicFormResponse {
+  form?: {
+    responseMode?: string
+    workflow?: unknown[]
+  }
+}
+
+/**
+ * Live-checks FormSG's public schema for a form's *current* MRF status.
+ * `responseMode === 'multirespondent'` alone isn't enough — a form can be
+ * left in that mode with no workflow ever configured, which every other MRF
+ * check in this codebase (get-form-schema.ts, the newSubmission trigger's own
+ * testRun) treats as a single-respondent form.
+ *
+ * Returns `null` — not `false` — on a missing form or fetch error, so
+ * callers can tell "confirmed not MRF" apart from "couldn't check" and fail
+ * safe (i.e. don't act on an unconfirmed result).
+ */
+export async function checkLiveMrfStatus(
+  formId: string,
+  env: FormEnv,
+): Promise<boolean | null> {
+  try {
+    const { data } = await axios.get<PublicFormResponse>(
+      `${getApiBaseUrl(env)}/v3/forms/${formId}`,
+      { timeout: REQUEST_TIMEOUT_MS },
+    )
+    const form = data?.form
+    if (!form) {
+      return null
+    }
+    return (
+      form.responseMode === 'multirespondent' &&
+      (form.workflow?.length ?? 0) > 0
+    )
+  } catch {
+    return null
+  }
+}

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.ts
@@ -1,6 +1,8 @@
 export interface ClarificationQuestion {
   question: string
   options: string[]
+  /** Renders the question as a visually urgent warning — reserve for choices with a real, hard-to-reverse consequence (e.g. overriding a connection another pipe depends on). */
+  isWarning?: boolean
 }
 
 /**
@@ -37,6 +39,8 @@ export function parseClarificationBlock(
         continue
       }
       current = { question, options: [] }
+    } else if (/^WARNING:\s*true$/i.test(line) && current) {
+      current.isWarning = true
     } else if (line.startsWith('- ') && current) {
       const option = line.slice(2).trim()
       if (option) {

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -79,6 +79,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
           z.object({
             question: z.string(),
             options: z.array(z.string()),
+            isWarning: z.boolean().optional(),
           }),
         )
         .min(1),

--- a/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
@@ -116,6 +116,11 @@ describe('executeStepService', () => {
 
     const updatedFlow = await Flow.query().findById(flow.id)
     expect(updatedFlow.testExecutionId).toBe(execution.id)
+
+    expect(mocks.testStep).toHaveBeenCalledWith({
+      stepId: actionStep.id,
+      testRunMetadata: { preferMock: true },
+    })
   })
 
   it('does not mark step as completed and returns success:false when testStep fails', async () => {

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -323,5 +323,43 @@ describe('listConnectionsService', () => {
 
       expect(mocks.checkLiveMrfStatus).not.toHaveBeenCalled()
     })
+
+    // Connection labels are user-controlled (updateConnection lets a user
+    // patch formattedData.screenName/formId on any connection they own), so a
+    // user can cheaply create many formsg connections tagged with a stale
+    // "[MRF] " label. Without a concurrency cap, listing them would fan out
+    // one concurrent outbound request per connection to FormSG's public API
+    // (self-DoS / shared-egress-IP-ban risk) — see hacktron finding
+    // e7ce2d1f-ca60-4640-ad3a-724646a7bebc.
+    it('caps concurrent live MRF checks when many connections are stale-tagged', async () => {
+      let inFlight = 0
+      let maxInFlight = 0
+      mocks.checkLiveMrfStatus.mockImplementation(async () => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        inFlight--
+        return false
+      })
+
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-concurrency-${randomUUID()}@example.com`,
+      })
+      const CONNECTION_COUNT = 12
+      await Promise.all(
+        Array.from({ length: CONNECTION_COUNT }, (_, i) =>
+          insertFormsgConn(user.id, `[MRF] form-${i} - Old Form ${i}`),
+        ),
+      )
+
+      await listConnectionsService(user, 'formsg')
+
+      expect(mocks.checkLiveMrfStatus).toHaveBeenCalledTimes(CONNECTION_COUNT)
+      // Sanity check that the test actually exercised overlapping calls,
+      // otherwise the upper-bound assertion below would pass trivially.
+      expect(maxInFlight).toBeGreaterThan(1)
+      expect(maxInFlight).toBeLessThanOrEqual(5)
+    })
   })
 })

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -10,6 +10,7 @@ import { listConnectionsService } from '../list-connections'
 const mocks = vi.hoisted(() => ({
   getAllLdFlags: vi.fn(),
   getRestrictedAppKeys: vi.fn(),
+  checkLiveMrfStatus: vi.fn(),
 }))
 
 vi.mock('@/helpers/launch-darkly', () => ({
@@ -17,10 +18,15 @@ vi.mock('@/helpers/launch-darkly', () => ({
   getRestrictedAppKeys: mocks.getRestrictedAppKeys,
 }))
 
+vi.mock('@/apps/formsg/common/check-live-mrf-status', () => ({
+  checkLiveMrfStatus: mocks.checkLiveMrfStatus,
+}))
+
 describe('listConnectionsService', () => {
   beforeEach(() => {
     mocks.getAllLdFlags.mockResolvedValue({})
     mocks.getRestrictedAppKeys.mockReturnValue([])
+    mocks.checkLiveMrfStatus.mockReset()
   })
 
   afterEach(() => {
@@ -199,5 +205,123 @@ describe('listConnectionsService', () => {
 
     expect(found?.label).toBe('My Workspace')
     expect(found).not.toHaveProperty('formattedData')
+  })
+
+  describe('stale [MRF] label correction (PLU-866)', () => {
+    const insertFormsgConn = async (userId: string, screenName: string) =>
+      Connection.query().insertAndFetch({
+        id: randomUUID(),
+        key: 'formsg',
+        userId,
+        verified: true,
+        draft: false,
+        formattedData: {
+          screenName,
+          formId: 'https://form.gov.sg/654ab1234abc1a012345f1e0',
+        },
+      })
+
+    it('strips the stale tag once a live check confirms the form is no longer MRF', async () => {
+      mocks.checkLiveMrfStatus.mockResolvedValue(false)
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-stale-${randomUUID()}@example.com`,
+      })
+      const conn = await insertFormsgConn(
+        user.id,
+        '[MRF] 654ab1234abc1a012345f1e0 - Old Form',
+      )
+
+      const result = await listConnectionsService(user, 'formsg')
+
+      expect(result.find((c) => c.id === conn.id)?.label).toBe(
+        '654ab1234abc1a012345f1e0 - Old Form',
+      )
+    })
+
+    it('keeps the env prefix while stripping only the MRF tag', async () => {
+      mocks.checkLiveMrfStatus.mockResolvedValue(false)
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-stale-env-${randomUUID()}@example.com`,
+      })
+      const conn = await insertFormsgConn(
+        user.id,
+        '[STAGING] [MRF] 654ab1234abc1a012345f1e0 - Old Form',
+      )
+
+      const result = await listConnectionsService(user, 'formsg')
+
+      expect(result.find((c) => c.id === conn.id)?.label).toBe(
+        '[STAGING] 654ab1234abc1a012345f1e0 - Old Form',
+      )
+    })
+
+    it('keeps the tag when the live check confirms the form is still MRF', async () => {
+      mocks.checkLiveMrfStatus.mockResolvedValue(true)
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-still-${randomUUID()}@example.com`,
+      })
+      const conn = await insertFormsgConn(
+        user.id,
+        '[MRF] 654ab1234abc1a012345f1e0 - Real MRF Form',
+      )
+
+      const result = await listConnectionsService(user, 'formsg')
+
+      expect(result.find((c) => c.id === conn.id)?.label).toBe(
+        '[MRF] 654ab1234abc1a012345f1e0 - Real MRF Form',
+      )
+    })
+
+    it('keeps the tag when the live check fails (fail safe)', async () => {
+      mocks.checkLiveMrfStatus.mockResolvedValue(null)
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-unknown-${randomUUID()}@example.com`,
+      })
+      const conn = await insertFormsgConn(
+        user.id,
+        '[MRF] 654ab1234abc1a012345f1e0 - Unreachable Form',
+      )
+
+      const result = await listConnectionsService(user, 'formsg')
+
+      expect(result.find((c) => c.id === conn.id)?.label).toBe(
+        '[MRF] 654ab1234abc1a012345f1e0 - Unreachable Form',
+      )
+    })
+
+    it('does not perform a live check for a label with no stale tag', async () => {
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-no-tag-${randomUUID()}@example.com`,
+      })
+      await insertFormsgConn(user.id, '654ab1234abc1a012345f1e0 - Plain Form')
+
+      await listConnectionsService(user, 'formsg')
+
+      expect(mocks.checkLiveMrfStatus).not.toHaveBeenCalled()
+    })
+
+    it('does not perform a live check for non-FormSG connections', async () => {
+      const user = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: `mrf-other-app-${randomUUID()}@example.com`,
+      })
+      await Connection.query().insertAndFetch({
+        id: randomUUID(),
+        key: 'slack',
+        userId: user.id,
+        verified: true,
+        draft: false,
+        formattedData: { screenName: '[MRF] some workspace' },
+      })
+
+      await listConnectionsService(user, 'slack')
+
+      expect(mocks.checkLiveMrfStatus).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/backend/src/services/mcp/execute-step.ts
+++ b/packages/backend/src/services/mcp/execute-step.ts
@@ -31,7 +31,14 @@ export async function executeStepService(
 
   // TODO: MRF redirect when AI builder supports it
 
-  const { executionStep, executionId } = await testStep({ stepId: step.id })
+  // AI Builder testing happens inline in chat, with no real user action to
+  // wait on — always prefer mock data (e.g. FormSG's newSubmission trigger)
+  // instead of waiting on a real event. Apps that don't recognise
+  // `preferMock` in their testRunMetadata schema just ignore it.
+  const { executionStep, executionId } = await testStep({
+    stepId: step.id,
+    testRunMetadata: { preferMock: true },
+  })
 
   await Flow.query().patchAndFetchById(step.flowId, {
     testExecutionId: executionId,

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -1,5 +1,8 @@
 import type { IJSONObject } from '@plumber/types'
 
+import { parseFormIdFromInput } from '@/apps/formsg/auth/verify-credentials'
+import { checkLiveMrfStatus } from '@/apps/formsg/common/check-live-mrf-status'
+import { parseFormEnvFromInput } from '@/apps/formsg/common/form-env'
 import App from '@/models/app'
 import type User from '@/models/user'
 
@@ -20,6 +23,47 @@ export function connectionLabel(c: {
     c.description ??
     c.key
   )
+}
+
+// Connections verified before PLU-866 (#1939) can still carry a stale
+// "[MRF] " tag baked into their stored screenName — that logic tagged any
+// form left in `multirespondent` responseMode even with no workflow
+// configured, and was removed without backfilling already-verified
+// connections. The tag only refreshes if the user re-verifies, so the AI
+// Builder's connection picker can still show a "fake MRF" label for an old
+// connection — and the model, told elsewhere that MRF is unsupported,
+// reasonably refuses to use it. Live-check and strip the tag (display-only,
+// no DB write) whenever we can positively confirm the form isn't MRF now.
+const STALE_MRF_TAG_REGEX = /^(\[[A-Z]+\] )?\[MRF\] /
+
+async function resolveMcpConnectionLabel(c: {
+  formattedData?: IJSONObject
+  description?: string
+  key: string
+}): Promise<string> {
+  const label = connectionLabel(c)
+
+  if (c.key !== 'formsg' || !STALE_MRF_TAG_REGEX.test(label)) {
+    return label
+  }
+
+  const rawFormId = c.formattedData?.formId as string | undefined
+  if (!rawFormId) {
+    return label
+  }
+
+  try {
+    const formId = parseFormIdFromInput(rawFormId)
+    const env = parseFormEnvFromInput(rawFormId)
+    const isCurrentlyMrf = await checkLiveMrfStatus(formId, env)
+    if (isCurrentlyMrf === false) {
+      return label.replace('[MRF] ', '')
+    }
+  } catch {
+    // Unparseable formId on this connection — leave the label as-is.
+  }
+
+  return label
 }
 
 export async function listConnectionsService(
@@ -45,12 +89,14 @@ export async function listConnectionsService(
       // tenants as a side effect — this mirrors the GraphQL resolver's behaviour
       // and is intentional.
       const connections = await app.auth.getSystemAddedConnections(user)
-      return connections.map((c) => ({
-        id: c.id,
-        appKey: c.key,
-        verified: c.verified,
-        label: connectionLabel(c),
-      }))
+      return Promise.all(
+        connections.map(async (c) => ({
+          id: c.id,
+          appKey: c.key,
+          verified: c.verified,
+          label: await resolveMcpConnectionLabel(c),
+        })),
+      )
     }
   }
 
@@ -62,10 +108,12 @@ export async function listConnectionsService(
   }
   const connections = await query
 
-  return connections.map((c) => ({
-    id: c.id,
-    appKey: c.key,
-    verified: c.verified,
-    label: connectionLabel(c),
-  }))
+  return Promise.all(
+    connections.map(async (c) => ({
+      id: c.id,
+      appKey: c.key,
+      verified: c.verified,
+      label: await resolveMcpConnectionLabel(c),
+    })),
+  )
 }

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -1,5 +1,7 @@
 import type { IJSONObject } from '@plumber/types'
 
+import pLimit from 'p-limit'
+
 import { parseFormIdFromInput } from '@/apps/formsg/auth/verify-credentials'
 import { checkLiveMrfStatus } from '@/apps/formsg/common/check-live-mrf-status'
 import { parseFormEnvFromInput } from '@/apps/formsg/common/form-env'
@@ -36,6 +38,14 @@ export function connectionLabel(c: {
 // no DB write) whenever we can positively confirm the form isn't MRF now.
 const STALE_MRF_TAG_REGEX = /^(\[[A-Z]+\] )?\[MRF\] /
 
+// Caps how many of these live checks can be in flight at once — connection
+// labels are user-controlled (via updateConnection's formattedData), so an
+// unbounded Promise.all over every connection would let a user with many
+// stale-tagged connections fire an unbounded burst of concurrent outbound
+// requests at FormSG's API.
+const MRF_LIVE_CHECK_CONCURRENCY = 5
+const mrfLiveCheckLimit = pLimit(MRF_LIVE_CHECK_CONCURRENCY)
+
 async function resolveMcpConnectionLabel(c: {
   formattedData?: IJSONObject
   description?: string
@@ -55,7 +65,9 @@ async function resolveMcpConnectionLabel(c: {
   try {
     const formId = parseFormIdFromInput(rawFormId)
     const env = parseFormEnvFromInput(rawFormId)
-    const isCurrentlyMrf = await checkLiveMrfStatus(formId, env)
+    const isCurrentlyMrf = await mrfLiveCheckLimit(() =>
+      checkLiveMrfStatus(formId, env),
+    )
     if (isCurrentlyMrf === false) {
       return label.replace('[MRF] ', '')
     }

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -80,6 +80,8 @@ export type PipeStatePart = {
 export interface ClarificationQuestion {
   question: string
   options: string[]
+  /** Renders the question as a visually urgent warning — reserved for choices with a real, hard-to-reverse consequence. */
+  isWarning?: boolean
 }
 
 // Type for clarification questions data annotation

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
@@ -5,7 +5,12 @@ import {
   useRef,
   useState,
 } from 'react'
-import { FaArrowCircleUp, FaChevronLeft, FaChevronRight } from 'react-icons/fa'
+import {
+  FaArrowCircleUp,
+  FaChevronLeft,
+  FaChevronRight,
+  FaExclamationTriangle,
+} from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
 import { Box, Button, Flex, Icon, Text, Textarea } from '@chakra-ui/react'
 import { Badge } from '@opengovsg/design-system-react'
@@ -86,19 +91,34 @@ export default function ChoicePicker({
     }
   }
 
+  const isWarning = currentQ.isWarning
+
   return (
     <Box w="full" maxW="4xl">
       <Box
-        bg="white"
+        bg={isWarning ? 'red.50' : 'white'}
         border="1px"
-        borderColor="gray.200"
+        borderColor={isWarning ? 'red.300' : 'gray.200'}
         borderRadius="16px"
         boxShadow="0 2px 4px rgba(0,0,0,0.1)"
         p={4}
         w="full"
       >
-        <Flex justify="space-between" align="center" mb={2}>
-          <Text>{currentQ.question}</Text>
+        <Flex justify="space-between" align="flex-start" mb={2}>
+          <Flex align="flex-start" gap={2}>
+            {isWarning && (
+              <Icon
+                as={FaExclamationTriangle}
+                color="red.500"
+                fontSize="16px"
+                flexShrink={0}
+                mt="3px"
+              />
+            )}
+            <Text fontWeight={isWarning ? 'semibold' : 'normal'}>
+              {currentQ.question}
+            </Text>
+          </Flex>
           {isMulti && (
             <Flex align="center" gap={2} ml={3} flexShrink={0}>
               <Icon


### PR DESCRIPTION
## What?

Three independent AI Builder / FormSG fixes bundled from the MCP bug bash:

1. **Testing a FormSG trigger always uses mock data.** `execute_step` now passes `testRunMetadata: { preferMock: true }` into `testStep`, so the AI Builder never waits on (or silently reuses) a real form submission when it tests a step inline in chat.
2. **Stale `[MRF]` connection labels no longer block the AI Builder.** Connections verified before #1939 removed the MRF-tagging logic can still carry a `[MRF] ` prefix baked into their stored `screenName`. The AI Builder's connection picker surfaces that stale label, and since the system prompt elsewhere says MRF is unsupported, the model reasonably refuses to use an old "fake MRF" connection that isn't actually MRF.
3. **A visually urgent warning treatment for high-consequence clarification questions.** Adds an `isWarning` flag to `ClarificationQuestion`, driven by a `WARNING: true` line in the `CLARIFICATION_DATA` block — used for the connection-override confirmation (overriding disconnects another pipe's trigger).

## Why?

- (1) AI Builder testing happens inline in chat with no real user action to wait on — there's no "go submit your form now" moment, so mock data is the only sensible default.
- (2) The `[MRF]` tag removal (#1939) fixed new/re-verified connections but never backfilled already-verified ones, since the tag only refreshes on re-verification. Old connections are stuck showing a tag that no longer reflects reality.
- (3) The existing neutral clarification card doesn't communicate that a choice has a real, hard-to-reverse consequence outside the current pipe (e.g. breaking another pipe's connection) — users can click past it without registering the risk.

## What changed?

- `packages/backend/src/services/mcp/execute-step.ts`: always passes `preferMock: true` in `testRunMetadata`. Apps that don't recognize `preferMock` (i.e. everything except FormSG's `newSubmission` trigger) just ignore it via their own zod schema.
- `packages/backend/src/apps/formsg/common/check-live-mrf-status.ts` (new): live-checks FormSG's public schema for a form's *current* MRF status (`responseMode === 'multirespondent' && workflow.length > 0`, matching every other MRF check in the codebase). Returns `null` (not `false`) on a fetch error or missing form, so callers can fail safe.
- `packages/backend/src/services/mcp/list-connections.ts`: `resolveMcpConnectionLabel` detects a stale `[MRF] ` tag on a FormSG connection's label, live-checks the form, and strips the tag display-only (no DB write) only when the check positively confirms the form isn't MRF. Any ambiguity — no `formId`, unparseable `formId`, fetch failure — leaves the label as-is.
- `packages/backend/src/routes/api/chat/parse-clarification-block.ts` / `schema.ts`: adds `isWarning?: boolean` to `ClarificationQuestion`, parsed from an optional `WARNING: true` line directly after `Q:` in a `CLARIFICATION_DATA` block.
- `packages/frontend/src/hooks/useChatStream.ts` / `ChoicePicker.tsx`: mirrors the type on the frontend; renders the warning card (red background/border, warning triangle icon, bold question text) for both the initial question and its review-mode summary.

## Tests

- `execute-step.itest.ts`: asserts `testStep` is called with `testRunMetadata: { preferMock: true }`.
- `list-connections.itest.ts`: new `describe('stale [MRF] label correction (PLU-866)')` block — strips the tag on a confirmed-non-MRF form (including when an env prefix like `[STAGING]` is present), keeps it when the live check confirms MRF or fails, and confirms no live check runs at all for a label with no stale tag or a non-FormSG connection.

## Deploy notes

None — no migrations or config changes. The stale-label fix is read-time only; nothing needs backfilling.
