### PR TITLE
[mcp-bug-bash]: ai builder gathersg fixes

### DIFF
--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -40,7 +40,15 @@ vi.mock('@/apps', () => ({
       key: 'slack',
       name: 'Slack',
       auth: {},
-      triggers: [],
+      triggers: [
+        {
+          key: 'noAuthTrigger',
+          name: 'No Auth Trigger',
+          description: 'A trigger that opts out of the app connection',
+          noAuthRequired: true,
+          arguments: [],
+        },
+      ],
       actions: [
         {
           key: 'sendMessage',
@@ -232,16 +240,25 @@ describe('listAppsService', () => {
     expect(formsg?.triggers).toHaveLength(1)
     expect(formsg?.actions).toHaveLength(0)
     const slack = apps.find((a) => a.key === 'slack')
-    expect(slack?.triggers).toHaveLength(0)
+    expect(slack?.triggers).toHaveLength(1)
     expect(slack?.actions).toHaveLength(1)
   })
 
-  it('sets requiresConnection based on whether app has auth', async () => {
+  it('sets requiresConnection on a trigger/action based on whether its app has auth', async () => {
     const apps = await listAppsService(user)
     const slack = apps.find((a) => a.key === 'slack')
     const formsg = apps.find((a) => a.key === 'formsg')
-    expect(slack?.requiresConnection).toBe(true)
-    expect(formsg?.requiresConnection).toBe(false)
+    expect(slack?.actions[0].requiresConnection).toBe(true)
+    expect(formsg?.triggers[0].requiresConnection).toBe(false)
+  })
+
+  it('sets requiresConnection to false for a trigger/action that opts out via noAuthRequired, even when its app has auth', async () => {
+    const apps = await listAppsService(user)
+    const slack = apps.find((a) => a.key === 'slack')
+    // slack has auth configured, but this trigger opts out individually —
+    // its sibling action (sendMessage) still requires a connection.
+    expect(slack?.triggers[0].requiresConnection).toBe(false)
+    expect(slack?.actions[0].requiresConnection).toBe(true)
   })
 
   it('serializes static dropdown options', async () => {

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -107,7 +107,6 @@ export async function listAppsService(user: IUser): Promise<IMcpApp[]> {
     .map((app) => ({
       key: app.key,
       name: app.name,
-      requiresConnection: !!app.auth,
       triggers: (app.triggers ?? [])
         .filter((t) => allLdFlags[`app_${app.key}_trigger_${t.key}`] !== false)
         .map((t) => {
@@ -116,6 +115,11 @@ export async function listAppsService(user: IUser): Promise<IMcpApp[]> {
             key: t.key,
             name: t.name,
             description: t.description,
+            // Mirrors get-app.ts / ChooseAppAndEvent's own connection check —
+            // a trigger/action can opt out of its app's connection even when
+            // the app has auth configured for its other triggers/actions
+            // (e.g. GatherSG's webhook trigger vs. its API-key actions).
+            requiresConnection: !!app.auth && !raw.noAuthRequired,
             fields: serializeFields(raw.arguments ?? []),
           }
         }),
@@ -127,6 +131,7 @@ export async function listAppsService(user: IUser): Promise<IMcpApp[]> {
             key: a.key,
             name: a.name,
             description: a.description,
+            requiresConnection: !!app.auth && !raw.noAuthRequired,
             fields: serializeFields(raw.arguments ?? []),
           }
         }),

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1371,13 +1371,13 @@ export interface IMcpAppAction {
   key: string
   name: string
   description?: string
+  requiresConnection: boolean
   fields: IMcpAppField[]
 }
 
 export interface IMcpApp {
   key: string
   name: string
-  requiresConnection: boolean
   triggers: IMcpAppAction[]
   actions: IMcpAppAction[]
 }


### PR DESCRIPTION
## What?

1. Stops the AI Builder from prompting for a connection on GatherSG's `newInstantWorkflow` trigger, which doesn't use one.
2. Allows users to skip optional configuration steps e.g. case status on gathersg

## Why?

`listAppsService`'s `list_apps` MCP tool computed `requiresConnection` once per **app** (`!!app.auth`), not per trigger/action. GatherSG's app has `auth` configured (its actions — `createCase`, `updateCase`, `tagOrUntagCase`, `getCaseDetails` — all need the API-key connection), but its `newInstantWorkflow` trigger already declares `noAuthRequired: true` on the trigger itself and doesn't use a connection at all. The app-level flag ignored that, so the AI Builder always asked the user to pick/add a GatherSG connection when configuring the trigger, even though nothing in the trigger's own field schema needs one. This mirrors the exact same `noAuthRequired` check the regular pipe editor already respects (`get-app.ts`, `ChooseAppAndEvent`) — the MCP path just wasn't wired up to it.

## What changed?

- `packages/types/index.d.ts`: moved `requiresConnection: boolean` from `IMcpApp` down onto `IMcpAppAction` — it's a per-trigger/action fact, not a per-app one (an app can mix both, like GatherSG does).
- `packages/backend/src/services/mcp/apps.ts`: `listAppsService` now computes `requiresConnection` per trigger and per action as `!!app.auth && !raw.noAuthRequired`, instead of once at the app level.
- `packages/backend/src/services/mcp/__tests__/apps.test.ts`: updated the mocked Slack fixture to include a `noAuthRequired: true` trigger alongside its existing (connection-requiring) action, and split the old single `sets requiresConnection based on whether app has auth` test into two: one confirming the per-trigger/action app-auth check, one confirming a trigger can opt out via `noAuthRequired` while its sibling action still requires a connection.

## Not covered

The AI Builder system prompt still describes `requiresConnection` as an app-level fact in a few places ("only if `requiresConnection` is `true` for this app") — worth a follow-up prompt update so the model doesn't generalize a no-connection trigger's answer to other steps of the same app, but that's prompt-only and out of scope for this code fix.

## Tests

`apps.test.ts` — see above; both new/updated assertions pass.

1. Check that gathersg trigger doesn't ask for a connection when prompted in the AI builder.
2. Check that formsg --> gathersg create case allows users to skip the step configuration for optional fields like case status

## Deploy notes

None — no migrations or config changes.
