### PR TITLE
fix: merge Telegram supergroup chatId into stored parameters atomically

### DIFF
--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -1,6 +1,7 @@
 import { IGlobalVariable } from '@plumber/types'
 
 import get from 'lodash.get'
+import { raw } from 'objection'
 
 import HttpError from '@/errors/http'
 import RetriableError from '@/errors/retriable-error'
@@ -71,12 +72,17 @@ export async function throwSendMessageError(
             throw err // uncaught error
           }
 
+          // `step.parameters` here is the resolved, per-run copy (see
+          // computeParameters in services/action.ts), not the persisted
+          // config. Merge chatId into the DB row's parameters directly via
+          // a jsonb `||` so we patch the actual stored value atomically,
+          // instead of spreading stale/resolved in-memory parameters back.
           await Step.query()
             .patchAndFetchById(step.id, {
-              parameters: {
-                ...step.parameters,
-                chatId: newChatId,
-              },
+              parameters: raw('?? || ?::jsonb', [
+                'parameters',
+                JSON.stringify({ chatId: newChatId }),
+              ]),
             })
             .context({
               shouldBypassBeforeUpdateHook: true,


### PR DESCRIPTION
## TL;DR

Fixes a subtle correctness bug in the Telegram bot's supergroup chat-ID migration handler: it was writing this run's _resolved_ action parameters back to the step's persisted config instead of merging just the changed field into the actual DB row.

## What changed?

In `throw-errors.ts`, when Telegram reports a group was upgraded to a supergroup (new `chatId`), we patch the step's stored parameters to point at the new chat ID so future runs don't fail the same way. Previously this did:

```ts
parameters: { ...step.parameters, chatId: newChatId }
```

`step.parameters` at that point is not the persisted config — it's the in-memory copy already overwritten by `computeParameters()` in `services/action.ts` with this run's _resolved_ values (variable references substituted with concrete runtime values). Spreading it back into the DB would permanently bake those resolved values into the user's stored parameters, silently clobbering any `{{variable}}` templates on other fields, with no protection against a concurrent write to the same row in between.

Changed to a single atomic jsonb merge, executed directly by Postgres against the actual stored row:

```ts
parameters: raw('?? || ?::jsonb', ['parameters', JSON.stringify({ chatId: newChatId })])
```

This reads and writes the real persisted `parameters` value in one statement, so only `chatId` changes and every other field (including unresolved variable templates) is left untouched.

## Why?

Received a user ticket about Telegram parameters becomign hardcoded and audited whether `step.parameters` can be mutated by anything other than direct user edits in the flow editor. This is the one deliberate case in the codebase where execution code patches a step's parameters on an _active/published_ pipe (via `shouldBypassBeforeUpdateHook`), so it's worth getting the merge semantics right rather than relying on a stale in-memory object.

## Tests

- [ ] Trigger a Telegram "Send Message" action against a group that gets upgraded to a supergroup mid-run, and confirm only `chatId` is updated in the step's stored parameters (other fields, especially any using variable references, remain untouched).
- [ ] Confirm the retriable error still fires with the correct old/new chat ID in the message.

## Deploy notes

No migrations, config, or env changes. Behavior-only fix scoped to the Telegram bot's send-message error handling.