### PR TITLE
fix: deploy failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ ENV VITE_MODE=$APP_ENV
 
 WORKDIR /opt/plumber
 COPY . ./
+RUN npm install -g npm@11.19.0
 RUN --mount=type=secret,id=NPM_TASKFORCESH_TOKEN \
   (export NPM_TASKFORCESH_TOKEN=$(cat /run/secrets/NPM_TASKFORCESH_TOKEN); npm ci)
 RUN npm run build
-RUN npm prune --production
+RUN npm prune --omit=dev --ignore-scripts
 
 FROM node:22-alpine as main
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "vitest": "^3.2.6",
         "wait-on": "^7.2.0"
       },
+      "engines": {
+        "npm": ">=11.10.0"
+      },
       "workspaces": {
         "packages": [
           "packages/*"


### PR DESCRIPTION
# Context

We upgraded to npm 11 to support min-package-age, but that caused `chakra-cli` failure during `npm prune`\- it couldn't find the binary.

Root cause: `npm prune` in version 10 was not removing devDependencies binaries from node_modules, but npm 11 did.

# Fix

Make `prune` step exclude lifecycle scripts. This is already ran during `npm ci`, no reason for us to run it again.