### PR TITLE
PLU-743: [IF-THEN-THEN-V2-17] Deprecate branch name

### DIFF
--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -21,7 +21,7 @@ const action: IRawAction = {
       label: 'Branch Name',
       key: 'branchName',
       type: 'string' as const,
-      required: true,
+      required: false,
       variables: false,
     },
     {

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -165,7 +165,8 @@ export default function Branch(props: BranchProps) {
             color="base.content.default"
             noOfLines={1}
           >
-            {branchSteps[0].parameters.branchName as string}
+            {(branchSteps[0].parameters.branchName as string) ||
+              'If-then Branch'}
           </Text>
 
           {/* Duplicate/delete branch buttons */}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -30,6 +30,7 @@ import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
+import getStepName from '@/helpers/getStepName'
 import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
@@ -71,6 +72,7 @@ export default function IfThen({
 }: IfThenProps): JSX.Element {
   const { ifThenStep, children } = block
   const {
+    allApps,
     currentStepId,
     flow,
     isDrawerOpen,
@@ -101,15 +103,11 @@ export default function IfThen({
     groupingActions ?? new Set<string>(),
   )
 
-  // The single-branch box merges what an if-then V1 group shows as two lines
-  // (its own caption, plus the branch name inside it) into one header. A
-  // user-renamed step takes priority, as it would for any step. Otherwise the
-  // branch name stands in, captioned as an if-then so it doesn't read as a
-  // name the user chose themselves.
-  const stepName = ifThenStep.config?.stepName
-  const branchName = ifThenStep.parameters?.branchName as string | undefined
-  const headerLabel =
-    stepName ?? (branchName ? `If-then: ${branchName}` : 'If-then')
+  // Reuses getStepName rather than re-deriving the same rule here, so a
+  // leftover V1 block's branchName keeps showing in the header exactly as it
+  // does in the drawer title below. isIfThenV2Enabled is hardcoded true: this
+  // component only ever mounts on the flag-ON render fork.
+  const headerLabel = getStepName(allApps, ifThenStep, true).stepName
 
   // IMPORTANT: assumes allowReorder already excludes read-only. The caller
   // (StepsList) folds that in before passing it down.

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -14,6 +14,7 @@ import {
   validateSubstep,
 } from '@/helpers/editor'
 import { validateStepParams } from '@/helpers/validateStepParams'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 type FlowSubstepProps = {
   hasConnection: boolean
@@ -41,6 +42,8 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   } = useDisclosure()
 
   const { arguments: args } = substep
+  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
+    useIfThenV2Enabled()
   const [isSaving, setIsSaving] = useState(false)
   const [isValid, setIsValid] = useState<boolean>(
     validateSubstep(substep, formContext.getValues() as IStep),
@@ -68,11 +71,19 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
         isInputVisibleForStep(
           selectedActionOrTrigger?.key,
           arg.key,
-          step.createdAt,
+          step,
           getFlagValue,
+          { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading },
         ),
       ) || [],
-    [args, step.createdAt, selectedActionOrTrigger, getFlagValue],
+    [
+      args,
+      step,
+      isIfThenV2Enabled,
+      isIfThenV2Loading,
+      selectedActionOrTrigger?.key,
+      getFlagValue,
+    ],
   )
 
   /**

--- a/packages/frontend/src/helpers/__tests__/getStepName.test.ts
+++ b/packages/frontend/src/helpers/__tests__/getStepName.test.ts
@@ -54,15 +54,98 @@ describe('getStepName', () => {
       const result = getStepName([], step)
       expect(result).toEqual({
         stepName: 'My Condition',
-        defaultStepName: 'Condition',
+        defaultStepName: 'If-then',
       })
     })
 
-    it('returns "Condition" when no custom name', () => {
+    it('returns "If-then" when no custom name', () => {
       const result = getStepName([], ifThenStep)
       expect(result).toEqual({
-        stepName: 'Condition',
-        defaultStepName: 'Condition',
+        stepName: 'If-then',
+        defaultStepName: 'If-then',
+      })
+    })
+
+    it('ignores branchName when the flag param is omitted, even if set', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        parameters: { branchName: 'Branch 1' },
+      })
+      const result = getStepName([], step)
+      expect(result).toEqual({
+        stepName: 'If-then',
+        defaultStepName: 'If-then',
+      })
+    })
+
+    it('ignores branchName when the flag is explicitly off', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        parameters: { branchName: 'Branch 1' },
+        config: { stepName: 'My Condition' },
+      })
+      const result = getStepName([], step, false)
+      expect(result).toEqual({
+        stepName: 'My Condition',
+        defaultStepName: 'If-then',
+      })
+    })
+
+    it('ignores branchName for a V2 step even when the flag is on', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        parameters: { branchName: 'Branch 1' },
+        config: { endStepId: 'step-2' },
+      })
+      const result = getStepName([], step, true)
+      expect(result).toEqual({
+        stepName: 'If-then',
+        defaultStepName: 'If-then',
+      })
+    })
+
+    it('combines branchName and stepName for a leftover V1 step when the flag is on', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        parameters: { branchName: 'Branch 1' },
+        config: { stepName: 'My Condition' },
+      })
+      const result = getStepName([], step, true)
+      expect(result).toEqual({
+        stepName: 'Branch 1 (My Condition)',
+        defaultStepName: 'Branch 1',
+      })
+    })
+
+    it('falls back to branchName alone for a leftover V1 step with no stepName, flag on', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        parameters: { branchName: 'Branch 1' },
+      })
+      const result = getStepName([], step, true)
+      expect(result).toEqual({
+        stepName: 'Branch 1',
+        defaultStepName: 'Branch 1',
+      })
+    })
+
+    it('falls back to "If-then" for a leftover V1 step with no branchName, flag on', () => {
+      const result = getStepName([], ifThenStep, true)
+      expect(result).toEqual({
+        stepName: 'If-then',
+        defaultStepName: 'If-then',
+      })
+    })
+
+    it('falls back to "If-then" when config.stepName was explicitly cleared to an empty string', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        config: { stepName: '' },
+      })
+      const result = getStepName([], step)
+      expect(result).toEqual({
+        stepName: 'If-then',
+        defaultStepName: 'If-then',
       })
     })
   })
@@ -81,6 +164,18 @@ describe('getStepName', () => {
       const result = getStepName([], step)
       expect(result).toEqual({
         stepName: 'Loop Items',
+        defaultStepName: 'For each item',
+      })
+    })
+
+    it('falls back to "For each item" when config.stepName was explicitly cleared to an empty string', () => {
+      const step = createMockStep({
+        ...forEachStep,
+        config: { stepName: '' },
+      })
+      const result = getStepName([], step)
+      expect(result).toEqual({
+        stepName: 'For each item',
         defaultStepName: 'For each item',
       })
     })

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -21,6 +21,8 @@ import {
   isGroupedMultiRowComplete,
 } from '@/helpers/grouped-multirow-validation'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
+import { isIfThenStep } from '@/helpers/toolbox'
+import type { IfThenV2State } from '@/hooks/useIfThenV2Enabled'
 
 export const getFlowStepHeaderWidth = (
   isDrawerOpen: boolean,
@@ -51,12 +53,23 @@ function isValidArgValue(value: IJSONValue): boolean {
 export function isInputVisibleForStep(
   actionOrTriggerKey: string | undefined,
   argKey: string,
-  stepCreatedAt: string | number,
+  step: IStep,
   getFlagValue: LaunchDarklyContextData['getFlagValue'],
+  ifThenV2State?: IfThenV2State,
 ): boolean {
+  // TODO (if-then-then): remove once if-then V2 is 100% rolled out.
+  if (
+    argKey === 'branchName' &&
+    isIfThenStep(step) &&
+    ifThenV2State?.isEnabled &&
+    !ifThenV2State.isLoading
+  ) {
+    return false
+  }
+
   const inputFlag = getInputFlag(actionOrTriggerKey ?? '', argKey)
   const flagValue = getFlagValue(inputFlag, false)
-  return !flagValue || +stepCreatedAt <= flagValue
+  return !flagValue || +step.createdAt <= flagValue
 }
 
 // Field definitions can specify a static `value` to pre-select (e.g. a
@@ -84,12 +97,7 @@ export function withDefaultParameters(
       // default here would make the form report a value the user never saw
       // and the backend never received, desyncing it from `dataIn`.
       if (
-        !isInputVisibleForStep(
-          actionOrTriggerKey,
-          arg.key,
-          step.createdAt,
-          getFlagValue,
-        )
+        !isInputVisibleForStep(actionOrTriggerKey, arg.key, step, getFlagValue)
       ) {
         continue
       }

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -5,7 +5,11 @@ import {
   isIfThenStep as checkIfThenStep,
 } from '@/helpers/toolbox'
 
-export default function getStepName(allApps: IApp[], step: IStep | undefined) {
+export default function getStepName(
+  allApps: IApp[],
+  step: IStep | undefined,
+  isIfThenV2Enabled = false,
+) {
   if (!step) {
     return {
       stepName: '',
@@ -17,15 +21,30 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
 
   // IfThen and ForEach are toolbox steps that don't need app lookup
   if (checkIfThenStep(step)) {
+    const isV2 = step.config?.endStepId != null
+    const branchName = step.parameters?.branchName as string | undefined
+
+    // Edge case: If-then V2 is enabled and viewer is looking at a V1 if-then.
+    // V1 if-thens may have both stepname and branch names - we combine them if
+    // thats the case.
+    if (!isV2 && isIfThenV2Enabled && branchName) {
+      return {
+        stepName: customStepName
+          ? `${branchName} (${customStepName})`
+          : branchName,
+        defaultStepName: branchName,
+      }
+    }
+
     return {
-      stepName: customStepName ?? 'Condition',
-      defaultStepName: 'Condition',
+      stepName: customStepName || 'If-then',
+      defaultStepName: 'If-then',
     }
   }
 
   if (checkForEachStep(step)) {
     return {
-      stepName: customStepName ?? 'For each item',
+      stepName: customStepName || 'For each item',
       defaultStepName: 'For each item',
     }
   }

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -18,6 +18,7 @@ import {
   isIfThenStep as checkIfThenStep,
   TOOLBOX_ACTIONS,
 } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 enum AI_ACTIONS {
   Pair = 'pair',
@@ -81,7 +82,14 @@ export function useStepMetadata(
     [actionsOrTriggers, step?.key],
   )
 
-  const { stepName, defaultStepName } = getStepName(allApps, step)
+  // TODO: remove this branchName-specific check once if-then V2 is rolled
+  // out to 100% and if-then V1 is retired.
+  const { isEnabled: isIfThenV2Enabled } = useIfThenV2Enabled()
+  const { stepName, defaultStepName } = getStepName(
+    allApps,
+    step,
+    isIfThenV2Enabled,
+  )
 
   const substeps = selectedActionOrTrigger?.substeps || []
   const hasConnection = substeps?.some(


### PR DESCRIPTION
# Context

We are enabling steps to be inserted _after_ If-thens. The main changes:

1. Introduce a `endStepId` marker in each if-then step, so that we know when the conditional steps end.
    1. The region between an If-Then action and its end step is called a "block".
    2. For empty blocks, the `endStepId` is set to the if-then's step ID.
2. Abandon the branch concept because its extra complexity.

> [!IMPORTANT]
> Important
>
> This new If-Then is called If-Then V2 in the codebase; we don't want to make a big bang change.

# This PR

Deprecates the `branchName` parameter for If-Then V2. High level approach:

1. Make `branchName` an optional param (we expect to move people to V2 ASAP so this shouldn't be too big of a problem)
2. Add an edge case to `argsToDisplay` to hide branch name - this is bad (tm) but I'll clean it up once v2 is rolled out fully.

Edge case: a branch might have both step name and branch name. In this case, we display it as `${branchName} (${customStepName})`.

# Tests

This is the top stack in the PR, so here are the tests:

### **With LD flag OFF**

- Check that published legacy pipes' If-Then still work.
- Check that I cannot add If-Then in an If-Then
- Check that I cannot add For-Each in an If-Then.
- [Legacy pipe] Check that I can only add If-Then at the end of a pipe without For-Each
- [Legacy pipe] Check that I can only add If-Then at the end of For-Each, in a pipe with For-each
- [Legacy pipe] Check that I cannot add steps after If-then.
- [Legacy pipe] Check that I cannot add steps after If-then when the If-Then is in a For-each.
- [Legacy pipe] Check that when I create a new If-Then branch in a legacy pipe with existing If-Then, `stepIdToJumpTo` is not populated
- [Legacy pipe] Check that when I create a new If-Then block in a pipe without existing If-then, `stepIdToJumpTo` is not populated.
- [Legacy pipe] Check that I can re-order branches within an If-Then block, and the new step order is respected when the pipe runs
- [Legacy pipe] Check that I can re-order steps outside the If-Then block, and the new step order is respected when the pipe runs

### **With LD flag ON**

- Check that all If-Thens (>=1 block) in published pipe work.
- Check that I cannot add If-Then in an If-Then.
- Check that I cannot add For-Each in an If-Then.
- Check that I can add steps after If-Then
- Check that I can add steps after an If-Then located in a For-Each
- Check that I can add If-Then in the middle of a pipe.
- Check that I can add If-Then in the middle of a For-Each
- Check that when I create a new If-Then block in a pipe without any If-Then, `stepIdToJumpTo` is populated.
- Check that when I create a new If-Then block in a For-Each in a pipe without any If-Then, `stepIdToJumpTo` is populated.
- Check that I can re-order steps outside If-Then (both before and after), and the new step order is respected when the pipe runs
- Check that I can re-order steps outside If-Then (both before and after) within a For-Each, and the new step order is respected when the pipe runs
- [Legacy -> new] Check that I can add steps after an If-Then when the pipe has a legacy If-then (i.e. no `stepIdToJumpTo`), and that the added steps run outside of the If-Then conditional
- [Legacy -> new] Check that I can add steps after an If-Then in a For-Each when the pipe has a legacy If-then (i.e. no `stepIdToJumpTo`), and that the added steps run outside of the If-Then conditional