### PR TITLE
fix(m365-excel): guard against excel tables with too many columns

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -2,6 +2,7 @@ import type { IGlobalVariable, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
 
+import { TEST_STEP_MAX_COLUMNS } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
 import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
@@ -86,6 +87,7 @@ const action: IRawAction = {
       key: 'columnValues',
       type: 'multirow-multicol' as const,
       autofillable: true,
+      maxAutofillOptions: TEST_STEP_MAX_COLUMNS,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
@@ -4,7 +4,9 @@ import type { z } from 'zod'
 
 import { filtersSchema } from '@/apps/m365-excel/common/schema'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 
+import { TEST_STEP_MAX_COLUMNS } from '../../../common/constants'
 import getTopNTableRows from '../../../common/get-top-n-table-rows'
 import type WorkbookSession from '../../../common/workbook-session'
 
@@ -81,6 +83,29 @@ export default async function getTableRowImpl(
     tableId,
     MAX_ROWS,
   )
+
+  // Testing a step against a table with many columns can generate an
+  // unwieldy amount of data out, so block it instead of letting the step
+  // test choke on it. In production, we don't want to break existing flows
+  // over this, so just log it for visibility instead. Checked here (instead
+  // of by callers) so it still fires even when no row is found.
+  if (columns.length > TEST_STEP_MAX_COLUMNS) {
+    if ($.execution.testRun) {
+      throw new StepError(
+        `Your Excel table has more than ${TEST_STEP_MAX_COLUMNS} columns.`,
+        'Reduce the number of columns in your table and try testing this step again.',
+      )
+    }
+
+    logger.error('Excel table exceeds test step column limit', {
+      event: 'm365-excel-table-column-limit-exceeded',
+      appKey: $.step?.appKey,
+      numColumns: columns.length,
+      flowId: $.flow?.id,
+      stepId: $.step?.id,
+      executionId: $.execution?.id,
+    })
+  }
 
   const columnIndices = filters.map(({ lookupColumn }) => {
     const idx = columns.indexOf(lookupColumn)

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -4,11 +4,13 @@ import z from 'zod'
 
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 
 import {
   GET_TABLE_ROWS_LIMIT,
   LOOKUP_CONDITIONS_SUBFIELDS,
   MAX_LOOKUP_CONDITIONS,
+  TEST_STEP_MAX_COLUMNS,
 } from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
 import { lookupParametersSchema } from '../../common/schema'
@@ -110,6 +112,28 @@ const action: IRawAction = {
       tableId,
       MAX_ROWS,
     )
+
+    // Testing a step against a table with many columns can generate an
+    // unwieldy amount of data out, so block it instead of letting the step
+    // test choke on it. In production, we don't want to break existing
+    // flows over this, so just log it for visibility instead.
+    if (rawColumns.length > TEST_STEP_MAX_COLUMNS) {
+      if ($.execution.testRun) {
+        throw new StepError(
+          `Your Excel table has more than ${TEST_STEP_MAX_COLUMNS} columns.`,
+          'Reduce the number of columns in your table and try testing this step again.',
+        )
+      }
+
+      logger.error('Excel table exceeds test step column limit', {
+        event: 'm365-excel-table-column-limit-exceeded',
+        appKey: $.step?.appKey,
+        numColumns: rawColumns.length,
+        flowId: $.flow?.id,
+        stepId: $.step?.id,
+        executionId: $.execution?.id,
+      })
+    }
 
     const columnIndices = filters.map(({ lookupColumn }) => {
       const idx = rawColumns.indexOf(lookupColumn)

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import { TEST_STEP_MAX_COLUMNS } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
 import {
   constructMsGraphValuesArrayForRowWrite,
@@ -38,6 +39,7 @@ const action: IRawAction = {
         'Enter the data to update the row with. Columns not specified will not be updated',
       type: 'multirow-multicol' as const,
       autofillable: true,
+      maxAutofillOptions: TEST_STEP_MAX_COLUMNS,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -6,6 +6,11 @@ export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
 
 export const GET_TABLE_ROWS_LIMIT = 500
 
+// Testing a step with a very wide table can generate a huge amount of data
+// out, which causes problems (e.g. slow/failed step test) downstream. Cap the
+// number of columns returned when the step is only being tested.
+export const TEST_STEP_MAX_COLUMNS = 100
+
 export const MAX_LOOKUP_CONDITIONS = 3
 
 export const LOOKUP_CONDITIONS_SUBFIELDS = [

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -253,6 +253,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         showDivider={type !== 'multirow-multicol'}
         type={type}
         autofillable={'autofillable' in schema && schema.autofillable}
+        maxAutofillOptions={
+          'maxAutofillOptions' in schema ? schema.maxAutofillOptions : undefined
+        }
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
         maxRows={schema.maxRows}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -30,6 +30,8 @@ export type MultiRowProps = {
   defaultValue?: string | IJSONValue
   // See IFieldMultiRowMultiCol.autofillable.
   autofillable?: boolean
+  // See IFieldMultiRowMultiCol.maxAutofillOptions.
+  maxAutofillOptions?: number
   // Optional node rendered beside the "+ And" add-row button (e.g. a wrapper's
   // own controls). Renders even when the add-row button is hidden at maxRows.
   addButtonSuffix?: ReactNode
@@ -54,6 +56,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     maxRows,
     defaultValue,
     autofillable,
+    maxAutofillOptions,
     addButtonSuffix,
     onRequestRemoveLastRow,
     ...forwardedInputCreatorProps
@@ -117,6 +120,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     confirm,
   } = useAutofill({
     autofillable,
+    maxAutofillOptions,
     type,
     subFields,
     stepId: forwardedInputCreatorProps.stepId,

--- a/packages/frontend/src/components/MultiRow/useAutofill.ts
+++ b/packages/frontend/src/components/MultiRow/useAutofill.ts
@@ -28,6 +28,8 @@ export type UseAutofillResult = {
 type UseAutofillArgs = {
   // Whether the field schema opted into Autofill (see IFieldMultiRowMultiCol.autofillable).
   autofillable: boolean | undefined
+  // See IFieldMultiRowMultiCol.maxAutofillOptions.
+  maxAutofillOptions: number | undefined
   type: string | undefined
   subFields: IField[]
   stepId: string | undefined
@@ -56,6 +58,7 @@ const rowHasValue = (row: Record<string, unknown>) =>
  */
 export default function useAutofill({
   autofillable,
+  maxAutofillOptions,
   type,
   subFields,
   stepId,
@@ -65,7 +68,7 @@ export default function useAutofill({
   getValues,
   setValue,
 }: UseAutofillArgs): UseAutofillResult {
-  const canAutofill =
+  const isAutofillableField =
     !!autofillable &&
     type === 'multirow-multicol' &&
     subFields?.[0]?.type === 'dropdown' &&
@@ -78,6 +81,14 @@ export default function useAutofill({
   } = useDynamicData(stepId, subFields?.[0], name)
 
   const optionCount = dynamicDataOptions?.length
+
+  // Wait for the option count to resolve before rendering the button at all,
+  // instead of showing it mid-load (with a spinner) only to potentially hide
+  // it once we learn the count exceeds maxAutofillOptions.
+  const canAutofill =
+    isAutofillableField &&
+    optionCount != null &&
+    (maxAutofillOptions == null || optionCount <= maxAutofillOptions)
 
   const buildAutofillRows = useCallback(
     (items: { value: string; type?: string }[]) =>

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -495,6 +495,12 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
    * user picks a handful of specific conditions.
    */
   autofillable?: boolean
+  /**
+   * When `autofillable` is set, hides the "Autofill" button if subFields[0]'s
+   * dynamic-data source has more options than this. Use when autofilling a
+   * very large number of rows would be unwieldy for the user (or the app).
+   */
+  maxAutofillOptions?: number
 }
 
 export interface IFieldMultiRow extends IBaseField {


### PR DESCRIPTION
## Summary

Testing `get-table-row`, `get-table-rows`, or `update-table-row` against a wide Excel table (many columns) could return an unwieldy amount of data out, causing the step test to choke.

- `getTableRowImpl` (shared by `get-table-row` and `update-table-row`) and `get-table-rows` now check the fetched column count against a new `TEST_STEP_MAX_COLUMNS` (100) limit:
  - During a step test (`$.execution.testRun`), throw a `StepError` telling the user to reduce the number of columns and retest.
  - In production runs, just `logger.error` (with `appKey`/`flowId`/`stepId`/`executionId`/`numColumns`) for visibility instead of breaking existing flows.
- Added an optional `maxAutofillOptions` to `IFieldMultiRowMultiCol`, threaded through `InputCreator` → `MultiRow` → `useAutofill`. `create-table-row` and `update-table-row` set this to `TEST_STEP_MAX_COLUMNS`, so the "Autofill"/"Add all N fields" button hides once the selected table has more than 100 columns (bulk-adding that many rows would be unwieldy).
- `useAutofill`'s `canAutofill` now waits for the dynamic-data option count to resolve before rendering the button at all, instead of showing it with a loading spinner and possibly hiding it again once the count is known.

## Test plan

- [x] `npm run -w backend lint:fix` / `npm run -w backend test:unit` — all 113 `m365-excel` unit tests pass
- [x] `npm run lint:fix` (root, both workspaces) — clean, no changes
- [ ] Manually test the "Add all fields" autofill button on `create-table-row`/`update-table-row` against tables with <100 and >100 columns
- [ ] Manually test-step `get-table-row`/`get-table-rows`/`update-table-row` against a table with >100 columns and confirm the `StepError` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)