### PR TITLE
feat(pair): align Pair step copy with Figma, add multicol column headers

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -18,9 +18,9 @@ import { schema } from './schema'
 const model = engineProvider.chat(appConfig.pair.foundry.imageModel)
 
 const action: IRawAction = {
-  name: 'Process an image',
+  name: 'Process image',
   key: 'processImage',
-  description: 'Extract information from an image or PDF',
+  description: 'Extract data or synthesise content from an image or PDF',
   linkToGuide: 'https://guide.plumber.gov.sg/user-guides/actions/pair',
   arguments: [
     {
@@ -35,17 +35,17 @@ const action: IRawAction = {
       disableUpload: true,
     },
     {
-      label: 'What do you want to extract?',
-      description: 'Use these as variables in later steps',
+      label: 'What should Pair give you back? (use in later steps)',
       key: 'responseFields',
       type: 'multirow-multicol' as const,
       required: true,
-      addRowButtonText: 'Add another',
+      addRowButtonText: 'Add output',
       subFields: [
         {
           key: 'description',
           label: 'What to look for',
-          placeholder: 'Whether the image contains a handwritten signature',
+          placeholder:
+            'e.g. Whether the image contains a handwritten signature',
           type: 'string',
           required: true,
           customStyle: { flex: 3, minWidth: 0, maxWidth: '75%' },
@@ -53,7 +53,7 @@ const action: IRawAction = {
         {
           key: 'fieldName',
           label: 'Output name',
-          placeholder: 'Signature present',
+          placeholder: 'e.g. Signature present',
           type: 'string',
           required: true,
           customStyle: { flex: 1 },

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -19,14 +19,13 @@ import { schema } from './schema'
 const turndownService = new TurndownService()
 
 const action: IRawAction = {
-  name: 'Use Pair',
+  name: 'Process text',
   key: 'sendPrompt',
-  description:
-    'Enter a custom prompt to summarise, categorise or analyse data with Pair',
+  description: 'Summarise, categorise, write or analyse textual data with AI',
   linkToGuide: 'https://guide.plumber.gov.sg/user-guides/actions/pair',
   arguments: [
     {
-      label: 'Describe what you want Pair to do',
+      label: 'What should Pair do? (prompt)',
       key: 'prompt',
       type: 'rich-text' as const,
       required: true,
@@ -57,8 +56,7 @@ const action: IRawAction = {
       })),
     },
     {
-      label: 'Define how you want Pair to structure what it extracts',
-      description: 'Use these as variables in later steps',
+      label: 'What should Pair give you back? (use in later steps)',
       key: 'responseFields',
       type: 'multirow-multicol' as const,
       required: true,
@@ -69,24 +67,24 @@ const action: IRawAction = {
       addRowButtonText: 'Add output',
       subFields: [
         {
+          label: 'Output name',
+          placeholder: 'e.g. Priority level',
+          key: 'fieldName',
+          type: 'string' as const,
+          required: true,
+          variables: false,
+        },
+        {
           label: 'Type',
           key: 'fieldType',
           type: 'dropdown' as const,
           required: true,
           showOptionValue: false,
           options: [
-            { label: 'Text', value: 'text' },
-            { label: 'Number', value: 'number' },
-            { label: 'Category', value: 'category' },
+            { label: 'Text', value: 'text', icon: 'text' },
+            { label: 'Number', value: 'number', icon: 'hash' },
+            { label: 'Category', value: 'category', icon: 'list-ol' },
           ],
-        },
-        {
-          label: 'Output name',
-          placeholder: 'E.g., Priority level',
-          key: 'fieldName',
-          type: 'string' as const,
-          required: true,
-          variables: false,
         },
         {
           label: 'Categories',

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -113,26 +113,26 @@ export const DEFAULT_PROMPT_VALUES = {
 
 export const DEFAULT_RESPONSE_FIELDS_VALUES = {
   analyse: [
-    { fieldType: 'text', fieldNameHint: 'key patterns or trends' },
-    { fieldType: 'text', fieldNameHint: 'strength' },
-    { fieldType: 'text', fieldNameHint: 'weakness' },
-    { fieldType: 'text', fieldNameHint: 'implications or recommendations' },
+    { fieldType: 'text', fieldName: 'Key patterns or trends' },
+    { fieldType: 'text', fieldName: 'Strength' },
+    { fieldType: 'text', fieldName: 'Weakness' },
+    { fieldType: 'text', fieldName: 'Implications or recommendations' },
     {
       fieldType: 'text',
-      fieldNameHint: 'supporting evidence for your conclusions',
+      fieldName: 'Supporting evidence for your conclusions',
     },
   ],
   categorise: [
     {
       fieldType: 'category',
-      fieldNameHint: 'sentiment',
-      fieldCategoriesHint: 'Positive, Negative, Neutral',
+      fieldName: 'Sentiment',
+      fieldCategories: 'Positive, Negative, Neutral',
     },
   ],
-  summarise: [{ fieldType: 'text', fieldNameHint: 'summary' }],
+  summarise: [{ fieldType: 'text', fieldName: 'Summary' }],
   write: [
-    { fieldType: 'text', fieldNameHint: 'title' },
-    { fieldType: 'text', fieldNameHint: 'content' },
+    { fieldType: 'text', fieldName: 'Title' },
+    { fieldType: 'text', fieldName: 'Content' },
   ],
-  custom: [{ fieldType: 'text', fieldNameHint: 'response' }],
+  custom: [{ fieldType: 'text', fieldName: 'Response' }],
 }

--- a/packages/backend/src/apps/pair/index.ts
+++ b/packages/backend/src/apps/pair/index.ts
@@ -5,7 +5,7 @@ import actions from './actions'
 const app: IApp = {
   name: 'Pair',
   key: 'pair',
-  description: 'Summarise, categorise or analyse data with Pair',
+  description: 'Process data using AI',
   iconUrl: '{BASE_URL}/apps/pair/assets/favicon.svg',
   authDocUrl: '',
   baseUrl: '',

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -2,12 +2,14 @@ import type {
   IFieldDropdown,
   IFieldDropdownOption,
   TDataOutMetadatumType,
+  TFieldDropdownOptionIcon,
 } from '@plumber/types'
 
 import { useCallback, useContext, useMemo } from 'react'
 import { useController, useFormContext } from 'react-hook-form'
+import { BiHash, BiListOl, BiText } from 'react-icons/bi'
 import Markdown from 'react-markdown'
-import { Box, Flex, FormControl, useDisclosure } from '@chakra-ui/react'
+import { As, Box, Flex, FormControl, useDisclosure } from '@chakra-ui/react'
 import {
   FormErrorMessage,
   FormLabel,
@@ -43,6 +45,12 @@ export interface ControlledAutocompleteProps {
   variableTypes?: TDataOutMetadatumType[]
 }
 
+const OPTION_ICONS: Record<TFieldDropdownOptionIcon, As> = {
+  text: BiText,
+  hash: BiHash,
+  'list-ol': BiListOl,
+}
+
 const formComboboxOptions = (
   options: readonly IFieldDropdownOption[],
   showOptionValue?: boolean,
@@ -57,6 +65,7 @@ const formComboboxOptions = (
       description:
         option['description'] ??
         (showOptionValue ? option['value'].toString() : ''),
+      icon: option.icon ? OPTION_ICONS[option.icon] : undefined,
     } satisfies ComboboxItem
     result.push(item)
   }

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -143,7 +143,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     <Box position="relative" display="flex" flexDirection="column">
       {argsToDisplay.length > 0 && (
         <Box flex="1" p={0} pb={4}>
-          <Stack w="100%" spacing={4}>
+          <Stack w="100%" spacing={7}>
             {argsToDisplay.map((argument) => (
               <InputCreator
                 key={argument.key}

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -3,7 +3,7 @@ import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 import React, { useContext } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { BiTrash } from 'react-icons/bi'
-import { Divider, Flex } from '@chakra-ui/react'
+import { Box, Divider, Flex, Text } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
@@ -14,6 +14,7 @@ import { applyDynamicPlaceholder } from './utils'
 type MultiColProps = {
   name: string
   subFields: IFieldMultiRowMultiColSubField[]
+  visibleColumnKeys?: Set<string>
   canRemoveRow?: boolean
   isEditorReadOnly?: boolean
   remove?: (index?: number | number[]) => void
@@ -24,6 +25,7 @@ export default function MultiCol(props: MultiColProps) {
   const {
     name,
     subFields,
+    visibleColumnKeys,
     canRemoveRow,
     isEditorReadOnly,
     remove,
@@ -33,6 +35,10 @@ export default function MultiCol(props: MultiColProps) {
 
   const { isMobile } = useContext(EditorContext)
   const { getValues } = useFormContext()
+
+  // Desktop table headers sit above the first row only. Mobile stacks columns,
+  // so labels are shown per input instead.
+  const hasColumnHeaders = !isMobile && subFields.some((subF) => subF.label)
 
   const DeleteButton = () => {
     return (
@@ -53,16 +59,18 @@ export default function MultiCol(props: MultiColProps) {
   ) => {
     const { type, variables } = subF
 
-    // Only show labels, descriptions, and tooltips on the first row
-    let schemaWithConditionalLabel =
-      index === 0
-        ? subF
-        : {
-            ...subF,
-            label: undefined,
-            description: undefined,
-            tooltipText: undefined,
-          }
+    // Desktop: labels/descriptions/tooltips only on the first row, and never
+    // once they are rendered as column headers. Mobile: every stacked row
+    // needs its own labels.
+    const shouldShowFieldLabel = isMobile || (index === 0 && !hasColumnHeaders)
+    let schemaWithConditionalLabel = shouldShowFieldLabel
+      ? subF
+      : {
+          ...subF,
+          label: undefined,
+          description: undefined,
+          tooltipText: undefined,
+        }
 
     schemaWithConditionalLabel = applyDynamicPlaceholder(
       schemaWithConditionalLabel,
@@ -95,6 +103,23 @@ export default function MultiCol(props: MultiColProps) {
               {showDeleteButton && <DeleteButton />}
             </Flex>
           </React.Fragment>
+        ) : hasColumnHeaders && index === 0 ? (
+          // Stretching keeps the header pinned to the top and the input to the
+          // bottom, so a hidden input or a wrapped header can't knock the row
+          // out of line.
+          <Flex
+            key={`${name}.${subF.key}`}
+            flexDir="column"
+            alignSelf="stretch"
+            style={subF.customStyle}
+          >
+            {(visibleColumnKeys?.has(subF.key) ?? true) && (
+              <Text textStyle="caption-3" color="base.content.medium" mb={2}>
+                {subF.label}
+              </Text>
+            )}
+            <Box mt="auto">{renderSubFieldInput(subF, subFIndex)}</Box>
+          </Flex>
         ) : (
           <div key={`${name}.${subF.key}`} style={subF.customStyle}>
             {renderSubFieldInput(subF, subFIndex)}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -1,7 +1,12 @@
 import type { IField, IJSONValue } from '@plumber/types'
 
 import { ReactNode, useCallback, useContext, useEffect, useMemo } from 'react'
-import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form'
 import { BiListPlus, BiPlus, BiTrash } from 'react-icons/bi'
 import Markdown from 'react-markdown'
 import { Flex } from '@chakra-ui/react'
@@ -9,6 +14,7 @@ import { Button, FormLabel, IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator, { InputCreatorProps } from '@/components/InputCreator'
 import { EditorContext } from '@/contexts/Editor'
+import { isFieldHidden } from '@/helpers/isFieldHidden'
 
 import MultiCol from '../MultiCol.tsx'
 
@@ -91,6 +97,23 @@ function MultiRow(props: MultiRowProps): JSX.Element {
       setValue(name, defaultValue)
     }
   }, [defaultValue, name, setValue])
+
+  // Computed here rather than in MultiCol, which only sees its own row: a
+  // column's header is dropped while every row hides that column.
+  const rowValues = useWatch({ name, control })
+  const visibleColumnKeys = useMemo(() => {
+    const rowsToCheck =
+      Array.isArray(rowValues) && rowValues.length ? rowValues : [{}]
+    return new Set(
+      subFields
+        .filter((subField) =>
+          rowsToCheck.some(
+            (row) => !isFieldHidden(subField.hiddenIf, row ?? {}),
+          ),
+        )
+        .map((subField) => subField.key),
+    )
+  }, [rowValues, subFields])
 
   const handleAddRow = useCallback(() => {
     // NOTE: only need to use this flag to focus on the rte
@@ -185,13 +208,14 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                   key={`${row.id}-${index}`}
                   flexDir="column"
                   gap={4}
-                  mb={4}
+                  mb={3}
                 >
                   {type === 'multirow-multicol' ? (
                     <>
                       <MultiCol
                         name={namePrefix}
                         subFields={subFields}
+                        visibleColumnKeys={visibleColumnKeys}
                         canRemoveRow={canRemoveRow}
                         isEditorReadOnly={isEditorReadOnly}
                         remove={() => removeRow(index)}

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -358,6 +358,13 @@
   height: 100%;
 }
 
+// Single-line inputs (e.g. multirow-multicol) must not fill the FormControl.
+// `height: 100%` would grow the field to include the label on mobile.
+.editor.editor--single-line {
+  height: auto;
+  flex: none;
+}
+
 .single-line-editor {
   white-space: nowrap;
   overflow-x: auto;

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -334,7 +334,11 @@ const Editor = ({
         placement={getPopoverPlacement(editor)}
       >
         <div
-          className={clsx('editor', containerClassName)}
+          className={clsx(
+            'editor',
+            isMulticol && 'editor--single-line',
+            containerClassName,
+          )}
           onClick={(e) => {
             e.stopPropagation()
             openSuggestions()

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -423,6 +423,12 @@ export interface IFieldDropdownSource {
   }[]
 }
 
+/**
+ * Referenced by name rather than by component because the field schema is
+ * serialised to JSON over /api/apps; the frontend maps each name back.
+ */
+export type TFieldDropdownOptionIcon = 'text' | 'hash' | 'list-ol'
+
 export interface IFieldDropdownOption {
   label: string
 
@@ -439,6 +445,8 @@ export interface IFieldDropdownOption {
    * false.
    */
   description?: string
+
+  icon?: TFieldDropdownOptionIcon
 }
 
 export interface IFieldText extends IBaseField {


### PR DESCRIPTION
## What

Clean up the Pair step to improve usability and readability 

Before 
<img width="613" height="403" alt="image" src="https://github.com/user-attachments/assets/5d24f85b-0b39-402b-bd82-cc4afc1e6b2a" />
<img width="496" height="215" alt="image" src="https://github.com/user-attachments/assets/affd2a4f-3724-40a0-91f7-15f91338b604" />

After
<img width="612" height="403" alt="image" src="https://github.com/user-attachments/assets/d83b6580-24db-4ab8-b1ee-83836c40c717" />
<img width="577" height="163" alt="image" src="https://github.com/user-attachments/assets/fc202f86-efcb-4be0-8860-12894d074c32" />



Before 
<img width="960" height="625" alt="image" src="https://github.com/user-attachments/assets/bca8e9ca-4fb4-47e8-bb1e-7ef02bcf6361" />
After
<img width="964" height="602" alt="image" src="https://github.com/user-attachments/assets/cee88c3d-9495-4df5-965c-3be54ce44440" />


Before
<img width="965" height="548" alt="image" src="https://github.com/user-attachments/assets/ee4ba755-27b0-4805-9f92-380008d82ea9" />
After
<img width="955" height="511" alt="image" src="https://github.com/user-attachments/assets/1eadb97e-57ea-45cb-a9c9-e262f5a93062" />


### Copy

- Actions renamed to **Process text** / **Process image**; app and action descriptions rewritten to say what each one does.
- Step field headers rewritten to a consistent question form — **"What should Pair do? (prompt)"** and **"What should Pair give you back? (use in later steps)"** — with the outputs header shared by both actions.
- Both actions' outputs tables aligned: same header, same **Add output** button, example-led placeholders.
- Presets now seed real field values instead of placeholder hints, so choosing a preset fills the outputs table in rather than ghosting it.
- Output types reordered to **Output name → Type → Categories**, matching the design.

### Column headers for `multirow-multicol`

Sub-field labels now render as compact `caption-3` column headers above the first row, instead of a full-size form label on each input.

- Scoped by data, not by a flag: only fields whose sub-fields carry a `label` are affected. Every field either labels all its columns or none, so no field ends up with a partially-filled header row. In practice this touches 3 of 21 multicol fields — both Pair actions and `m365-excel/write-cell-values`. The other 18 are placeholder-driven and render exactly as before.
- A column's header is hidden while *every* row hides that column, so Pair's `CATEGORIES` header only appears once a Category row exists. This has to be computed in `MultiRow`, since `MultiCol` only ever sees its own row.
- Columns stretch to the row height with the input pinned to the bottom, so a hidden input (`hiddenIf`) or a header that wraps can't knock the row out of alignment.
- `caption-3` already existed in the theme with exactly the design's values, so no theme change.

### Dropdown option icons

Dropdown options can now name an icon, rendered both in the option list and in the input once selected. Used for the Pair output types (Text / Number / Category).

Icons are referenced **by name** rather than by component because the field schema reaches the frontend as JSON from the REST `/api/apps` route; the frontend maps each name back to a component. No GraphQL schema change and no codegen — that route passes `actions` through untouched.

### Spacing

Wider gap between step fields, tighter gap between rows, per the design.

## Reviewer notes

**to check**
Can help to verify that this caption-3 change did not affect this multi-col behaviour anywhere else

**Not verified locally.** Lint, typecheck and tests all shell out through the repo's version-manager hook, which aborts in this environment. Nothing here has been run. Please run the checks and load a Pair step before merging — in particular:

- fresh Pair step → no `CATEGORIES` header; set a row's Type to Category → header appears and columns don't shift
- `m365-excel/write-cell-values` is the one non-Pair field affected — its "Cell Address (e.g. A1)" label now renders as a 10px uppercase micro-label, which may want shortening
- the change spans all three packages, so `@plumber/types` needs rebuilding for the other two to typecheck

**Accessibility regression.** Row 0's inputs previously had a real `FormLabel` inside their `FormControl`, giving screen readers a label association. A plain `Text` header has no `htmlFor` link, so those inputs are now unlabelled to assistive tech. Rows 1+ were already in that state, but row 0 is a regression. Threading an `aria-label` through `InputCreator` would close it — happy to do that here or as a follow-up.

**Dead code left behind.** The `fieldNameHint` → `fieldName` rename means no app sets a `*Hint` key any more, so `applyDynamicPlaceholder` (`MultiCol.tsx/utils.ts`) and its test file are now unreachable. Left in place for a separate cleanup.

**Still open, deliberately.** Column gap (8px vs the design's 16px) is unchanged, since it affects all 21 multicol fields including the placeholder-driven ones. The Pair column widths are also still the code's, not the design's.
