### PR TITLE
fix: skip flag-gated defaults when seeding form parameters

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -7,6 +7,7 @@ import ChooseConnectionSubstep from '@/components/ChooseConnectionSubstep'
 import FlowSubstep from '@/components/FlowSubstep'
 import Form from '@/components/Form'
 import { EditorContext } from '@/contexts/Editor'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepExecutionsProvider } from '@/contexts/StepExecutions'
 import {
   generateValidationSchema,
@@ -32,6 +33,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
   } = useDisclosure()
 
   const { onUpdateStep, resetTimestamp } = useContext(EditorContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
 
   const { app, hasConnection, isTrigger, selectedActionOrTrigger, substeps } =
     useStepMetadata(step)
@@ -49,8 +51,14 @@ export default function Step(props: StepProps): React.ReactElement | null {
   )
 
   const stepWithDefaultParameters = useMemo(
-    () => withDefaultParameters(step, substeps),
-    [step, substeps],
+    () =>
+      withDefaultParameters(
+        step,
+        substeps,
+        selectedActionOrTrigger?.key,
+        getFlagValue,
+      ),
+    [step, substeps, selectedActionOrTrigger, getFlagValue],
   )
 
   return (

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -6,10 +6,13 @@ import { Box, Stack, useDisclosure, usePrevious } from '@chakra-ui/react'
 
 import FlowStepTestController from '@/components/FlowStepTestController'
 import InputCreator from '@/components/InputCreator'
-import { getInputFlag } from '@/config/flags'
 import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
-import { hasDirtyFields, validateSubstep } from '@/helpers/editor'
+import {
+  hasDirtyFields,
+  isInputVisibleForStep,
+  validateSubstep,
+} from '@/helpers/editor'
 import { validateStepParams } from '@/helpers/validateStepParams'
 
 type FlowSubstepProps = {
@@ -61,14 +64,14 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   // filter inputs hidden behind feature flags based on timestamp
   const argsToDisplay = useMemo(
     () =>
-      args?.filter((arg) => {
-        const inputFlag = getInputFlag(
-          selectedActionOrTrigger?.key ?? '',
+      args?.filter((arg) =>
+        isInputVisibleForStep(
+          selectedActionOrTrigger?.key,
           arg.key,
-        )
-        const flagValue = getFlagValue(inputFlag, false)
-        return !flagValue || +step.createdAt <= flagValue
-      }) || [],
+          step.createdAt,
+          getFlagValue,
+        ),
+      ) || [],
     [args, step.createdAt, selectedActionOrTrigger, getFlagValue],
   )
 

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -14,6 +14,8 @@ import * as yup from 'yup'
 import type { ObjectShape } from 'yup/lib/object'
 
 import { TOOLBOX_ACTION_TO_ICON_MAP } from '@/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent'
+import { getInputFlag } from '@/config/flags'
+import type { LaunchDarklyContextData } from '@/contexts/LaunchDarkly'
 import {
   areRowsComplete,
   isGroupedMultiRowComplete,
@@ -44,6 +46,19 @@ function isValidArgValue(value: IJSONValue): boolean {
   return value != null && value !== ''
 }
 
+// Input flags gate a field's rollout by the step's creation time: the field
+// only shows for steps created after the flag's configured timestamp.
+export function isInputVisibleForStep(
+  actionOrTriggerKey: string | undefined,
+  argKey: string,
+  stepCreatedAt: string | number,
+  getFlagValue: LaunchDarklyContextData['getFlagValue'],
+): boolean {
+  const inputFlag = getInputFlag(actionOrTriggerKey ?? '', argKey)
+  const flagValue = getFlagValue(inputFlag, false)
+  return !flagValue || +stepCreatedAt <= flagValue
+}
+
 // Field definitions can specify a static `value` to pre-select (e.g. a
 // boolean-radio defaulting to "No"). That default only reaches react-hook-form
 // via each input's own `defaultValue` prop, which registers asynchronously
@@ -54,14 +69,32 @@ function isValidArgValue(value: IJSONValue): boolean {
 export function withDefaultParameters(
   step: IStep,
   substeps: ISubstep[],
+  actionOrTriggerKey: string | undefined,
+  getFlagValue: LaunchDarklyContextData['getFlagValue'],
 ): IStep {
   const defaultParameters: IJSONObject = {}
 
   for (const substep of substeps ?? []) {
     for (const arg of substep.arguments ?? []) {
-      if (arg.value !== undefined && step.parameters[arg.key] === undefined) {
-        defaultParameters[arg.key] = arg.value as IJSONValue
+      if (arg.value === undefined || step.parameters[arg.key] !== undefined) {
+        continue
       }
+
+      // Skip fields hidden behind a not-yet-active input flag: seeding their
+      // default here would make the form report a value the user never saw
+      // and the backend never received, desyncing it from `dataIn`.
+      if (
+        !isInputVisibleForStep(
+          actionOrTriggerKey,
+          arg.key,
+          step.createdAt,
+          getFlagValue,
+        )
+      ) {
+        continue
+      }
+
+      defaultParameters[arg.key] = arg.value as IJSONValue
     }
   }
 


### PR DESCRIPTION
## TL;DR

Fixes a bug where a successfully tested FormSG step (or any step with a feature-flag-gated input) kept showing "Previous result" instead of "Step was set up successfully!".

## What changed?

- `withDefaultParameters` no longer seeds a default value for an argument whose input is hidden behind a not-yet-active feature flag (e.g. FormSG's `nricFilter` dropdown). Previously it seeded defaults for every substep argument regardless of flag gating.
- Extracted the flag-visibility check (previously duplicated in `FlowSubstep`'s `argsToDisplay` filter) into a shared `isInputVisibleForStep` helper in `editor.ts`, used by both `FlowSubstep` and `withDefaultParameters`.
- Removed a few stray `console.log` debug statements left over in `editor.ts`, `Step.tsx`, and `FlowStepTestController/index.tsx`.

Root cause: `matchParamsToDataIn` compares form params against the last test execution's `dataIn`. A hidden field's default value (e.g. `nricFilter: 'none'`) was present in form params but absent from `dataIn` (since the field was never shown/saved), and the comparison had no tolerance for a param present where `dataIn` was missing the key — so it always reported a mismatch.

## Tests

- [ ] Open an existing FormSG pipe step where the NRIC filter input is flag-gated and hidden, run "Check step", confirm it now shows "Step was set up successfully!" and stays that way (not "Previous result").
- [ ] Confirm a step with a *visible* flag-gated field still behaves correctly (default still seeds normally when the flag is active).
- [ ] `npm run -w frontend lint` and `npm test` pass.

## Deploy notes

None. Frontend-only change, no migrations or config changes.
