### PR TITLE
chore: bump dompurify, @grpc/grpc-js, joi, ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10741,6 +10741,13 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/turndown": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
@@ -15836,9 +15843,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20903,9 +20903,9 @@
       "license": "MIT"
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6129,9 +6129,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34589,9 +34589,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## TL;DR

Bumps four transitive dependencies (`dompurify`, `@grpc/grpc-js`, `joi`, `ws`) to their latest patch versions to clear moderate/high `npm audit` advisories. None have first-party call sites or breaking API changes.

## What changed?

- **dompurify** 3.4.1 → 3.4.13 — fixes `IN_PLACE` sanitization bypasses and DOM-clobbering XSS (GHSA-hpcv-96wg-7vj8, GHSA-r47g-fvhr-h676, GHSA-rp9w-3fw7-7cwq). Pulled in via `streamdown → mermaid`; no direct dompurify usage in Plumber code.
- **@grpc/grpc-js** 1.14.3 → 1.14.4 — fixes two crash bugs from malformed requests/compressed messages (GHSA-5375-pq7m-f5r2, GHSA-99f4-grh7-6pcq). Pulled in via unused OpenTelemetry OTLP-gRPC exporters and test-only `testcontainers`/`dockerode`.
- **joi** 17.13.3 → 17.13.4 — fixes an uncaught `RangeError` DoS on deeply nested recursive `link()` schemas (GHSA-q7cg-457f-vx79). Pulled in via `wait-on`, a devDependency used only in the frontend's `dev` script.
- **ws** 8.18.3 → 8.21.3 — fixes uninitialized memory disclosure via `close()` (GHSA-58qx-3vcg-4xpx) and a memory-exhaustion DoS from tiny fragments/chunks (GHSA-96hv-2xvq-fx4p). Pulled in via dev-only tooling (`graphql-codegen`, `chakra-ui` CLI); Plumber has no production WebSocket client/server (GraphQL API is HTTP-only, no `Subscription` type).

All four are transitive (no entry in any `package.json`), applied via `npm update <package>`, and stay within each parent's already-declared semver range. No `package.json` or `overrides` changes were needed.

## Tests

- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] Backend starts cleanly (`npm run dev`) with no OpenTelemetry/instrumentation errors
- [ ] Backend integration test suite (`.itest.ts`, requires Docker via `npm run setup`) passes, exercising `testcontainers`/`dockerode`

## Deploy notes

None. All changes are lockfile-only version bumps of indirect dependencies with no first-party code touching the affected APIs.
