### PR TITLE
fix: bound RichTextEditor height for borderless/presets variant

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -346,7 +346,7 @@
 
   .editor__content > .tiptap.ProseMirror {
     height: 100%;
-    max-height: none;
+    max-height: 20em;
   }
 
   .editor__content .ProseMirror {


### PR DESCRIPTION
## TL;DR

Fixes the Pair prompt field's rich text editor growing unbounded instead of scrolling internally, like Postman's body field does.

## What changed?

`.editor--borderless .editor__content > .tiptap.ProseMirror` now caps at `max-height: 20em` instead of `none`.

`RichTextEditorWithPresets` (used whenever a field schema defines `presets`, e.g. Pair's `prompt` field) always applies the `editor--borderless` container class. That class removed the height cap entirely, so the editor grew with content instead of scrolling. Postman's `body` field has no `presets`, so it renders the plain `RichTextEditor` and keeps the default `20em` cap, which is why only Pair showed the bug.

## Tests

- [ ] Open a Pair "Send prompt" action, type/paste enough text into the prompt field to exceed a few lines, and confirm the editor caps its height and scrolls internally instead of growing.
- [ ] Confirm Postman's body field still behaves the same as before (bounded + scrolling).
- [ ] Confirm the presets side panel (shown when the field is empty) still renders correctly alongside the editor.

## Deploy notes

None. Frontend-only CSS change.