### PR TITLE
PLU-791: [SES-MULTI-RECIPIENT-2]: surface blacklisted CC addresses in Postman email step

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -1055,7 +1055,7 @@ describe('send transactional email', () => {
       expect($.http.post).toHaveBeenCalledTimes(1)
     })
 
-    it('drops a suppressed CC from the SES call but keeps it in dataOut', async () => {
+    it('drops a suppressed CC from the SES call and surfaces it in dataOut', async () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
       // Only the CC is suppressed — the To recipient still sends.
       mocks.getSuppressedEmails.mockResolvedValueOnce(['cc-bad@open.gov.sg'])
@@ -1065,7 +1065,12 @@ describe('send transactional email', () => {
         'cc-good@open.gov.sg,cc-bad@open.gov.sg'
       $.step.parameters.attachments = []
 
-      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      let thrown: unknown
+      try {
+        await sendTransactionalEmail.run($)
+      } catch (e) {
+        thrown = e
+      }
 
       // Sent once for the single (non-suppressed) To recipient, and the
       // suppressed CC is dropped from the actual SES API call.
@@ -1075,15 +1080,91 @@ describe('send transactional email', () => {
         'cc-good@open.gov.sg',
       ])
 
-      // ...but the full CC list (including the suppressed address) is still
-      // reported in dataOut, since CC status is not tracked.
+      // The full CC list is still reported in dataOut, now alongside a
+      // per-address ccStatus marking the suppressed one.
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: expect.objectContaining({
           status: ['ACCEPTED'],
           recipient: ['recipient@open.gov.sg'],
           cc: ['cc-good@open.gov.sg', 'cc-bad@open.gov.sg'],
+          ccStatus: ['ACCEPTED', 'BLACKLISTED'],
         }),
       })
+
+      // The blacklisted CC is no longer silent: it surfaces as a
+      // PartialStepError (all To recipients succeeded, so the step doesn't
+      // fail outright), but with no retry button yet — CC-only retry isn't
+      // built.
+      expect(thrown).toBeInstanceOf(PartialStepError)
+      const thrownMessage = (thrown as Error).message
+      expect(thrownMessage).toContain('cc-bad@open.gov.sg')
+      expect(thrownMessage).not.toContain('cc-good@open.gov.sg')
+      expect(JSON.parse(thrownMessage).partialRetry.buttonMessage).toBe('')
+
+      // The owner's blacklist notification email includes the blacklisted CC.
+      expect(mocks.sendBlacklistEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blacklistedRecipients: ['cc-bad@open.gov.sg'],
+        }),
+      )
+    })
+
+    it('shows the blacklist removal instructions once, covering both a blacklisted recipient and a blacklisted CC', async () => {
+      mocks.getLdFlagValue.mockResolvedValue(true)
+      mocks.getSuppressedEmails.mockResolvedValueOnce([
+        'bad-recipient@open.gov.sg',
+        'bad-cc@open.gov.sg',
+      ])
+
+      $.step.parameters.destinationEmail =
+        'good-recipient@open.gov.sg,bad-recipient@open.gov.sg'
+      $.step.parameters.destinationEmailCc =
+        'good-cc@open.gov.sg,bad-cc@open.gov.sg'
+      $.step.parameters.attachments = []
+
+      let thrown: unknown
+      try {
+        await sendTransactionalEmail.run($)
+      } catch (e) {
+        thrown = e
+      }
+
+      expect(thrown).toBeInstanceOf(PartialStepError)
+      const message = (thrown as Error).message
+      expect(message).toContain('bad-recipient@open.gov.sg')
+      expect(message).toContain('bad-cc@open.gov.sg')
+      // One shared "use this form" sentence, not one per address section.
+      expect(message.match(/use this form/g)).toHaveLength(1)
+    })
+
+    it('does not repeat an address blacklisted as both a recipient and a CC', async () => {
+      mocks.getLdFlagValue.mockResolvedValue(true)
+      mocks.getSuppressedEmails.mockResolvedValueOnce(['both@open.gov.sg'])
+
+      $.step.parameters.destinationEmail = 'good@open.gov.sg,both@open.gov.sg'
+      $.step.parameters.destinationEmailCc = 'both@open.gov.sg'
+      $.step.parameters.attachments = []
+
+      let thrown: unknown
+      try {
+        await sendTransactionalEmail.run($)
+      } catch (e) {
+        thrown = e
+      }
+
+      expect(thrown).toBeInstanceOf(PartialStepError)
+      const message = (thrown as Error).message
+      // Shown once, under the recipients section — no separate CC paragraph
+      // repeating the same address.
+      expect(message.match(/both@open\.gov\.sg/g)).toHaveLength(1)
+      expect(message).not.toContain('CC email address')
+
+      // The owner notification email also lists it once, not twice.
+      expect(mocks.sendBlacklistEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blacklistedRecipients: ['both@open.gov.sg'],
+        }),
+      )
     })
 
     it('does not resend to CC recipients on a partial retry', async () => {

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/get-data-out-metadata.ts
@@ -34,13 +34,18 @@ async function getDataOutMetadata(
       order: 5,
       type: 'array',
     },
+    ccStatus: {
+      label: 'CC status',
+      order: 6,
+      type: 'array',
+    },
     from: {
       label: 'Sender',
-      order: 6,
+      order: 7,
     },
     reply_to: {
       label: 'Reply-To email',
-      order: 7,
+      order: 8,
     },
   }
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -283,6 +283,14 @@ async function sendEmail(
     })
     dataOut.status = updatedStatus
     dataOut.recipient = prevDataOut.recipient
+
+    // CC isn't re-sent on a partial retry (see ccList above), so this attempt
+    // knows nothing new about it — carry the previous attempt's cc/ccStatus
+    // forward instead of letting them silently disappear from dataOut.
+    if (prevDataOut.cc) {
+      dataOut.cc = prevDataOut.cc
+      dataOut.ccStatus = prevDataOut.ccStatus
+    }
   }
 
   /**
@@ -302,6 +310,8 @@ async function sendEmail(
   const blacklistedRecipients = dataOut.recipient.filter(
     (_, i) => dataOut.status[i] === 'BLACKLISTED',
   )
+  const blacklistedCcs =
+    dataOut.cc?.filter((_, i) => dataOut.ccStatus?.[i] === 'BLACKLISTED') ?? []
 
   const defaultSendEmailParams = {
     flowId: $.flow.id,
@@ -320,11 +330,19 @@ async function sendEmail(
    * Send blacklist notification email if any
    * If there are any invalid attachments, it will be included in this email
    */
-  if (blacklistedRecipients.length > 0 && !$.execution.testRun) {
+  if (
+    (blacklistedRecipients.length > 0 || blacklistedCcs.length > 0) &&
+    !$.execution.testRun
+  ) {
     try {
       await sendBlacklistEmail({
         ...defaultSendEmailParams,
-        blacklistedRecipients,
+        // Deduped: the same address can be blacklisted as both a recipient
+        // and a CC, and the owner notification email would otherwise list it
+        // twice.
+        blacklistedRecipients: [
+          ...new Set([...blacklistedRecipients, ...blacklistedCcs]),
+        ],
       })
     } catch (e) {
       logger.error(e)
@@ -333,6 +351,7 @@ async function sendEmail(
         flowId: $.flow.id,
         executionId: $.execution.id,
         blacklistedRecipients,
+        blacklistedCcs,
         error: e,
       })
     }
@@ -372,6 +391,7 @@ async function sendEmail(
       error,
       isPartialSuccess: hasAtLeastOneSuccess || invalidAttachments.length > 0,
       blacklistedRecipients,
+      blacklistedCcs,
       invalidAttachments,
       isRetryWithoutAttachments,
     })

--- a/packages/backend/src/apps/postman/common/data-out-validator.ts
+++ b/packages/backend/src/apps/postman/common/data-out-validator.ts
@@ -1,23 +1,27 @@
 import { z } from 'zod'
 
+const postmanEmailSendStatusSchema = z.enum([
+  'ACCEPTED',
+  'BLACKLISTED',
+  'RATE-LIMITED',
+  'INVALID-ATTACHMENT',
+  'ATTACHMENT-SIZE-EXCEEDED',
+  'INTERMITTENT-ERROR',
+  'ERROR',
+])
+
 export const dataOutSchema = z
   .object({
-    status: z.array(
-      z.enum([
-        'ACCEPTED',
-        'BLACKLISTED',
-        'RATE-LIMITED',
-        'INVALID-ATTACHMENT',
-        'ATTACHMENT-SIZE-EXCEEDED',
-        'INTERMITTENT-ERROR',
-        'ERROR',
-      ]),
-    ),
+    status: z.array(postmanEmailSendStatusSchema),
     recipient: z.array(z.string().email().toLowerCase()),
     body: z.string().optional(),
     subject: z.string().optional(),
     from: z.string().optional(),
     reply_to: z.string().email().optional(),
+    cc: z.array(z.string().email().toLowerCase()).optional(),
+    // Aligned with `cc` — only populated on the SES path, since CC suppression
+    // is an SES-only concept (the Postman path doesn't check suppression).
+    ccStatus: z.array(postmanEmailSendStatusSchema).optional(),
   })
   .describe('Data out object for send transactional email')
 

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -470,8 +470,8 @@ export async function sendTransactionalEmails(
 }> {
   // Pre-send suppression check (SES path only). CC addresses are included so a
   // blacklisted CC can be dropped from the SES call rather than re-sent to
-  // (which would re-bounce and inflate the bounce rate). CC suppression is
-  // silent — the full ccList is still reported in dataOut.
+  // (which would re-bounce and inflate the bounce rate). The full ccList is
+  // still reported in dataOut, alongside its per-address ccStatus below.
   let suppressedSet = new Set<string>()
   if (useSes) {
     const suppressedEmails = await EmailSuppressionEntry.getSuppressedEmails([
@@ -491,7 +491,7 @@ export async function sendTransactionalEmails(
 
   const activeRecipients = recipients.filter((r) => !suppressedSet.has(r))
   // Suppressed CCs are removed from the API call only — dataOut keeps the full
-  // ccList (CC status is not tracked per the field's documented behaviour).
+  // ccList, with `ccStatus` (computed below) marking suppressed addresses.
   const ccAddressesToSend = email.ccList?.filter((cc) => !suppressedSet.has(cc))
 
   // SES sends the whole batch in ⌈N/50⌉ bulk calls and reports a per-recipient
@@ -551,6 +551,24 @@ export async function sendTransactionalEmails(
     }
   })
 
+  // CC has no per-recipient send of its own to fail — it rides along on the
+  // To send(s) — so a blacklisted CC can only be surfaced by pushing a
+  // synthetic error here. Without this, `errorStatus` below would stay
+  // undefined (and no PartialStepError would ever mention the CC) whenever
+  // every To recipient succeeded.
+  const blacklistedCcs = (email.ccList ?? []).filter((cc) =>
+    suppressedSet.has(cc),
+  )
+  if (blacklistedCcs.length > 0) {
+    errors.push({
+      status: 'BLACKLISTED',
+      recipient: blacklistedCcs.join(', '),
+      error: {
+        message: 'CC email address is in suppression list',
+      } as HttpError,
+    })
+  }
+
   /**
    * Since we can only return one error per postman step, we have to select in terms of priority:
    * 1. RATE-LIMITED (so we can auto-retry)
@@ -571,10 +589,31 @@ export async function sendTransactionalEmails(
     ].indexOf(error.status),
   )
 
+  // CC status is only meaningful on the SES path — the Postman path never
+  // checks suppression, so CC there stays untracked (folded into `params.cc`
+  // only, as before).
+  const ccStatus: PostmanEmailSendStatus[] | undefined =
+    useSes && email.ccList?.length
+      ? email.ccList.map((cc): PostmanEmailSendStatus => {
+          if (suppressedSet.has(cc)) {
+            return 'BLACKLISTED'
+          }
+          // CCs ride along on every To send in the batch, so they're
+          // delivered whenever any To recipient's send succeeded.
+          if (status.some((s) => s === 'ACCEPTED')) {
+            return 'ACCEPTED'
+          }
+          // Nothing was delivered at all — mirror the same top-priority
+          // error the step itself surfaces.
+          return sortedErrors.length ? sortedErrors[0].status : 'ERROR'
+        })
+      : undefined
+
   const dataOut = {
     status,
     recipient,
     ...params,
+    ...(ccStatus && { ccStatus }),
   } satisfies PostmanEmailDataOut
   return {
     dataOut,

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -182,6 +182,7 @@ export function throwPostmanStepError({
   error,
   isPartialSuccess,
   blacklistedRecipients,
+  blacklistedCcs,
   invalidAttachments,
   isRetryWithoutAttachments,
 }: {
@@ -190,6 +191,7 @@ export function throwPostmanStepError({
   error: HttpError
   isPartialSuccess: boolean
   blacklistedRecipients: string[]
+  blacklistedCcs: string[]
   invalidAttachments: string[]
   isRetryWithoutAttachments: boolean
 }) {
@@ -202,14 +204,31 @@ export function throwPostmanStepError({
 
   switch (status) {
     case 'BLACKLISTED': {
-      let name = 'Blacklisted recipient email'
+      // The same address can be blacklisted as both a To-recipient and a CC
+      // (e.g. someone put it in both fields) — once it's already called out
+      // in the recipients section, repeating it verbatim in a second CC
+      // paragraph reads as a confusing duplicate, so the CC section only
+      // covers addresses not already shown above.
+      const ccOnlyBlacklisted = blacklistedCcs.filter(
+        (cc) => !blacklistedRecipients.includes(cc),
+      )
+      const hasBlacklistedRecipients = blacklistedRecipients.length > 0
+      const hasBlacklistedCcs = ccOnlyBlacklisted.length > 0
+
+      let name = hasBlacklistedRecipients
+        ? 'Blacklisted recipient email'
+        : 'Blacklisted CC email'
+      // The removal-request form covers both fields — recipients and CC are
+      // just addresses to it, no distinction needed.
       const formLink = createRequestBlacklistFormLink({
         userEmail: $.user.email,
         executionId: $.execution.id,
-        blacklistedRecipients,
+        blacklistedRecipients: [
+          ...new Set([...blacklistedRecipients, ...blacklistedCcs]),
+        ],
       })
 
-      // log individual blacklisted recipients
+      // log individual blacklisted recipients and CCs
       blacklistedRecipients.forEach((recipient) => {
         logger.info('Blacklisted recipient for postman email step', {
           event: 'postman-step-blacklisted-recipient',
@@ -218,21 +237,57 @@ export function throwPostmanStepError({
           executionId: $.execution.id,
         })
       })
+      blacklistedCcs.forEach((cc) => {
+        logger.info('Blacklisted CC for postman email step', {
+          event: 'postman-step-blacklisted-cc',
+          blacklistedEmail: cc,
+          stepId: $.step.id,
+          executionId: $.execution.id,
+        })
+      })
 
-      let solution = `The following email addresses have been blacklisted by Postman:
+      // Recipients and CC each get their own address list, but share a single
+      // closing "use this form" sentence rather than repeating it per list.
+      const addressSections: string[] = []
+      if (hasBlacklistedRecipients) {
+        addressSections.push(
+          `The following email addresses have been blacklisted by Postman:
          \n${blacklistedRecipients
            .map((recipient) => `**${recipient}**`)
-           .join('\n\n')}
+           .join('\n\n')}`,
+        )
+      }
+      if (hasBlacklistedCcs) {
+        name = hasBlacklistedRecipients
+          ? 'Blacklisted recipient and CC email'
+          : 'Blacklisted CC email'
+        addressSections.push(
+          `The following CC email addresses have been blacklisted by Postman:
+         \n${ccOnlyBlacklisted.map((cc) => `**${cc}**`).join('\n\n')}`,
+        )
+      }
+
+      const solutionSections: string[] = [
+        `${addressSections.join('\n\n&nbsp;\n\n')}
          \nIf you believe that they are valid and active, please [use this form](${formLink}) to request for removal from blacklist and try again.
-        `
+        `,
+      ]
 
       if (hasInvalidAttachments) {
         name += ` and invalid attachment(s)`
-        solution += `\n\n&nbsp;\n\n${invalidAttachmentsSolution}`
+        solutionSections.push(invalidAttachmentsSolution)
       }
 
-      let buttonMessage = 'Resend to blacklisted recipients'
-      if (isRetryWithoutAttachments) {
+      const solution = solutionSections.join('\n\n&nbsp;\n\n')
+
+      // CC-only retry isn't built yet — only offer the resend button when
+      // there's a blacklisted To-recipient the existing retry flow can
+      // actually act on (mirrors the invalid-attachments-only case above,
+      // which also withholds the button when there's nothing to retry).
+      let buttonMessage = hasBlacklistedRecipients
+        ? 'Resend to blacklisted recipients'
+        : ''
+      if (buttonMessage && isRetryWithoutAttachments) {
         buttonMessage += ' without attachments'
       }
 


### PR DESCRIPTION
## Stack Context

This is PR 2 of a 3-PR stack. PR 1 (merged below) swapped the SES transport to chunked bulk sends with no CC behaviour change. This PR makes blacklisted CC addresses visible instead of silently dropped. PR 3 builds the actual retry for them.

## What?

- `ccStatus` (parallel array to `cc`, SES path only — Postman never checks suppression) tracks per-address CC suppression status.
- A blacklisted CC now surfaces via a `PartialStepError` even when every To recipient succeeds — previously nothing was thrown in that case, so the CC drop was invisible.
- The flow owner's blacklist notification email now includes blacklisted CC addresses alongside blacklisted recipients (deduplicated — see below).
- No retry button yet for CC-only blacklists; that's PR 3.
- An address blacklisted in **both** the To and CC fields is only shown once (under the recipients section) instead of appearing in a duplicate CC paragraph, and is only listed once in the owner notification email rather than twice.
- The solution text shares a single "use this form" removal-request sentence across the recipient and CC sections instead of repeating it per section.
- `ccStatus` is registered as an array type in `get-data-out-metadata.ts`, so it renders as one "List" row in the step output variable picker instead of flattening into `ccStatus.0`, `ccStatus.1`, ...
- `cc`/`ccStatus` are carried forward across a partial retry instead of silently disappearing from `dataOut` (CC isn't resent during a retry in this PR — that's still PR 3 — so its last-known status needs to persist).

## Why?

- Blacklisted CC addresses were previously dropped with zero visibility — no error, no notification, nothing in the step output. This closes that gap without yet building the retry mechanism (kept as its own PR to keep the diffs reviewable).
- The dedup and shared-sentence fixes came out of manual testing during this PR: testing with the same address in both fields (a natural thing to do with only one test mailbox) surfaced a confusing duplicate in both the error message and the owner notification email.

## Test plan

### Automated
- [x] `npm run -w backend test:unit -- src/apps/postman` — all passing
- [x] `npm run -w backend lint`

### Manual (SES flags on for test recipients)
- [ ] Blacklist only a CC (all To recipients succeed) — confirm a `PartialStepError` fires listing the blacklisted CC, with **no** resend button (not built until PR 3), and the flow owner's notification email includes it.
- [ ] Blacklist a recipient and a CC with **different** addresses — confirm both sections render, separated by a visible blank line, with one shared "use this form" sentence (not repeated per section).
- [ ] Blacklist the **same** address in both the To and CC fields — confirm it's shown once (under the recipients section only), and the owner notification email lists it once, not twice.
- [ ] Check the step's output variable picker after a CC blacklist — confirm `ccStatus` shows as a single "List"-badged row, not flattened into `ccStatus.0`, `ccStatus.1`, ...
- [ ] Blacklist a recipient (not CC), retry after whitelisting — confirm `dataOut.cc`/`ccStatus` from the prior attempt are still present after the retry (not silently dropped), since CC isn't touched by this retry yet.
- [ ] Regression: plain multi-recipient send with no blacklist — still works exactly as PR 1 left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
