### PR TITLE
add auto retry for postman sms

### DIFF
--- a/packages/backend/src/apps/postman-sms/__tests__/request-error-handler.test.ts
+++ b/packages/backend/src/apps/postman-sms/__tests__/request-error-handler.test.ts
@@ -111,5 +111,40 @@ describe('Postman SMS request error handler', () => {
         delayInMs: 3000,
       })
     })
+
+    it('should retry on connection ETIMEDOUT', async () => {
+      const axiosError = {
+        isAxiosError: true,
+        name: 'AxiosError',
+        message: 'connect ETIMEDOUT 1.2.3.4:443',
+        code: 'ETIMEDOUT',
+      } as unknown as AxiosError
+
+      const error = new HttpError(axiosError)
+
+      await expect(requestErrorHandler($, error)).rejects.toThrow(
+        RetriableError,
+      )
+      await expect(requestErrorHandler($, error)).rejects.toMatchObject({
+        delayType: 'step',
+        delayInMs: 3000,
+      })
+    })
+
+    it('should not crash when HTTP error response data is missing', async () => {
+      const axiosError = {
+        isAxiosError: true,
+        name: 'AxiosError',
+        message: 'Request failed with status code 400',
+        response: {
+          status: 400,
+        },
+      } as unknown as AxiosError
+
+      const error = new HttpError(axiosError)
+
+      await expect(requestErrorHandler($, error)).rejects.toThrow(StepError)
+      await expect(requestErrorHandler($, error)).rejects.not.toThrow(TypeError)
+    })
   })
 })

--- a/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
+++ b/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
@@ -44,7 +44,7 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
     case 524: // Cloudflare-specific error
       return handle5xxErrors($, error)
     default:
-      if (error.message === 'read ETIMEDOUT') {
+      if (error.code === 'ETIMEDOUT' || error.message.includes('ETIMEDOUT')) {
         throw new RetriableError({
           error: `Retrying ${error.message} from Postman SMS`,
           // pausing the entire queue here is not a good idea because we wont be able to fully utilize
@@ -54,7 +54,7 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
         })
       }
 
-      if (error.response.data.error?.code === 'parameter_invalid') {
+      if (error.response.data?.error?.code === 'parameter_invalid') {
         throw new StepError(
           'Campaign template was not set up correctly',
           'Ensure that you have followed the instructions in our guide to set up your campaign template.',


### PR DESCRIPTION
**Based on DD bits AI**

Goal: Fix the Postman SMS request error handler so that connection ETIMEDOUT errors are properly retried instead of permanently failing with a TypeError crash.

Observed symptom: When postman.gov.sg has a connection timeout (ETIMEDOUT), the request error handler crashes with TypeError: Cannot read properties of undefined (reading 'error'), causing the job to be marked as UnrecoverableError (never retried). Trace: https://ogp.datadoghq.com/apm/trace/2325905269920620449

Evidence pointers:

packages/backend/src/apps/postman-sms/common/request-error-handler.ts — line 47 checks error.message === 'read ETIMEDOUT' (too narrow, misses connection timeouts). Line 57 accesses error.response.data.error?.code without guarding response.data being undefined.
packages/backend/src/errors/http.ts — constructor sets this.response.data = error.response?.data (undefined when no HTTP response), and this.code = error.code (preserves the Axios error code like 'ETIMEDOUT').
Tests at packages/backend/src/apps/postman-sms/__tests__/request-error-handler.test.ts
Root cause (confirmed): When a connection-level ETIMEDOUT occurs, HttpError has response.data = undefined and code = 'ETIMEDOUT'. The handler's message check at line 47 doesn't match (wrong string), then line 57 crashes on undefined.error.

Fix: In request-error-handler.ts:

Broaden the ETIMEDOUT check to also match connection timeouts (use error.code === 'ETIMEDOUT' or include it in the condition)
Add null safety on line 57: error.response.data?.error?.code