### PR TITLE
fix: unpublish leftover flow repeatable jobs after BullMQ upgrade

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -247,7 +247,6 @@ describe('updateFlowStatus', () => {
     })
 
     expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
-    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(fakeFlow.id)
     expect(result).toEqual(fakeFlow)
   })
 
@@ -267,7 +266,7 @@ describe('updateFlowStatus', () => {
       config: {},
       updatedBy: owner.id,
     })
-    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(fakeFlow.id)
+    expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
     expect(result).toEqual(fakeFlow)
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -247,6 +247,27 @@ describe('updateFlowStatus', () => {
     })
 
     expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
+    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(fakeFlow.id)
+    expect(result).toEqual(fakeFlow)
+  })
+
+  it('deactivates the flow even when no repeatable job is listed', async () => {
+    fakeFlow.active = true
+    flowQueue.getRepeatableJobs = vi.fn().mockResolvedValue([])
+
+    const result = await updateFlowStatus(
+      {},
+      { input: { ...defaultInput, active: false } },
+      context,
+    )
+
+    expect(patchSpy).toHaveBeenCalledWith({
+      active: false,
+      publishedAt: null,
+      config: {},
+      updatedBy: owner.id,
+    })
+    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(fakeFlow.id)
     expect(result).toEqual(fakeFlow)
   })
 

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -3,12 +3,15 @@ import {
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
 import {
-  addFlowRepeatableJob,
-  removeFlowRepeatableJobs,
-} from '@/queues/helpers/flow-repeatable-jobs'
+  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+  REMOVE_AFTER_30_DAYS,
+} from '@/helpers/default-job-configuration'
+import flowQueue from '@/queues/flow'
+import { removeFlowRepeatableJobs } from '@/queues/helpers/flow-repeatable-jobs'
 
 import type { MutationResolvers, Step } from '../__generated__/types.generated'
 
+const JOB_NAME = 'flow'
 const EVERY_15_MINUTES_CRON = '*/15 * * * *'
 
 const validateFlowSteps = (steps: Step[]) => {
@@ -74,7 +77,18 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
 
   if (trigger.type !== 'webhook') {
     if (params.input.active) {
-      await addFlowRepeatableJob(flow.id, repeatOptions.pattern)
+      const jobName = `${JOB_NAME}-${flow.id}`
+
+      await flowQueue.add(
+        jobName,
+        { flowId: flow.id },
+        {
+          repeat: repeatOptions,
+          jobId: flow.id,
+          removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+          removeOnFail: REMOVE_AFTER_30_DAYS,
+        },
+      )
     } else {
       await removeFlowRepeatableJobs(flow.id)
     }

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -3,14 +3,12 @@ import {
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
 import {
-  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-  REMOVE_AFTER_30_DAYS,
-} from '@/helpers/default-job-configuration'
-import flowQueue from '@/queues/flow'
+  addFlowRepeatableJob,
+  removeFlowRepeatableJobs,
+} from '@/queues/helpers/flow-repeatable-jobs'
 
 import type { MutationResolvers, Step } from '../__generated__/types.generated'
 
-const JOB_NAME = 'flow'
 const EVERY_15_MINUTES_CRON = '*/15 * * * *'
 
 const validateFlowSteps = (steps: Step[]) => {
@@ -76,23 +74,9 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
 
   if (trigger.type !== 'webhook') {
     if (params.input.active) {
-      const jobName = `${JOB_NAME}-${flow.id}`
-
-      await flowQueue.add(
-        jobName,
-        { flowId: flow.id },
-        {
-          repeat: repeatOptions,
-          jobId: flow.id,
-          removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-          removeOnFail: REMOVE_AFTER_30_DAYS,
-        },
-      )
+      await addFlowRepeatableJob(flow.id, repeatOptions.pattern)
     } else {
-      const repeatableJobs = await flowQueue.getRepeatableJobs()
-      const job = repeatableJobs.find((job) => job.id === flow.id)
-
-      await flowQueue.removeRepeatableByKey(job.key)
+      await removeFlowRepeatableJobs(flow.id)
     }
   }
 

--- a/packages/backend/src/queues/helpers/__tests__/flow-repeatable-jobs.test.ts
+++ b/packages/backend/src/queues/helpers/__tests__/flow-repeatable-jobs.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  addFlowRepeatableJob,
+  FLOW_REPEATABLE_JOB_NAME,
+  flowIdFromRepeatableJob,
+  getFlowRepeatableJobName,
+  isRepeatableJobForFlow,
+  reconcileInactiveFlowRepeatableJobs,
+  removeFlowRepeatableJobs,
+} from '../flow-repeatable-jobs'
+
+const FLOW_ID = '550e8400-e29b-41d4-a716-446655440000'
+const OTHER_FLOW_ID = '11111111-2222-4333-8444-555555555555'
+
+const mocks = vi.hoisted(() => ({
+  add: vi.fn(),
+  getRepeatableJobs: vi.fn(),
+  removeRepeatableByKey: vi.fn(),
+  removeJobScheduler: vi.fn(),
+  getJobSchedulers: vi.fn(),
+  waitUntilReady: vi.fn(),
+  flowQuery: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+vi.mock('@/queues/flow', () => ({
+  default: {
+    add: mocks.add,
+    getRepeatableJobs: mocks.getRepeatableJobs,
+    removeRepeatableByKey: mocks.removeRepeatableByKey,
+    removeJobScheduler: mocks.removeJobScheduler,
+    getJobSchedulers: mocks.getJobSchedulers,
+    waitUntilReady: mocks.waitUntilReady,
+  },
+}))
+
+vi.mock('@/models/flow', () => ({
+  default: {
+    query: mocks.flowQuery,
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: mocks.logInfo,
+  },
+}))
+
+describe('flow-repeatable-jobs', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.getRepeatableJobs.mockResolvedValue([])
+    mocks.getJobSchedulers.mockResolvedValue([])
+    mocks.removeRepeatableByKey.mockResolvedValue(undefined)
+    mocks.removeJobScheduler.mockResolvedValue(undefined)
+    mocks.add.mockResolvedValue(undefined)
+    mocks.waitUntilReady.mockResolvedValue(undefined)
+  })
+
+  describe('isRepeatableJobForFlow', () => {
+    it('matches the pre-5.10 job.id field', () => {
+      expect(
+        isRepeatableJobForFlow(
+          { key: 'other', id: FLOW_ID, name: 'unrelated' },
+          FLOW_ID,
+        ),
+      ).toBe(true)
+    })
+
+    it('matches the job name used when publishing', () => {
+      expect(
+        isRepeatableJobForFlow(
+          {
+            key: 'md5-hash-without-uuid',
+            name: getFlowRepeatableJobName(FLOW_ID),
+          },
+          FLOW_ID,
+        ),
+      ).toBe(true)
+    })
+
+    it('matches a custom scheduler key equal to the flow id', () => {
+      expect(isRepeatableJobForFlow({ key: FLOW_ID }, FLOW_ID)).toBe(true)
+    })
+
+    it('matches legacy concat keys even when id and name are missing', () => {
+      expect(
+        isRepeatableJobForFlow(
+          { key: `flow-${FLOW_ID}:${FLOW_ID}:::*/15 * * * *` },
+          FLOW_ID,
+        ),
+      ).toBe(true)
+    })
+
+    it('does not match a different flow', () => {
+      expect(
+        isRepeatableJobForFlow(
+          {
+            key: `flow-${OTHER_FLOW_ID}:${OTHER_FLOW_ID}:::0 * * * *`,
+            id: OTHER_FLOW_ID,
+            name: getFlowRepeatableJobName(OTHER_FLOW_ID),
+          },
+          FLOW_ID,
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('flowIdFromRepeatableJob', () => {
+    it('prefers job.id', () => {
+      expect(
+        flowIdFromRepeatableJob({
+          key: 'ignored',
+          id: FLOW_ID,
+          name: getFlowRepeatableJobName(OTHER_FLOW_ID),
+        }),
+      ).toBe(FLOW_ID)
+    })
+
+    it('parses the published job name', () => {
+      expect(
+        flowIdFromRepeatableJob({
+          key: 'md5-hash',
+          name: getFlowRepeatableJobName(FLOW_ID),
+        }),
+      ).toBe(FLOW_ID)
+    })
+
+    it('parses a legacy concat key', () => {
+      expect(
+        flowIdFromRepeatableJob({
+          key: `flow-${FLOW_ID}:${FLOW_ID}:::0 * * * *`,
+        }),
+      ).toBe(FLOW_ID)
+    })
+  })
+
+  describe('addFlowRepeatableJob', () => {
+    it('enqueues a repeatable job named after the flow', async () => {
+      await addFlowRepeatableJob(FLOW_ID, '0 * * * *')
+
+      expect(mocks.add).toHaveBeenCalledWith(
+        `${FLOW_REPEATABLE_JOB_NAME}-${FLOW_ID}`,
+        { flowId: FLOW_ID },
+        expect.objectContaining({
+          repeat: { pattern: '0 * * * *' },
+          jobId: FLOW_ID,
+        }),
+      )
+    })
+  })
+
+  describe('removeFlowRepeatableJobs', () => {
+    it('removes every matching leftover key, not only job.id', async () => {
+      mocks.getRepeatableJobs.mockResolvedValue([
+        { key: 'md5-hash', name: getFlowRepeatableJobName(FLOW_ID) },
+        {
+          key: `flow-${FLOW_ID}:${FLOW_ID}:::*/15 * * * *`,
+        },
+        {
+          key: `flow-${OTHER_FLOW_ID}:${OTHER_FLOW_ID}:::0 * * * *`,
+          id: OTHER_FLOW_ID,
+        },
+      ])
+
+      await removeFlowRepeatableJobs(FLOW_ID)
+
+      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith('md5-hash')
+      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(
+        `flow-${FLOW_ID}:${FLOW_ID}:::*/15 * * * *`,
+      )
+      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(FLOW_ID)
+      expect(mocks.removeRepeatableByKey).not.toHaveBeenCalledWith(
+        `flow-${OTHER_FLOW_ID}:${OTHER_FLOW_ID}:::0 * * * *`,
+      )
+      expect(mocks.removeJobScheduler).toHaveBeenCalledWith('md5-hash')
+      expect(mocks.removeJobScheduler).toHaveBeenCalledWith(FLOW_ID)
+    })
+
+    it('still tries the flow id when nothing is listed', async () => {
+      await removeFlowRepeatableJobs(FLOW_ID)
+
+      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(FLOW_ID)
+      expect(mocks.removeJobScheduler).toHaveBeenCalledWith(FLOW_ID)
+    })
+  })
+
+  describe('reconcileInactiveFlowRepeatableJobs', () => {
+    it('removes leftover jobs whose flows are inactive or missing', async () => {
+      mocks.getRepeatableJobs.mockResolvedValue([
+        {
+          key: 'active-key',
+          id: FLOW_ID,
+          name: getFlowRepeatableJobName(FLOW_ID),
+        },
+        {
+          key: 'inactive-key',
+          id: OTHER_FLOW_ID,
+          name: getFlowRepeatableJobName(OTHER_FLOW_ID),
+        },
+      ])
+      mocks.flowQuery.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          whereIn: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: FLOW_ID }]),
+          }),
+        }),
+      })
+
+      const removed = await reconcileInactiveFlowRepeatableJobs()
+
+      expect(removed).toBe(1)
+      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith('inactive-key')
+      expect(mocks.removeRepeatableByKey).not.toHaveBeenCalledWith('active-key')
+    })
+  })
+})

--- a/packages/backend/src/queues/helpers/__tests__/flow-repeatable-jobs.test.ts
+++ b/packages/backend/src/queues/helpers/__tests__/flow-repeatable-jobs.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  addFlowRepeatableJob,
   FLOW_REPEATABLE_JOB_NAME,
   flowIdFromRepeatableJob,
   getFlowRepeatableJobName,
@@ -14,11 +13,8 @@ const FLOW_ID = '550e8400-e29b-41d4-a716-446655440000'
 const OTHER_FLOW_ID = '11111111-2222-4333-8444-555555555555'
 
 const mocks = vi.hoisted(() => ({
-  add: vi.fn(),
   getRepeatableJobs: vi.fn(),
   removeRepeatableByKey: vi.fn(),
-  removeJobScheduler: vi.fn(),
-  getJobSchedulers: vi.fn(),
   waitUntilReady: vi.fn(),
   flowQuery: vi.fn(),
   logInfo: vi.fn(),
@@ -26,11 +22,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/queues/flow', () => ({
   default: {
-    add: mocks.add,
     getRepeatableJobs: mocks.getRepeatableJobs,
     removeRepeatableByKey: mocks.removeRepeatableByKey,
-    removeJobScheduler: mocks.removeJobScheduler,
-    getJobSchedulers: mocks.getJobSchedulers,
     waitUntilReady: mocks.waitUntilReady,
   },
 }))
@@ -51,10 +44,7 @@ describe('flow-repeatable-jobs', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mocks.getRepeatableJobs.mockResolvedValue([])
-    mocks.getJobSchedulers.mockResolvedValue([])
     mocks.removeRepeatableByKey.mockResolvedValue(undefined)
-    mocks.removeJobScheduler.mockResolvedValue(undefined)
-    mocks.add.mockResolvedValue(undefined)
     mocks.waitUntilReady.mockResolvedValue(undefined)
   })
 
@@ -78,10 +68,6 @@ describe('flow-repeatable-jobs', () => {
           FLOW_ID,
         ),
       ).toBe(true)
-    })
-
-    it('matches a custom scheduler key equal to the flow id', () => {
-      expect(isRepeatableJobForFlow({ key: FLOW_ID }, FLOW_ID)).toBe(true)
     })
 
     it('matches legacy concat keys even when id and name are missing', () => {
@@ -136,25 +122,13 @@ describe('flow-repeatable-jobs', () => {
     })
   })
 
-  describe('addFlowRepeatableJob', () => {
-    it('enqueues a repeatable job named after the flow', async () => {
-      await addFlowRepeatableJob(FLOW_ID, '0 * * * *')
-
-      expect(mocks.add).toHaveBeenCalledWith(
-        `${FLOW_REPEATABLE_JOB_NAME}-${FLOW_ID}`,
-        { flowId: FLOW_ID },
-        expect.objectContaining({
-          repeat: { pattern: '0 * * * *' },
-          jobId: FLOW_ID,
-        }),
-      )
-    })
-  })
-
   describe('removeFlowRepeatableJobs', () => {
     it('removes every matching leftover key, not only job.id', async () => {
       mocks.getRepeatableJobs.mockResolvedValue([
-        { key: 'md5-hash', name: getFlowRepeatableJobName(FLOW_ID) },
+        {
+          key: 'md5-hash',
+          name: `${FLOW_REPEATABLE_JOB_NAME}-${FLOW_ID}`,
+        },
         {
           key: `flow-${FLOW_ID}:${FLOW_ID}:::*/15 * * * *`,
         },
@@ -170,19 +144,15 @@ describe('flow-repeatable-jobs', () => {
       expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(
         `flow-${FLOW_ID}:${FLOW_ID}:::*/15 * * * *`,
       )
-      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(FLOW_ID)
       expect(mocks.removeRepeatableByKey).not.toHaveBeenCalledWith(
         `flow-${OTHER_FLOW_ID}:${OTHER_FLOW_ID}:::0 * * * *`,
       )
-      expect(mocks.removeJobScheduler).toHaveBeenCalledWith('md5-hash')
-      expect(mocks.removeJobScheduler).toHaveBeenCalledWith(FLOW_ID)
     })
 
-    it('still tries the flow id when nothing is listed', async () => {
+    it('does nothing when no matching job is listed', async () => {
       await removeFlowRepeatableJobs(FLOW_ID)
 
-      expect(mocks.removeRepeatableByKey).toHaveBeenCalledWith(FLOW_ID)
-      expect(mocks.removeJobScheduler).toHaveBeenCalledWith(FLOW_ID)
+      expect(mocks.removeRepeatableByKey).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/backend/src/queues/helpers/flow-repeatable-jobs.ts
+++ b/packages/backend/src/queues/helpers/flow-repeatable-jobs.ts
@@ -1,9 +1,3 @@
-import type { QueuePro } from '@taskforcesh/bullmq-pro'
-
-import {
-  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-  REMOVE_AFTER_30_DAYS,
-} from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import flowQueue from '@/queues/flow'
@@ -16,36 +10,19 @@ export type FlowRepeatableJobLike = {
   name?: string | null
 }
 
-type JobSchedulerQueue = {
-  removeJobScheduler: (schedulerId: string) => Promise<unknown>
-  getJobSchedulers: () => Promise<FlowRepeatableJobLike[]>
-}
-
 export function getFlowRepeatableJobName(flowId: string): string {
   return `${FLOW_REPEATABLE_JOB_NAME}-${flowId}`
 }
 
-function asJobSchedulerQueue(queue: QueuePro): JobSchedulerQueue | null {
-  const candidate = queue as QueuePro & Partial<JobSchedulerQueue>
-  if (typeof candidate.removeJobScheduler !== 'function') {
-    return null
-  }
-  return candidate as JobSchedulerQueue
-}
-
 /**
- * BullMQ 5.10+ (bullmq-pro 7.44) stopped putting the custom `jobId` on
- * listed jobs. Match every leftover key format so unpublish still works.
+ * BullMQ 5.10+ stopped putting the custom `jobId` on listed jobs.
+ * Match leftover 7.8.1 keys as well as post-upgrade keys.
  */
 export function isRepeatableJobForFlow(
   job: FlowRepeatableJobLike,
   flowId: string,
 ): boolean {
-  if (
-    job.id === flowId ||
-    job.name === getFlowRepeatableJobName(flowId) ||
-    job.key === flowId
-  ) {
+  if (job.id === flowId || job.name === getFlowRepeatableJobName(flowId)) {
     return true
   }
 
@@ -71,67 +48,18 @@ export function flowIdFromRepeatableJob(
   return null
 }
 
-async function listRepeatableJobs(
-  queue: QueuePro,
-): Promise<FlowRepeatableJobLike[]> {
-  const jobs = await queue.getRepeatableJobs()
-  const byKey = new Map<string, FlowRepeatableJobLike>(
-    jobs.map((job) => [job.key, job]),
-  )
-
-  const schedulerQueue = asJobSchedulerQueue(queue)
-  if (schedulerQueue) {
-    const schedulers = await schedulerQueue.getJobSchedulers()
-    for (const scheduler of schedulers) {
-      if (!byKey.has(scheduler.key)) {
-        byKey.set(scheduler.key, scheduler)
-      }
-    }
-  }
-
-  return [...byKey.values()]
-}
-
-export async function addFlowRepeatableJob(
-  flowId: string,
-  pattern: string,
-): Promise<void> {
-  await flowQueue.add(
-    getFlowRepeatableJobName(flowId),
-    { flowId },
-    {
-      // Custom repeat.key is a 5.10+ feature. Setting it on 7.8.1 changes
-      // delayed job ids without changing the zset member, so removal misses
-      // the already-scheduled job.
-      repeat: { pattern },
-      jobId: flowId,
-      removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-      removeOnFail: REMOVE_AFTER_30_DAYS,
-    },
-  )
-}
-
 export async function removeFlowRepeatableJobs(flowId: string): Promise<void> {
-  const jobs = await listRepeatableJobs(flowQueue)
+  const jobs = await flowQueue.getRepeatableJobs()
   const matching = jobs.filter((job) => isRepeatableJobForFlow(job, flowId))
-  const keys = new Set(matching.map((job) => job.key))
-  keys.add(flowId)
 
-  for (const key of keys) {
-    await flowQueue.removeRepeatableByKey(key)
-  }
-
-  const schedulerQueue = asJobSchedulerQueue(flowQueue)
-  if (schedulerQueue) {
-    for (const key of keys) {
-      await schedulerQueue.removeJobScheduler(key)
-    }
+  for (const job of matching) {
+    await flowQueue.removeRepeatableByKey(job.key)
   }
 }
 
 export async function reconcileInactiveFlowRepeatableJobs(): Promise<number> {
   await flowQueue.waitUntilReady()
-  const jobs = await listRepeatableJobs(flowQueue)
+  const jobs = await flowQueue.getRepeatableJobs()
   const flowIds = [
     ...new Set(
       jobs

--- a/packages/backend/src/queues/helpers/flow-repeatable-jobs.ts
+++ b/packages/backend/src/queues/helpers/flow-repeatable-jobs.ts
@@ -1,0 +1,177 @@
+import type { QueuePro } from '@taskforcesh/bullmq-pro'
+
+import {
+  REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+  REMOVE_AFTER_30_DAYS,
+} from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import flowQueue from '@/queues/flow'
+
+export const FLOW_REPEATABLE_JOB_NAME = 'flow'
+
+export type FlowRepeatableJobLike = {
+  key: string
+  id?: string | null
+  name?: string | null
+}
+
+type JobSchedulerQueue = {
+  removeJobScheduler: (schedulerId: string) => Promise<unknown>
+  getJobSchedulers: () => Promise<FlowRepeatableJobLike[]>
+}
+
+export function getFlowRepeatableJobName(flowId: string): string {
+  return `${FLOW_REPEATABLE_JOB_NAME}-${flowId}`
+}
+
+function asJobSchedulerQueue(queue: QueuePro): JobSchedulerQueue | null {
+  const candidate = queue as QueuePro & Partial<JobSchedulerQueue>
+  if (typeof candidate.removeJobScheduler !== 'function') {
+    return null
+  }
+  return candidate as JobSchedulerQueue
+}
+
+/**
+ * BullMQ 5.10+ (bullmq-pro 7.44) stopped putting the custom `jobId` on
+ * listed jobs. Match every leftover key format so unpublish still works.
+ */
+export function isRepeatableJobForFlow(
+  job: FlowRepeatableJobLike,
+  flowId: string,
+): boolean {
+  if (
+    job.id === flowId ||
+    job.name === getFlowRepeatableJobName(flowId) ||
+    job.key === flowId
+  ) {
+    return true
+  }
+
+  return typeof job.key === 'string' && job.key.includes(flowId)
+}
+
+export function flowIdFromRepeatableJob(
+  job: FlowRepeatableJobLike,
+): string | null {
+  if (job.id) {
+    return job.id
+  }
+
+  if (job.name?.startsWith(`${FLOW_REPEATABLE_JOB_NAME}-`)) {
+    return job.name.slice(FLOW_REPEATABLE_JOB_NAME.length + 1) || null
+  }
+
+  const legacyMatch = job.key?.match(/^flow-([0-9a-f-]{36})/i)
+  if (legacyMatch) {
+    return legacyMatch[1]
+  }
+
+  return null
+}
+
+async function listRepeatableJobs(
+  queue: QueuePro,
+): Promise<FlowRepeatableJobLike[]> {
+  const jobs = await queue.getRepeatableJobs()
+  const byKey = new Map<string, FlowRepeatableJobLike>(
+    jobs.map((job) => [job.key, job]),
+  )
+
+  const schedulerQueue = asJobSchedulerQueue(queue)
+  if (schedulerQueue) {
+    const schedulers = await schedulerQueue.getJobSchedulers()
+    for (const scheduler of schedulers) {
+      if (!byKey.has(scheduler.key)) {
+        byKey.set(scheduler.key, scheduler)
+      }
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+export async function addFlowRepeatableJob(
+  flowId: string,
+  pattern: string,
+): Promise<void> {
+  await flowQueue.add(
+    getFlowRepeatableJobName(flowId),
+    { flowId },
+    {
+      // Custom repeat.key is a 5.10+ feature. Setting it on 7.8.1 changes
+      // delayed job ids without changing the zset member, so removal misses
+      // the already-scheduled job.
+      repeat: { pattern },
+      jobId: flowId,
+      removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+      removeOnFail: REMOVE_AFTER_30_DAYS,
+    },
+  )
+}
+
+export async function removeFlowRepeatableJobs(flowId: string): Promise<void> {
+  const jobs = await listRepeatableJobs(flowQueue)
+  const matching = jobs.filter((job) => isRepeatableJobForFlow(job, flowId))
+  const keys = new Set(matching.map((job) => job.key))
+  keys.add(flowId)
+
+  for (const key of keys) {
+    await flowQueue.removeRepeatableByKey(key)
+  }
+
+  const schedulerQueue = asJobSchedulerQueue(flowQueue)
+  if (schedulerQueue) {
+    for (const key of keys) {
+      await schedulerQueue.removeJobScheduler(key)
+    }
+  }
+}
+
+export async function reconcileInactiveFlowRepeatableJobs(): Promise<number> {
+  await flowQueue.waitUntilReady()
+  const jobs = await listRepeatableJobs(flowQueue)
+  const flowIds = [
+    ...new Set(
+      jobs
+        .map((job) => flowIdFromRepeatableJob(job))
+        .filter((flowId): flowId is string => flowId !== null),
+    ),
+  ]
+
+  if (flowIds.length === 0) {
+    return 0
+  }
+
+  const activeFlows = await Flow.query()
+    .select('id')
+    .whereIn('id', flowIds)
+    .where('active', true)
+  const activeIds = new Set(activeFlows.map((flow) => flow.id))
+
+  const processedFlowIds = new Set<string>()
+  let removed = 0
+  for (const job of jobs) {
+    const flowId = flowIdFromRepeatableJob(job)
+    if (!flowId || activeIds.has(flowId) || processedFlowIds.has(flowId)) {
+      continue
+    }
+
+    processedFlowIds.add(flowId)
+    await removeFlowRepeatableJobs(flowId)
+    removed += 1
+  }
+
+  if (removed > 0) {
+    logger.info(
+      'Removed leftover repeatable jobs for inactive or deleted flows',
+      {
+        event: 'flow-repeatable-jobs-reconciled',
+        removed,
+      },
+    )
+  }
+
+  return removed
+}

--- a/packages/backend/src/worker.ts
+++ b/packages/backend/src/worker.ts
@@ -8,8 +8,15 @@ import '@/workers/action'
 
 import logger from '@/helpers/logger'
 import { startSesConsumer } from '@/helpers/ses-consumer'
+import { reconcileInactiveFlowRepeatableJobs } from '@/queues/helpers/flow-repeatable-jobs'
 
 startSesConsumer()
+
+void reconcileInactiveFlowRepeatableJobs().catch((err) => {
+  logger.error('Failed to reconcile leftover flow repeatable jobs', {
+    err: err instanceof Error ? err.stack : err,
+  })
+})
 
 process.on('uncaughtException', (err) => {
   try {

--- a/packages/backend/src/workers/__tests__/flow.itest.ts
+++ b/packages/backend/src/workers/__tests__/flow.itest.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   logInfo: vi.fn(),
   logError: vi.fn(),
   flowQueryResult: vi.fn(() => ({
+    active: true,
     getTriggerStep: vi.fn(async () => ({})),
   })),
 }))
@@ -87,6 +88,34 @@ describe('Flow worker', () => {
 
       expect(mocks.logInfo).toHaveBeenCalledWith(
         `JOB ID: ${job.id} - FLOW ID: test-flow-id has started!`,
+      )
+    })
+
+    it('skips inactive flows and does not process them', async () => {
+      mocks.flowQueryResult.mockReturnValue({
+        active: false,
+        getTriggerStep: vi.fn(async () => ({})),
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        flowWorker.on('completed', async (_) => {
+          resolve()
+        })
+      })
+      const job = await flowQueue.add(
+        'test-job',
+        {
+          flowId: 'test-flow-id',
+        },
+        {
+          jobId: 'test-inactive-job-id',
+        },
+      )
+      await jobProcessed
+
+      expect(mocks.processFlow).not.toHaveBeenCalled()
+      expect(mocks.logInfo).toHaveBeenCalledWith(
+        `JOB ID: ${job.id} - FLOW ID: test-flow-id skipped because the flow is inactive`,
       )
     })
 

--- a/packages/backend/src/workers/__tests__/flow.itest.ts
+++ b/packages/backend/src/workers/__tests__/flow.itest.ts
@@ -102,7 +102,7 @@ describe('Flow worker', () => {
           resolve()
         })
       })
-      const job = await flowQueue.add(
+      await flowQueue.add(
         'test-job',
         {
           flowId: 'test-flow-id',
@@ -114,9 +114,6 @@ describe('Flow worker', () => {
       await jobProcessed
 
       expect(mocks.processFlow).not.toHaveBeenCalled()
-      expect(mocks.logInfo).toHaveBeenCalledWith(
-        `JOB ID: ${job.id} - FLOW ID: test-flow-id skipped because the flow is inactive`,
-      )
     })
 
     it('logs an error on job failure', async () => {

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -7,7 +7,6 @@ import {
 } from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
-import { removeFlowRepeatableJobs } from '@/queues/helpers/flow-repeatable-jobs'
 import triggerQueue from '@/queues/trigger'
 import { processFlow } from '@/services/flow'
 
@@ -18,11 +17,6 @@ export const worker = new WorkerPro(
 
     const flow = await Flow.query().findById(flowId).throwIfNotFound()
     if (!flow.active) {
-      // Leftover schedules from pre-5.10 keys keep firing after unpublish.
-      await removeFlowRepeatableJobs(flowId)
-      logger.info(
-        `JOB ID: ${job.id} - FLOW ID: ${flowId} skipped because the flow is inactive`,
-      )
       return
     }
 

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -7,6 +7,7 @@ import {
 } from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
+import { removeFlowRepeatableJobs } from '@/queues/helpers/flow-repeatable-jobs'
 import triggerQueue from '@/queues/trigger'
 import { processFlow } from '@/services/flow'
 
@@ -16,6 +17,15 @@ export const worker = new WorkerPro(
     const { flowId } = job.data
 
     const flow = await Flow.query().findById(flowId).throwIfNotFound()
+    if (!flow.active) {
+      // Leftover schedules from pre-5.10 keys keep firing after unpublish.
+      await removeFlowRepeatableJobs(flowId)
+      logger.info(
+        `JOB ID: ${job.id} - FLOW ID: ${flowId} skipped because the flow is inactive`,
+      )
+      return
+    }
+
     const triggerStep = await flow.getTriggerStep()
 
     const { data, error } = await processFlow({ flowId })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Unpublishing a cron pipe only looked up `repeatableJobs.find((job) => job.id === flow.id)`. That works on bullmq-pro 7.8.1 (bullmq 5.7.8). BullMQ 5.10+ (what 7.44.0 vendors) no longer puts the custom `jobId` on listed jobs, so unpublish cannot find them.

Unpublish before the upgrade can also leave a delayed iteration. After upgrade that job is rescheduled under the new key format. If the flow is already inactive, a retry never reaches Redis (`if (flow.active === params.input.active) return flow`).

## What

Keep using `Queue.add({ repeat })`, `getRepeatableJobs()`, and `removeRepeatableByKey()`. No job schedulers.

- Publish is unchanged.
- Unpublish removes every listed job whose `id`, `name` (`flow-{id}`), or key belongs to that flow. That covers 7.8.1 concat keys and post-upgrade hashed keys.
- Worker skips processing if the flow is inactive, so a leftover tick cannot run an unpublished pipe.
- Worker start reconciles Redis against `flows.active`, which strips leftovers for pipes that were already unpublished before deploy.

## Upgrade order

1. Deploy this on 7.8.1.
2. Restart workers so reconcile strips leftover jobs for inactive pipes.
3. Then bump `@taskforcesh/bullmq-pro` 7.8.1 → 7.44.0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-734c7ff8-9d6e-4504-ab9c-985b75bba3cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-734c7ff8-9d6e-4504-ab9c-985b75bba3cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

