### PR TITLE
[BUG-BASH-8] fix: surface variable types to AI Builder for-each selection

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -49,7 +49,7 @@ export function createMcpBridgeTools(
   return {
     list_apps: tool<ListAppsInput, IMcpApp[]>({
       description:
-        'List all available Plumber apps, triggers, and actions with their field schemas.',
+        "List all available Plumber apps, triggers, and actions with their field schemas. A field's variableTypes, when present, restricts it to upstream variables whose execute_step dataOutMetadata type matches one of the listed values.",
       inputSchema: z.object({}),
       execute: async (): Promise<IMcpApp[]> => {
         return listAppsService(user)
@@ -221,7 +221,7 @@ export function createMcpBridgeTools(
 
     execute_step: tool({
       description:
-        'Test a configured step in a pipe. Runs the step, marks it as completed on success, and returns its output data. Call after update_step_parameters to verify the step works. The returned dataOut will be used to wire variables into downstream steps. Warning: for steps that send a real message (SMS by Postman sendSms, Telegram sendMessage, Slack sendMessageToChannel, PaySG sendEmail), this actually sends it to the configured recipient/channel/number — confirm the details with the user before calling this for those steps.',
+        "Test a configured step in a pipe. Runs the step, marks it as completed on success, and returns its output data. Call after update_step_parameters to verify the step works. The returned dataOut will be used to wire variables into downstream steps; dataOutMetadata tags each dataOut key with a type (e.g. 'array', 'table') — cross-check this against a downstream field's variableTypes (from list_apps) before templating a {{step.X.path}} reference into that field. Warning: for steps that send a real message (SMS by Postman sendSms, Telegram sendMessage, Slack sendMessageToChannel, PaySG sendEmail), this actually sends it to the configured recipient/channel/number — confirm the details with the user before calling this for those steps.",
       inputSchema: z.object({
         step_id: z.uuid().describe('ID of the step to test'),
       }),

--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -103,6 +103,13 @@ vi.mock('@/apps', () => ({
               },
             },
             {
+              key: 'rowId',
+              label: 'Row',
+              type: 'string',
+              required: true,
+              variableTypes: ['tile_row_id'],
+            },
+            {
               key: 'rowData',
               label: 'Row data',
               type: 'multirow-multicol',
@@ -369,6 +376,24 @@ describe('listAppsService', () => {
         'field',
         'text',
       ])
+    })
+  })
+
+  describe('variableTypes', () => {
+    it('exposes variableTypes when the field declares them', async () => {
+      const apps = await listAppsService(user)
+      const tiles = apps.find((a) => a.key === 'tiles')
+      const rowIdField = tiles?.actions[0].fields.find((f) => f.key === 'rowId')
+      expect(rowIdField?.variableTypes).toEqual(['tile_row_id'])
+    })
+
+    it('omits variableTypes when the field does not declare them', async () => {
+      const apps = await listAppsService(user)
+      const tiles = apps.find((a) => a.key === 'tiles')
+      const tableIdField = tiles?.actions[0].fields.find(
+        (f) => f.key === 'tableId',
+      )
+      expect(tableIdField?.variableTypes).toBeUndefined()
     })
   })
 

--- a/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import apps from '@/apps'
 import Execution from '@/models/execution'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
@@ -110,6 +111,13 @@ describe('executeStepService', () => {
       dataOut: { output: 'data' },
       errorDetails: null,
     })
+    // postman's sendTransactionalEmail declares a getDataOutMetadata that
+    // tags `recipient`/`status`/`cc` as 'array' typed outputs.
+    expect(result.dataOutMetadata).toMatchObject({
+      recipient: { type: 'array' },
+      status: { type: 'array' },
+      cc: { type: 'array' },
+    })
 
     const updated = await Step.query().findById(actionStep.id)
     expect(updated.status).toBe('completed')
@@ -146,9 +154,39 @@ describe('executeStepService', () => {
     expect(result.errorDetails).toMatchObject({
       message: 'Invalid credentials',
     })
+    // dataOut is null, so getDataOutMetadata has nothing to tag types for.
+    expect(result.dataOutMetadata).toBeNull()
 
     const unchanged = await Step.query().findById(actionStep.id)
     expect(unchanged.status).not.toBe('completed')
+  })
+
+  it('returns dataOutMetadata:null (instead of throwing) when getDataOutMetadata fails', async () => {
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+
+    const execution = await Execution.query().insertAndFetch({
+      id: randomUUID(),
+      flowId: flow.id,
+    })
+    const execStep = makeExecutionStep({ dataOut: { output: 'data' } })
+    mocks.testStep.mockResolvedValueOnce({
+      executionStep: execStep,
+      executionId: execution.id,
+    })
+
+    const sendEmailAction = apps.postman.actions.find(
+      (a) => a.key === 'sendTransactionalEmail',
+    )
+    const getDataOutMetadataSpy = vi
+      .spyOn(sendEmailAction, 'getDataOutMetadata')
+      .mockRejectedValueOnce(new Error('schema mismatch'))
+
+    const result = await executeStepService(user, actionStep.id)
+
+    expect(result.success).toBe(true)
+    expect(result.dataOutMetadata).toBeNull()
+
+    getDataOutMetadataSpy.mockRestore()
   })
 
   it('throws if the pipe is active', async () => {

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -44,6 +44,10 @@ function serializeField(
     required: field.required ?? false,
   }
 
+  if ('variableTypes' in field && field.variableTypes?.length) {
+    base.variableTypes = field.variableTypes
+  }
+
   if (field.type === 'dropdown') {
     if (field.options?.length && !field.source) {
       base.options = mapOptions(field.options)

--- a/packages/backend/src/services/mcp/execute-step.ts
+++ b/packages/backend/src/services/mcp/execute-step.ts
@@ -1,7 +1,8 @@
-import type { IJSONObject } from '@plumber/types'
+import type { IDataOutMetadata, IJSONObject } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import type User from '@/models/user'
 import testStep from '@/services/test-step'
@@ -12,6 +13,7 @@ export interface McpExecuteStepResult {
   stepId: string
   executionStepId: string
   dataOut: IJSONObject | null
+  dataOutMetadata: IDataOutMetadata | null
   errorDetails: IJSONObject | null
 }
 
@@ -51,12 +53,28 @@ export async function executeStepService(
     })
   }
 
+  const command = step.isAction
+    ? await step.getActionCommand()
+    : await step.getTriggerCommand()
+  const dataOutMetadata: IDataOutMetadata | null = await (
+    command?.getDataOutMetadata?.(executionStep) ?? Promise.resolve(null)
+  ).catch((error: Error): IDataOutMetadata | null => {
+    logger.warn('executeStepService: failed to get dataOut metadata', {
+      stepId: step.id,
+      appKey: step.appKey,
+      key: step.key,
+      error: error.message,
+    })
+    return null
+  })
+
   return {
     success: !executionStep.isFailed,
     pipeId: step.flowId,
     stepId: step.id,
     executionStepId: executionStep.id,
     dataOut: executionStep.dataOut ?? null,
+    dataOutMetadata,
     errorDetails: executionStep.errorDetails ?? null,
   }
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1365,6 +1365,12 @@ export interface IMcpAppField {
   subFields?: IMcpAppField[]
   maxGroups?: number
   maxRowsPerGroup?: number
+  /**
+   * If set, this field only accepts a variable reference whose upstream
+   * output is tagged with one of these types (see `IDataOutMetadatum.type`,
+   * surfaced per-step via `execute_step`'s `dataOutMetadata`).
+   */
+  variableTypes?: TDataOutMetadatumType[]
 }
 
 export interface IMcpAppAction {


### PR DESCRIPTION
## TL;DR

The AI Builder couldn't reliably pick the right variable for fields that restrict input to specific types (e.g. For-each's `items` field only accepts `array`/`table` outputs) because the LLM never saw those type constraints. This surfaces them through the existing MCP tools.

## What changed?

- `list_apps`: `serializeField()` now copies a field's `variableTypes` (e.g. For-each's `['array', 'table']`) into the schema sent to the LLM.
- `execute_step`: now calls the app's `getDataOutMetadata()` (already used by the frontend's variable picker via GraphQL) and returns it as `dataOutMetadata`, so the LLM can see which upstream output keys are `array`/`table`-typed. The call is wrapped so a metadata-schema mismatch can't fail an otherwise-successful step test — falls back to `null` and logs a warning instead.
- Updated the `list_apps`/`execute_step` tool descriptions in `mcp-bridge-tools.ts` to tell the LLM to cross-check `variableTypes` against `dataOutMetadata` before templating a `{{step.X.path}}` reference.
- Left an updated prompt draft (`chat_v158.md`, untracked/gitignored) with the actual instruction text and user-facing phrasing for when no compatible variable exists — publishing it to Langfuse is a manual follow-up outside this repo.

## Tests (manual)

- [ ] In the AI Builder chat, build a flow with "Find multiple rows" (or "Find multiple table rows") → For-each, and confirm the assistant correctly wires the rows step's output into For-each's `items` instead of guessing or asking you to pick manually.
- [ ] Confirm a step whose output can't satisfy a `variableTypes`-restricted field (e.g. a single-row action feeding into For-each) gets a plain-language nudge to add the right kind of step, not raw type/variable jargon.

## Deploy notes

None — additive fields on existing MCP tool responses, no schema/migration changes.
