### PR TITLE
docs: add Cursor Cloud environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+Plumber is a no-code workflow automation monorepo. See [.claude/CLAUDE.md](.claude/CLAUDE.md) for
+architecture, conventions, and the standard dev loop. See [README.md](README.md) for local setup.
+
+## Cursor Cloud specific instructions
+
+These notes cover non-obvious startup and run caveats for this Cloud Agent environment.
+The base image already provides Node 22.19.0 (via nvm), npm 11.19.0, and Docker with the
+compose plugin. The startup update script runs `npm ci` from the repo root.
+
+### Required secret
+
+`npm ci` needs `NPM_TASKFORCESH_TOKEN`. The `.npmrc` authenticates the private
+`@taskforcesh/bullmq-pro` package against `npm.taskforce.sh`. Without this token the install
+fails with `401 Unauthorized`. Add it as a Cloud Agent secret.
+
+### Start Docker before bringing up services
+
+The Docker daemon does not auto-start on boot. Start it once per session before `npm run setup`:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+sudo chmod 666 /var/run/docker.sock
+```
+
+`docker-compose` is a shim at `/usr/local/bin/docker-compose` that calls `docker compose`.
+The npm scripts invoke `docker-compose`, so keep this shim available.
+
+### Infra services
+
+`npm run setup` starts Postgres (5432), tiles-postgres (5431), Redis (6379), MinIO (9000 API,
+9001 console), and DynamoDB Local (8000). The `tunnel` service needs `CLOUDFLARE_TOKEN` and is
+optional. Local webhooks can POST directly to `http://localhost:3000/webhooks/<flow-id>`.
+
+Run `npm run migrate` once to apply main Postgres migrations. The backend `postsetup` hook
+creates the local DynamoDB tile table.
+
+### Run the app
+
+`npm run dev` runs the backend (`:3000`), the BullMQ worker, and the Vite frontend (`:3001`)
+together. Vite proxies `/graphql`, `/api`, and `/apps` to `:3000`. Restart `npm run dev` after
+backend changes. The frontend hot-reloads on its own.
+
+### Login uses an OTP printed to backend logs
+
+Dev login does not send real email. The one-time password prints in the backend terminal output.
+Read it there to complete login. The dev admin email is `admin@example.gov.sg`.
+
+### Node binary note
+
+`node` resolves to `/exec-daemon/node` (22.14.x) while `npm` resolves to the nvm-managed 22.19.0.
+This mix works. npm 11.x satisfies the repo's `engine-strict` requirement (`npm >= 11.10.0`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,16 @@ The npm scripts invoke `docker-compose`, so keep this shim available.
 9001 console), and DynamoDB Local (8000). The `tunnel` service needs `CLOUDFLARE_TOKEN` and is
 optional. Local webhooks can POST directly to `http://localhost:3000/webhooks/<flow-id>`.
 
-Run `npm run migrate` once to apply main Postgres migrations. The backend `postsetup` hook
-creates the local DynamoDB tile table.
+Run `npm run migrate` once to apply main Postgres migrations. Run
+`npm run -w backend dynamodb:setup` once to create the local DynamoDB tile table (the backend
+`postsetup` hook does this only when you run `npm run setup`, not `docker compose` directly).
+
+### Fix one `.env` placeholder before starting the backend
+
+`packages/backend/.env-example` sets `PAIR_ROME_BASE_URL=...`. That placeholder is not a valid
+URL. The backend builds a Langfuse OTLP trace exporter from it at startup and crashes with
+`Could not parse user-provided export URL`. Set `PAIR_ROME_BASE_URL` to any valid URL in your
+local `.env` (for example `https://rome.example.invalid`). Tracing does not export in dev.
 
 ### Run the app
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a root `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to start and run Plumber inside a Cursor Cloud Agent VM.

## Why

Sets up the Cloud Agent development environment and captures durable, non-obvious startup caveats so future agents can run the app without rediscovering them.

## Verified working in the VM

- Node 22.19.0 (nvm) + npm 11.19.0, Docker 28.5.2 + compose plugin (fuse-overlayfs storage driver).
- Infra via `docker compose`: Postgres (5432), tiles-postgres (5431), Redis (6379), MinIO (9000/9001), DynamoDB Local (8000).
- `npm ci` (needs `NPM_TASKFORCESH_TOKEN`), `npm run migrate` (53 migrations), DynamoDB tile table created.
- `npm run dev`: backend `:3000`, worker, and Vite frontend `:3001` all start.
- Hello-world: logged in with `admin@example.gov.sg` (OTP from backend logs) and created a pipe with a Webhook trigger.
- Lint passes, backend unit tests pass (2020), full build succeeds.

## Non-obvious caveats captured in AGENTS.md

- `npm ci` requires the `NPM_TASKFORCESH_TOKEN` secret for the private `@taskforcesh/bullmq-pro` package.
- The Docker daemon is not auto-started. Start `dockerd` before `npm run setup`.
- `docker-compose` is a shim at `/usr/local/bin/docker-compose` that calls `docker compose`.
- `.env-example` sets `PAIR_ROME_BASE_URL=...`, which crashes the backend at startup. Set a valid URL in `.env`.
- Dev login OTP prints to the backend logs (no real email).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efe441c7-039f-4503-a795-6716895733be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efe441c7-039f-4503-a795-6716895733be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

