### PR TITLE
add stricter check for mrf mock data generation

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -204,7 +204,10 @@ function patchMockData(
 ) {
   const formFields = formDetails.form.form_fields as Array<FormField>
 
-  const isMrf = formDetails.form.responseMode === 'multirespondent'
+  const isMrf =
+    formDetails.form.responseMode === 'multirespondent' &&
+    // if the workflow is not set up, we treat it as a single respondent form
+    formDetails.form.workflow?.length > 0
 
   // for myinfo children fields
   const newChildrenSubfieldResponses = Object.create(null)


### PR DESCRIPTION
## Problem

`get-mock-data.ts`'s `isMrf` check only tested `responseMode === 'multirespondent'`. Since new FormSG forms default to `multirespondent` responseMode even when no workflow has been configured, this misclassified ordinary (non-MRF) forms as MRF. As a result, mock data generation incorrectly stripped `section`-type field answers for forms that aren't actually MRF.

This check had already been fixed elsewhere (#1938, `get-form-schema.ts`; and the existing check in `new-submission/index.ts`) to require a non-empty `workflow` array, but `get-mock-data.ts` was never updated to match.

## Solution

Align `isMrf` in `get-mock-data.ts` with the same `responseMode === 'multirespondent' && workflow?.length > 0` check already used in `new-submission/index.ts` and `get-form-schema.ts`.

## How to test

1. In FormSG, create a new form (defaults to `multirespondent` responseMode) with **no** workflow configured, and add a `section` field plus a few other field types.
2. Connect the form to a Plumber pipe (FormSG trigger) and click "Test step" / run the AI Builder test flow that generates mock data for this trigger.
3. **Before this fix**: the section field's answer is missing from the generated mock data (treated as MRF).
4. **After this fix**: the section field's answer is present in the generated mock data, since the form has no workflow and should be treated as single-respondent.
5. As a regression check, repeat with a form that *does* have a workflow configured (a real MRF form) and confirm section fields are still correctly stripped.
6. `npm run -w backend test:unit -- src/apps/formsg` — all existing formsg unit tests pass (251/251).