### PR TITLE
chore(archival): auto-create archive bucket in local MinIO setup

### DIFF
--- a/packages/backend-archive/README.md
+++ b/packages/backend-archive/README.md
@@ -32,17 +32,9 @@ Start the dev stack (Postgres + MinIO) from the repo root if it isn't already ru
 npm run setup
 ```
 
-### 2. Create the archive bucket in MinIO
+This also creates the `plumber-development-archive-bucket` MinIO bucket used below.
 
-```bash
-# Install mc (MinIO client) if not present
-brew install minio/stable/mc
-
-mc alias set local http://localhost:9000 minio-username minio-password
-mc mb local/plumber-archive-dev --ignore-existing
-```
-
-### 3. Create `.env.archival`
+### 2. Create `.env.archival`
 
 Create a `.env.archival` file at the repo root (do **not** commit it):
 
@@ -61,7 +53,7 @@ ARCHIVE_POSTGRES_READER_HOST=localhost
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio-username
 S3_SECRET_KEY=minio-password
-ARCHIVE_BUCKET=plumber-archive-dev
+ARCHIVE_BUCKET=plumber-development-archive-bucket
 
 # Job settings
 ARCHIVE_ENABLED=true
@@ -75,7 +67,7 @@ ARCHIVE_DELETED_FLOWS_ONLY=true # restrict to soft-deleted flows only
 ARCHIVE_TEST_RUNS=false         # also archive test executions on active flows
 ```
 
-### 4. Run the archival script
+### 3. Run the archival script
 
 ```bash
 # Load env vars, then run
@@ -92,17 +84,17 @@ The script logs structured JSON to stdout. Key events to look for:
 | `archival.flow.archived` | All executions for a flow have been processed — lists IDs. |
 | `archival.run.complete` | Final summary — total `executions_archived`, `executions_skipped`, `durationMs`. |
 
-### 5. Verify S3 contents
+### 4. Verify S3 contents
 
 ```bash
 # List all archived executions for a flow
-mc ls --recursive local/plumber-archive-dev/executions/flow_id=<your-flow-id>/
+mc ls --recursive local/plumber-development-archive-bucket/executions/flow_id=<your-flow-id>/
 
 # Inspect one object's metadata
-mc stat "local/plumber-archive-dev/executions/flow_id=<uuid>/year=YYYY/month=MM/execution_id=<uuid>.json.gz"
+mc stat "local/plumber-development-archive-bucket/executions/flow_id=<uuid>/year=YYYY/month=MM/execution_id=<uuid>.json.gz"
 
 # Inspect the payload
-mc cat "local/plumber-archive-dev/executions/flow_id=<uuid>/year=YYYY/month=MM/execution_id=<uuid>.json.gz" \
+mc cat "local/plumber-development-archive-bucket/executions/flow_id=<uuid>/year=YYYY/month=MM/execution_id=<uuid>.json.gz" \
   | gunzip | jq .
 ```
 
@@ -173,7 +165,7 @@ Each archival run writes a summary object to `_meta/runs/{runAt}.json` in the bu
 
 ```bash
 # Find the runAt timestamp in the startup log (archival.run.start → "runAt" field), then:
-mc cat "local/plumber-archive-dev/_meta/runs/<runAt>.json" | jq '.stepCounts'
+mc cat "local/plumber-development-archive-bucket/_meta/runs/<runAt>.json" | jq '.stepCounts'
 ```
 
 Output shape:
@@ -199,10 +191,10 @@ Dates are keyed by the step's `created_at`, converted to SGT (not the archival r
 To get cumulative counts by date across every run stored in the bucket, download all meta files and sum them. Because the same date can appear in multiple run files (old backlog dates get touched across several runs), group by date + app + action rather than assuming one date lives in one file:
 
 ```bash
-mc ls local/plumber-archive-dev/_meta/runs/ \
+mc ls local/plumber-development-archive-bucket/_meta/runs/ \
   | awk '{print $NF}' \
   | while read -r f; do
-      mc cat "local/plumber-archive-dev/_meta/runs/$f"
+      mc cat "local/plumber-development-archive-bucket/_meta/runs/$f"
     done \
   | jq -s '
       [ .[] | select(.dryRun == false) | .stepCounts | to_entries[] |

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -72,7 +72,8 @@ services:
       mc alias set plumber-minio http://minio:9000 minio-username minio-password &&
       mc alias set local http://minio:9000 minio-username minio-password &&
       mc mb --ignore-existing plumber-minio/plumber-development-common-bucket &&
-      echo 'bucket created' &&
+      mc mb --ignore-existing plumber-minio/plumber-development-archive-bucket &&
+      echo 'buckets created' &&
       mc put /assets/plumber-logo.jpg local/plumber-development-common-bucket/mock/plumber-logo.jpg &&
       echo 'logo uploaded to bucket'
       "


### PR DESCRIPTION
## TL;DR

`npm run setup` didn't provision the S3 bucket the archival pipeline needs, so running it locally required manual `mc` steps that didn't even match the documented bucket name.

## What changed?

- `packages/backend/docker-compose.dev.yml`: `create-minio-buckets` now also creates `plumber-development-archive-bucket`, alongside the existing common bucket.
- `packages/backend-archive/README.md`: dropped the manual `brew install mc` / `mc mb` bucket-creation steps (now redundant), and renamed all `plumber-archive-dev` references to `plumber-development-archive-bucket` to match `packages/backend-archive/.env-example`.

## Why?

`ARCHIVE_BUCKET` is required by `packages/backend-archive/src/helpers/archival/config.ts` with no default, so any archival script fails immediately without a bucket. The README asked devs to create one by hand under a different name than `.env-example` used, so following either doc alone left a dev unable to run archival scripts against MinIO. Folding bucket creation into `npm run setup` and aligning the naming makes local archival setup a single command, consistent with how the rest of the dev stack (Postgres, Redis, DynamoDB, common bucket) is already provisioned.

## Tests

- [ ] Run `npm run setup` from a clean state and confirm `plumber-development-archive-bucket` exists in MinIO (`mc ls local/`).
- [ ] Follow the updated README to create `.env.archival` and run `npm run -w backend-archive archive:backfill` against the auto-created bucket.

## Deploy notes

None — dev-only tooling and docs change.