### PR TITLE
PLU-823: add connection functionality for other apps in AI builder

### DIFF
--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -5,6 +5,7 @@ import { FieldValues, SubmitHandler } from 'react-hook-form'
 import {
   Alert,
   AlertIcon,
+  Box,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -15,6 +16,8 @@ import {
 } from '@chakra-ui/react'
 import { Button, Infobox, Link } from '@opengovsg/design-system-react'
 
+import ConnectionHeader from '@/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConnectionHeader'
+import { DEFAULT_ADD_CONNECTION_LABEL } from '@/components/FlowStepConfigurationModal/constants'
 import InputCreator from '@/components/InputCreator'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
@@ -137,10 +140,18 @@ export default function AddAppConnection(
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
-          {hasConnection ? 'Edit connection' : 'Add connection'}
-        </ModalHeader>
-        <ModalCloseButton />
+        <Box my={8}>
+          <ConnectionHeader
+            selectedApp={application}
+            headerText={
+              hasConnection
+                ? `Edit ${name} connection`
+                : auth?.connectionModalLabel?.addConnectionLabel ??
+                  DEFAULT_ADD_CONNECTION_LABEL
+            }
+          />
+          <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
+        </Box>
 
         {authDocUrl && (
           <Alert status="info" fontWeight="300" px={8}>

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -26,6 +26,7 @@ type AddAppConnectionProps = {
   onClose: (response: Record<string, unknown>) => void
   application: IApp
   connectionId?: string
+  flowId?: string
 }
 
 type Response = {
@@ -39,7 +40,7 @@ type Response = {
 export default function AddAppConnection(
   props: AddAppConnectionProps,
 ): React.ReactElement {
-  const { application, connectionId, onClose } = props
+  const { application, connectionId, onClose, flowId } = props
   const { name, authDocUrl, key, auth } = application
   const [error, setError] = React.useState<IJSONObject | null>(null)
   const [inProgress, setInProgress] = React.useState(false)
@@ -79,6 +80,7 @@ export default function AddAppConnection(
           id: connectionId,
         },
         fields: data,
+        flowId,
       }
 
       let stepIndex = 0
@@ -107,7 +109,7 @@ export default function AddAppConnection(
 
       setInProgress(false)
     },
-    [connectionId, key, steps, onClose],
+    [connectionId, key, steps, onClose, flowId],
   )
 
   if (auth?.connectionType !== 'user-added') {

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
 import { Box, Button, Flex, Icon, Input, Spinner, Text } from '@chakra-ui/react'
+
 import { AI_BUILDER_INLINE_CONNECT_APP_KEYS } from '@/pages/AiBuilder/constants'
 
 interface DynamicPickerOption {
@@ -330,7 +331,9 @@ export default function DynamicPicker({
                   onClick={onAddConnection}
                   fontWeight="normal"
                 >
-                  {appKey === 'formsg' ? 'Add a new form' : 'Add a new connection'}
+                  {appKey === 'formsg'
+                    ? 'Add a new form'
+                    : 'Add a new connection'}
                 </Button>
               )}
             </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
 import { Box, Button, Flex, Icon, Input, Spinner, Text } from '@chakra-ui/react'
+import { AI_BUILDER_INLINE_CONNECT_APP_KEYS } from '@/pages/AiBuilder/constants'
 
 interface DynamicPickerOption {
   name: string
@@ -172,9 +173,16 @@ export default function DynamicPicker({
   // Zero options — distinct from a fetch error.
   const showEmptyState = !isLoading && !isError && options.length === 0
 
-  // In-chat "Add new form" entry point — FormSG only, and only when the host
-  // page provided a handler for it.
-  const canAddConnection = appKey === 'formsg' && Boolean(onAddConnection)
+  // In-chat "add connection" entry point — FormSG (its own bespoke modal) or
+  // any app key in AI_BUILDER_INLINE_CONNECT_APP_KEYS (the generic
+  // AddAppConnection-based modal) — and only when the host page provided a
+  // handler for it.
+  const canAddConnection =
+    Boolean(onAddConnection) &&
+    (appKey === 'formsg' ||
+      AI_BUILDER_INLINE_CONNECT_APP_KEYS.includes(
+        appKey as (typeof AI_BUILDER_INLINE_CONNECT_APP_KEYS)[number],
+      ))
 
   return (
     <Box w="full" maxW="4xl">
@@ -233,7 +241,7 @@ export default function DynamicPicker({
                   isDisabled={isStreaming}
                   onClick={onAddConnection}
                 >
-                  Add your form
+                  {appKey === 'formsg' ? 'Add your form' : 'Add connection'}
                 </Button>
               ) : (
                 <Text color="gray.500" fontSize="sm" px={2}>
@@ -322,7 +330,7 @@ export default function DynamicPicker({
                   onClick={onAddConnection}
                   fontWeight="normal"
                 >
-                  Add a new form
+                  {appKey === 'formsg' ? 'Add a new form' : 'Add a new connection'}
                 </Button>
               )}
             </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -34,7 +34,7 @@ interface PromptInputProps {
   cancelStream: () => void
   clarification?: ClarificationQuestion[]
   dynamicPicker?: DynamicPickerPart['data']
-  onAddConnection?: (context: { question: string }) => void
+  onAddConnection?: (context: { question: string; appKey: string }) => void
   /** Form URL already shared in the conversation (drives the picker's forced key-completion card). */
   knownFormUrl?: string
   /** Opens the Add-new-form modal (empty-state "Connect your form" entry). */
@@ -269,7 +269,11 @@ export default function PromptInput({
         }
         onAddConnection={
           onAddConnection && isAppKeyMode
-            ? () => onAddConnection({ question: dynamicPicker.question })
+            ? () =>
+                onAddConnection({
+                  question: dynamicPicker.question,
+                  appKey: dynamicPicker.appKey,
+                })
             : undefined
         }
         knownFormUrl={knownFormUrl}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -24,7 +24,7 @@ interface ChatInterfaceProps {
   cancelStream: () => void
   resetChat: () => void
   hasReachedLimit: boolean
-  onAddConnection?: (context: { question: string }) => void
+  onAddConnection?: (context: { question: string; appKey: string }) => void
   knownFormUrl?: string
   onConnectForm?: () => void
   /** Resets any form-connection state that lives outside useChatStream's own reset. */

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -41,3 +41,21 @@ export const PLACEHOLDER_MESSAGES = [
 // Maximum number of messages allowed in a conversation (hard limit).
 // Keep in sync with backend/src/routes/api/chat/{schema,index}.ts.
 export const MAX_MESSAGES = 150
+
+// App keys that support AI Builder's generic in-chat "add connection" flow
+// (secret-key or OAuth-via-popup apps, driven entirely by each app's
+// auth.fields/auth.authenticationSteps — see components/AddAppConnection).
+// FormSG is handled separately by AddFormsgConnectionModal and is
+// intentionally not in this list. Databricks and M365-Excel are
+// system-added (no user-entered fields) and are out of scope for this list.
+export const AI_BUILDER_INLINE_CONNECT_APP_KEYS = [
+  'lettersg',
+  'gathersg',
+  'paysg',
+  'postman-sms',
+  'telegram-bot',
+  'slack',
+] as const
+
+export type AiBuilderInlineConnectAppKey =
+  (typeof AI_BUILDER_INLINE_CONNECT_APP_KEYS)[number]

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -97,6 +97,42 @@ export const buildNoOptionsFoundMessage = (
 ): string =>
   `Q: ${question}\nA: [no options available${reason ? `: ${reason}` : ''}]`
 
+// Shared answer format for a connection-picker turn — used both when the
+// user picks an existing connection (see PromptInput's onSelect) and when
+// they create one inline via AddAppConnection. Keep this in sync with the
+// system prompt's picker-answer contract if the format ever changes.
+export const buildPickerAnswerMessage = (
+  question: string,
+  label: string,
+  connectionId: string,
+): string => `Q: ${question}\nA: ${label} (id: ${connectionId})`
+
+// AddAppConnection's onClose hands back the raw accumulated response object
+// from walking auth.authenticationSteps (createConnection's result, the
+// submitted field values, etc.) rather than a clean (label, id) pair. Pull
+// out what the chat answer needs: the new connection's id, and a display
+// label — the user-entered "screenName" field when the app has one (every
+// secret-key app in AI_BUILDER_INLINE_CONNECT_APP_KEYS except Telegram and
+// Slack declares one), otherwise the caller-supplied fallback (the app's
+// display name).
+export const extractConnectionResult = (
+  response: Record<string, unknown>,
+  fallbackLabel: string,
+): { label: string; connectionId: string } | null => {
+  const createConnectionResult = response.createConnection as
+    | { id?: string }
+    | undefined
+  const connectionId = createConnectionResult?.id
+  if (!connectionId) {
+    return null
+  }
+
+  const fields = response.fields as Record<string, unknown> | undefined
+  const label = (fields?.screenName as string | undefined) ?? fallbackLabel
+
+  return { label, connectionId }
+}
+
 export const isNoOptionsSignalMessage = (text: string): boolean =>
   text.includes('\nA: [no options available')
 

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -107,28 +107,50 @@ export const buildPickerAnswerMessage = (
   connectionId: string,
 ): string => `Q: ${question}\nA: ${label} (id: ${connectionId})`
 
+interface ConnectionMutationResult {
+  id?: string
+  formattedData?: Record<string, unknown>
+}
+
 // AddAppConnection's onClose hands back the raw accumulated response object
-// from walking auth.authenticationSteps (createConnection's result, the
-// submitted field values, etc.) rather than a clean (label, id) pair. Pull
-// out what the chat answer needs: the new connection's id, and a display
-// label — the user-entered "screenName" field when the app has one (every
-// secret-key app in AI_BUILDER_INLINE_CONNECT_APP_KEYS except Telegram and
-// Slack declares one), otherwise the caller-supplied fallback (the app's
-// display name).
+// from walking auth.authenticationSteps (createConnection's/verifyConnection's
+// results, the submitted field values, etc.) rather than a clean (label, id)
+// pair. Pull out what the chat answer needs: the new connection's id, and a
+// display label.
+//
+// The label preference order matters: several apps' verifyCredentials
+// derives or rewrites screenName from a live API call during verification —
+// Slack/Telegram have no user-facing "Label" field at all (screenName comes
+// entirely from the OAuth team name / bot's own name), and PaySG appends an
+// env suffix ([LIVE]/[STAGING]) server-side. So the raw submitted
+// fields.screenName is stale/wrong for those apps — the canonical label only
+// exists on verifyConnection's returned formattedData once verification has
+// run. createConnection's formattedData is checked as a fallback in case a
+// future app's step sequence doesn't end in verifyConnection; fields.screenName
+// and the caller-supplied app-name fallback cover apps with no auth-derived
+// label at all.
 export const extractConnectionResult = (
   response: Record<string, unknown>,
   fallbackLabel: string,
 ): { label: string; connectionId: string } | null => {
   const createConnectionResult = response.createConnection as
-    | { id?: string }
+    | ConnectionMutationResult
     | undefined
   const connectionId = createConnectionResult?.id
   if (!connectionId) {
     return null
   }
 
+  const verifyConnectionResult = response.verifyConnection as
+    | ConnectionMutationResult
+    | undefined
   const fields = response.fields as Record<string, unknown> | undefined
-  const label = (fields?.screenName as string | undefined) ?? fallbackLabel
+
+  const label =
+    (verifyConnectionResult?.formattedData?.screenName as string | undefined) ??
+    (createConnectionResult?.formattedData?.screenName as string | undefined) ??
+    (fields?.screenName as string | undefined) ??
+    fallbackLabel
 
   return { label, connectionId }
 }

--- a/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
@@ -37,6 +37,36 @@ describe('extractConnectionResult', () => {
     })
   })
 
+  it('prefers verifyConnection.formattedData.screenName over the raw submitted field (e.g. PaySG appending an [LIVE]/[STAGING] suffix server-side)', () => {
+    const response = {
+      createConnection: { id: 'conn-789' },
+      fields: { screenName: 'My PaySG Account', apiKey: 'secret' },
+      verifyConnection: {
+        id: 'conn-789',
+        formattedData: { screenName: 'My PaySG Account [STAGING]' },
+      },
+    }
+    expect(extractConnectionResult(response, 'PaySG')).toEqual({
+      connectionId: 'conn-789',
+      label: 'My PaySG Account [STAGING]',
+    })
+  })
+
+  it('uses verifyConnection.formattedData.screenName for apps with no user-facing Label field (e.g. Slack/Telegram deriving it from a live API call)', () => {
+    const response = {
+      createConnection: { id: 'conn-abc' },
+      fields: { consumerKey: 'client-id', consumerSecret: 'client-secret' },
+      verifyConnection: {
+        id: 'conn-abc',
+        formattedData: { screenName: 'Jane Doe @ Acme Workspace' },
+      },
+    }
+    expect(extractConnectionResult(response, 'Slack')).toEqual({
+      connectionId: 'conn-abc',
+      label: 'Jane Doe @ Acme Workspace',
+    })
+  })
+
   it('returns null when no connection was created (e.g. the step sequence failed)', () => {
     expect(extractConnectionResult({}, 'PaySG')).toBeNull()
   })

--- a/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPickerAnswerMessage, extractConnectionResult } from '../helpers'
+
+describe('buildPickerAnswerMessage', () => {
+  it('formats the question, label, and id into the picker answer contract', () => {
+    expect(buildPickerAnswerMessage('Which Slack workspace?', 'My Workspace', 'conn-123')).toBe(
+      'Q: Which Slack workspace?\nA: My Workspace (id: conn-123)',
+    )
+  })
+})
+
+describe('extractConnectionResult', () => {
+  it('returns the connection id and the user-entered screenName as label', () => {
+    const response = {
+      createConnection: { id: 'conn-123' },
+      fields: { screenName: 'My Connection', apiKey: 'secret' },
+    }
+    expect(extractConnectionResult(response, 'PaySG')).toEqual({
+      connectionId: 'conn-123',
+      label: 'My Connection',
+    })
+  })
+
+  it('falls back to the provided label when no screenName field was submitted', () => {
+    const response = {
+      createConnection: { id: 'conn-456' },
+      fields: { token: 'bot-token-value' },
+    }
+    expect(extractConnectionResult(response, 'Telegram')).toEqual({
+      connectionId: 'conn-456',
+      label: 'Telegram',
+    })
+  })
+
+  it('returns null when no connection was created (e.g. the step sequence failed)', () => {
+    expect(extractConnectionResult({}, 'PaySG')).toBeNull()
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts
@@ -4,9 +4,13 @@ import { buildPickerAnswerMessage, extractConnectionResult } from '../helpers'
 
 describe('buildPickerAnswerMessage', () => {
   it('formats the question, label, and id into the picker answer contract', () => {
-    expect(buildPickerAnswerMessage('Which Slack workspace?', 'My Workspace', 'conn-123')).toBe(
-      'Q: Which Slack workspace?\nA: My Workspace (id: conn-123)',
-    )
+    expect(
+      buildPickerAnswerMessage(
+        'Which Slack workspace?',
+        'My Workspace',
+        'conn-123',
+      ),
+    ).toBe('Q: Which Slack workspace?\nA: My Workspace (id: conn-123)')
   })
 })
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -1,10 +1,11 @@
-import type { IJSONObject } from '@plumber/types'
+import type { IApp, IJSONObject } from '@plumber/types'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CloseButton, Container, Flex, HStack, Text } from '@chakra-ui/react'
 
+import AddAppConnection from '@/components/AddAppConnection'
 import * as URLS from '@/config/urls'
 import { useChatStream } from '@/hooks/useChatStream'
 import { useNavigationGuard } from '@/hooks/useNavigationGuard'
@@ -20,8 +21,10 @@ import {
 import {
   buildFormConnectedMessage,
   buildKickoffMessage,
+  buildPickerAnswerMessage,
   buildUrlSharedKickoffMessage,
   buildUrlSharedMessage,
+  extractConnectionResult,
   extractFormIdFromLabel,
   extractLastFormUrl,
   formatFormUrlLabel,
@@ -41,6 +44,7 @@ function AiBuilderContent() {
     isDrawerOpen,
     steps,
     output,
+    allApps,
   } = useAiBuilderContext()
 
   const {
@@ -129,6 +133,16 @@ function AiBuilderContent() {
     { kind: 'picker'; question: string } | { kind: 'kickoff' } | null
   >(null)
 
+  // In-chat "add connection" modal for every non-FormSG app in
+  // AI_BUILDER_INLINE_CONNECT_APP_KEYS — a thin wrapper around
+  // AddAppConnection's generic authenticationSteps engine. Kept separate
+  // from addFormContext above since FormSG's flow has its own two-kind
+  // (picker/kickoff) state machine that doesn't apply here.
+  const [addConnectionContext, setAddConnectionContext] = useState<{
+    appKey: string
+    question: string
+  } | null>(null)
+
   // Display-only composer chip anchoring the connected form (S3).
   const [attachedForm, setAttachedForm] = useState<{ label: string } | null>(
     null,
@@ -160,8 +174,13 @@ function AiBuilderContent() {
   }, [attachedForm, prefillFormUrl, knownFormSchema])
 
   const handleAddConnection = useCallback(
-    (context: { question: string }) =>
-      setAddFormContext({ kind: 'picker', ...context }),
+    (context: { question: string; appKey: string }) => {
+      if (context.appKey === 'formsg') {
+        setAddFormContext({ kind: 'picker', question: context.question })
+        return
+      }
+      setAddConnectionContext(context)
+    },
     [],
   )
 
@@ -208,6 +227,31 @@ function AiBuilderContent() {
     [addFormContext, sendMessage],
   )
 
+  // AddAppConnection's onClose hands back the raw accumulated response from
+  // walking auth.authenticationSteps, not a clean (label, id) pair — pull
+  // out what the chat answer needs. If the step sequence never reached
+  // createConnection (e.g. the user closed the modal, or a step failed and
+  // the user hasn't retried), there's nothing to tell the chat.
+  const handleGenericAddConnectionSuccess = useCallback(
+    (response: Record<string, unknown>, fallbackLabel: string) => {
+      if (!addConnectionContext) {
+        return
+      }
+      const result = extractConnectionResult(response, fallbackLabel)
+      if (result) {
+        sendMessage(
+          buildPickerAnswerMessage(
+            addConnectionContext.question,
+            result.label,
+            result.connectionId,
+          ),
+        )
+      }
+      setAddConnectionContext(null)
+    },
+    [addConnectionContext, sendMessage],
+  )
+
   // Url-only-variant submit — the user shared their form without a key. As
   // the first message it asks for suggestions; mid-conversation it is a
   // plain share the LLM picks up from where it is.
@@ -229,6 +273,7 @@ function AiBuilderContent() {
   const handleNewChat = useCallback(() => {
     setAttachedForm(null)
     setAddFormContext(null)
+    setAddConnectionContext(null)
   }, [])
 
   // Determine if we have unsaved work
@@ -255,6 +300,10 @@ function AiBuilderContent() {
   const handleClose = useCallback(() => {
     guardedNavigate(() => navigate(URLS.FLOWS, { replace: true }))
   }, [guardedNavigate, navigate])
+
+  const addConnectionApp: IApp | undefined = addConnectionContext
+    ? allApps.find((app) => app.key === addConnectionContext.appKey)
+    : undefined
 
   return (
     <StepConfigContext.Provider
@@ -333,6 +382,15 @@ function AiBuilderContent() {
           onSuccess={handleAddFormSuccess}
           onSubmitUrl={handleSubmitUrl}
         />
+        {addConnectionContext && addConnectionApp && flowId && (
+          <AddAppConnection
+            application={addConnectionApp}
+            flowId={flowId}
+            onClose={(response) =>
+              handleGenericAddConnectionSuccess(response, addConnectionApp.name)
+            }
+          />
+        )}
         <ExitAlert
           cancelRef={cancelRef}
           isOpen={showWarning}


### PR DESCRIPTION
## Problem

Closes PLU-823

In AI Builder chat, the connection picker only supported creating a new connection inline for **FormSG**. For every other app, an empty connection list hit a dead-end message ("you can add one in Plumber's connection settings"), forcing the user out of chat entirely to connect an app.

## Solution

**Features**:

- Generalized the existing FormSG-only "Add connection" flow to **LetterSG, Ownself Gather, PaySG, SMS by Postman, Telegram, and Slack** — the picker's empty state now offers an in-chat "Add connection" action for these apps too.
- Reused the existing generic credential-collection engine (`AddAppConnection`, driven by each app's `auth.fields`/`auth.authenticationSteps`) already used by the regular (non-AI-Builder) editor, instead of building bespoke per-app UI. This includes Slack's OAuth popup flow with no new frontend OAuth handling.
- The modal now shows which app the new connection is for (app icon + name), reusing the existing `ConnectionHeader` component from the regular editor.
- Threaded `appKey` through the `DynamicPicker` → `PromptInput` → `ChatInterface` → `AiBuilder` callback chain so FormSG keeps using its existing bespoke modal unchanged, while every other app routes to the new generic flow.

**Improvements**:

- Fixed a latent gap in `AddAppConnection` where `flowId` was never threaded into its internal `createConnection`/`verifyConnection` calls (both require it). This had no live effect before this PR since nothing in the frontend linked to that component's route — it's what makes reuse in AI Builder possible.

**Hard constraint upheld throughout**: the secret/API key/OAuth credentials never pass through the chat route or the LLM. Credentials always flow browser → GraphQL directly; only the resulting `connectionId` and a display label ever reach the chat message (verified end-to-end during review, including via network inspection).

**Out of scope for this PR**: Databricks and M365-Excel's silent auto-connect (system-added apps, no user-entered fields) — tracked as a separate follow-up.

## Tests

**Manual test plan** (AI Builder chat, one app at a time):

1. Build a workflow that needs a connection for one of: LetterSG, Ownself Gather, PaySG, SMS by Postman, Telegram, Slack.
2. Reach step configuration with **zero existing connections** for that app — confirm the picker's empty state shows an "Add connection" button (not the old dead-end text).
3. Click it — confirm the modal shows the app's icon/name in the header, its guide link (if the app has one), and its credential fields.
4. Submit valid credentials — confirm the modal closes and the chat continues, with the connection assigned to the step.
5. Submit invalid credentials — confirm an inline error appears and the modal stays open for retry.
6. For **Slack** specifically: confirm submitting Client ID/Secret opens Slack's OAuth consent in a popup, and completing it closes the popup and resumes the chat.
7. Open devtools Network tab during step 4 — confirm the credential value only appears in the `createConnection`/`verifyConnection` GraphQL requests, never in any `/api/chat` request.
8. Regression check: confirm FormSG's existing "Add your form" flow (button copy, modal, behavior) is completely unchanged.

**Automated**: `npm run -w frontend test` — includes new unit tests for the picker-answer/connection-extraction helpers (`packages/frontend/src/pages/AiBuilder/helpers/inlineConnectionAnswer.test.ts`). Full frontend suite passes (187/187).

## Deploy Notes

No new environment variables, scripts, or dependencies. Purely a frontend feature (plus one prop-threading fix in a shared component) — no MCP tool or system-prompt changes were needed.
