### PR TITLE
PLU-743: [IF-THEN-THEN-V2-18] Condition-block preview helpers

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildConditionSentence } from '../buildConditionSentence'
+import type { ConditionPreviewPart } from '../getConditionBlockPreview'
+import { MAX_CONDITION_LABEL_LENGTH } from '../truncateConditionLabel'
+
+const LONG = 'A'.repeat(MAX_CONDITION_LABEL_LENGTH + 10)
+
+const leadingVar = (id: string, label: string): ConditionPreviewPart => ({
+  type: 'variable',
+  id,
+  label,
+  position: 'leading',
+})
+
+const trailingVar = (id: string, label: string): ConditionPreviewPart => ({
+  type: 'variable',
+  id,
+  label,
+  position: 'trailing',
+})
+
+const never = () => undefined
+
+describe('buildConditionSentence', () => {
+  it('resolves a variable to its real label, not its path segment', () => {
+    const resolve = vi.fn().mockReturnValue('2. What is your full name?')
+
+    const { parts } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.fields.6483.answer', 'answer')],
+      resolve,
+    )
+
+    expect(resolve).toHaveBeenCalledWith('step.abc.fields.6483.answer')
+    // Long enough to be cut, but it is the resolved label being cut, not
+    // "answer" — which is the whole point of the lookup.
+    expect(parts[0].display.startsWith('2. What is your')).toBe(true)
+  })
+
+  it('falls back to the path segment when nothing resolves', () => {
+    const { parts } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.row.a3f1', 'a3f1')],
+      never,
+    )
+
+    expect(parts[0].display).toBe('a3f1')
+  })
+
+  it('caps a leading part and reports it', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.x', LONG)],
+      never,
+    )
+
+    expect(isLeadingTruncated).toBe(true)
+    expect(parts[0].display).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(parts[0].display.endsWith('…')).toBe(true)
+  })
+
+  it('lets a trailing part run on, so layout can clip it', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'IF',
+      [trailingVar('step.abc.x', LONG)],
+      never,
+    )
+
+    expect(parts[0].display).toBe(LONG)
+    expect(isLeadingTruncated).toBe(false)
+  })
+
+  it('caps a typed leading value but not a typed trailing one', () => {
+    const { parts } = buildConditionSentence(
+      'IF',
+      [
+        { type: 'literal', text: LONG, position: 'leading' },
+        { type: 'literal', text: LONG, position: 'trailing' },
+      ],
+      never,
+    )
+
+    expect(parts[0].display).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(parts[1].display).toBe(LONG)
+  })
+
+  it('never truncates connectives or the emphasised keyword', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'REPEAT',
+      [
+        { type: 'text', text: LONG },
+        { type: 'emphasis', text: LONG },
+      ],
+      never,
+    )
+
+    expect(parts[0].display).toBe(LONG)
+    expect(parts[1].display).toBe(LONG)
+    expect(isLeadingTruncated).toBe(false)
+  })
+
+  it('builds the tooltip sentence from untruncated text, badge first', () => {
+    const { fullSentence } = buildConditionSentence(
+      'IF',
+      [
+        leadingVar('step.abc.x', LONG),
+        { type: 'text', text: ' is equal to ' },
+        { type: 'literal', text: 'Yes', position: 'trailing' },
+      ],
+      never,
+    )
+
+    expect(fullSentence).toBe(`IF ${LONG} is equal to Yes`)
+  })
+
+  it('uses the resolved label in the tooltip too', () => {
+    const { fullSentence } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.row.a3f1', 'a3f1')],
+      () => 'Status',
+    )
+
+    expect(fullSentence).toBe('IF Status')
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
@@ -33,8 +33,7 @@ describe('buildConditionSentence', () => {
     )
 
     expect(resolve).toHaveBeenCalledWith('step.abc.fields.6483.answer')
-    // Long enough to be cut, but it is the resolved label being cut, not
-    // "answer" — which is the whole point of the lookup.
+    // The resolved label is what gets cut, not the "answer" path segment.
     expect(parts[0].display.startsWith('2. What is your')).toBe(true)
   })
 

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
@@ -18,7 +18,6 @@ const conditions = (rows: Array<Record<string, unknown>>[]): IJSONObject =>
     conditions: rows.map((groupRows) => ({ rows: groupRows })),
   } as unknown as IJSONObject)
 
-/** Renders the parts the way the header does, for readable assertions. */
 const asText = (parts: ConditionPreviewPart[]): string =>
   parts
     .map((part) => (part.type === 'variable' ? part.label : part.text))
@@ -278,6 +277,26 @@ describe('getConditionBlockPreviewParts', () => {
     ).toBe('Specify condition')
   })
 
+  it('tolerates conditions that are not an array', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts({
+          conditions: 'nonsense',
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('drops a field that is neither text nor a number', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: { a: 1 }, condition: 'equals', text: 'x' }]]),
+        ),
+      ),
+    ).toBe('is equal to x')
+  })
+
   it('marks typed values as literals and the operator as a connective', () => {
     const parts = getConditionBlockPreviewParts(
       conditions([
@@ -292,8 +311,7 @@ describe('getConditionBlockPreviewParts', () => {
     )
 
     expect(typesOf(parts)).toEqual(['variable', 'text', 'text', 'literal'])
-    // The operator phrase is a `text` part so the header leaves it intact; the
-    // typed value is a `literal` so the header may truncate it.
+    // The header leaves a `text` part intact and may truncate a `literal`.
     expect(parts.find((part) => part.type === 'text')).toEqual({
       type: 'text',
       text: ' is greater than or equal to',
@@ -351,7 +369,7 @@ describe('getConditionBlockPreviewParts', () => {
       )
       .map((part) => part.position)
 
-    // field variable, then the value's literal prefix and its variable
+    // field, then the value's literal prefix and its variable
     expect(positions).toEqual(['leading', 'trailing', 'trailing'])
   })
 

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
@@ -1,0 +1,414 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  type ConditionPreviewPart,
+  getConditionBlockPreviewParts,
+  getForEachBlockPreviewParts,
+} from '../getConditionBlockPreview'
+
+const STEP_ID = '0191b4ee-1a2b-4c3d-8e9f-a1b2c3d4e5f6'
+const OTHER_STEP_ID = '0191b4ee-1a2b-4c3d-8e9f-000000000000'
+
+const variable = (path: string) => `{{step.${STEP_ID}.${path}}}`
+
+const conditions = (rows: Array<Record<string, unknown>>[]): IJSONObject =>
+  ({
+    conditions: rows.map((groupRows) => ({ rows: groupRows })),
+  } as unknown as IJSONObject)
+
+/** Renders the parts the way the header does, for readable assertions. */
+const asText = (parts: ConditionPreviewPart[]): string =>
+  parts
+    .map((part) => (part.type === 'variable' ? part.label : part.text))
+    .join('')
+
+const typesOf = (parts: ConditionPreviewPart[]): string[] =>
+  parts.map((part) => part.type)
+
+describe('getConditionBlockPreviewParts', () => {
+  it('falls back to a prompt when there are no conditions', () => {
+    expect(getConditionBlockPreviewParts(undefined)).toEqual([
+      { type: 'text', text: 'Specify condition' },
+    ])
+    expect(getConditionBlockPreviewParts({} as IJSONObject)).toEqual([
+      { type: 'text', text: 'Specify condition' },
+    ])
+    expect(
+      getConditionBlockPreviewParts({
+        conditions: [],
+      } as unknown as IJSONObject),
+    ).toEqual([{ type: 'text', text: 'Specify condition' }])
+  })
+
+  it('falls back to a prompt when every row is still blank', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: '', condition: '', text: '' }]]),
+        ),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('maps an operator key to its plain-language phrase', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Age'), condition: 'gte', text: '21' }],
+          ]),
+        ),
+      ),
+    ).toBe('Age is greater than or equal to 21')
+  })
+
+  it('renders "is not" for a negated row', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Status'),
+                is: 'not',
+                condition: 'equals',
+                text: 'Rejected',
+              },
+            ],
+          ]),
+        ),
+      ).trim(),
+    ).toBe('Status is not equal to Rejected')
+  })
+
+  it('omits the comparison value for the empty operator', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Email'), condition: 'empty', text: 'ignored' }],
+          ]),
+        ),
+      ).trim(),
+    ).toBe('Email is empty')
+  })
+
+  it('negates each operator with its own verb phrase, not a blanket "is not"', () => {
+    const preview = (condition: string, negated: boolean) =>
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Subject'),
+                is: negated ? 'not' : 'and',
+                condition,
+                text: 'x',
+              },
+            ],
+          ]),
+        ),
+      )
+
+    expect(preview('contains', false)).toBe('Subject contains x')
+    expect(preview('contains', true)).toBe('Subject does not contain x')
+    expect(preview('begins', false)).toBe('Subject begins with x')
+    expect(preview('begins', true)).toBe('Subject does not begin with x')
+    expect(preview('equals', true)).toBe('Subject is not equal to x')
+    expect(preview('after', true)).toBe('Subject is not after x')
+  })
+
+  it('falls back to the raw operator key when it has no phrase', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Score'), condition: 'weird', text: '3' }],
+          ]),
+        ),
+      ),
+    ).toBe('Score is weird 3')
+
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Score'),
+                is: 'not',
+                condition: 'weird',
+                text: '3',
+              },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('Score is not weird 3')
+  })
+
+  it('splits a step variable out as its own part, labelled by last segment', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Responses.Email address'),
+            condition: 'equals',
+            text: 'a@b.gov.sg',
+          },
+        ],
+      ]),
+    )
+
+    expect(parts[0]).toEqual({
+      type: 'variable',
+      id: `step.${STEP_ID}.Responses.Email address`,
+      label: 'Email address',
+      position: 'leading',
+    })
+  })
+
+  it('drops a variable pipe modifier from the lookup id', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: `{{step.${STEP_ID}.Amount|currency}}`,
+            condition: 'gt',
+            text: '0',
+          },
+        ],
+      ]),
+    )
+
+    expect(parts[0]).toEqual({
+      type: 'variable',
+      id: `step.${STEP_ID}.Amount`,
+      label: 'Amount',
+      position: 'leading',
+    })
+  })
+
+  it('keeps literal text around a variable', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Name'),
+            condition: 'contains',
+            text: `Hi ${variable('Nickname')} !`,
+          },
+        ],
+      ]),
+    )
+
+    expect(asText(parts)).toBe('Name contains Hi Nickname !')
+    expect(parts.filter((part) => part.type === 'variable')).toHaveLength(2)
+  })
+
+  it('handles several variables in one value', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: `{{step.${STEP_ID}.First}} {{step.${OTHER_STEP_ID}.Last}}`,
+            condition: 'equals',
+            text: 'x',
+          },
+        ],
+      ]),
+    )
+
+    expect(
+      parts
+        .filter(
+          (part): part is Extract<ConditionPreviewPart, { type: 'variable' }> =>
+            part.type === 'variable',
+        )
+        .map((part) => part.label),
+    ).toEqual(['First', 'Last'])
+  })
+
+  it('treats a plain (non-variable) value as text', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: 'Age', condition: 'lt', text: '18' }]]),
+        ),
+      ),
+    ).toBe('Age is less than 18')
+  })
+
+  it('stringifies numeric and boolean parameter values', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: 42, condition: 'equals', text: true }]]),
+        ),
+      ),
+    ).toBe('42 is equal to true')
+  })
+
+  it('previews the first non-empty row, skipping blank rows and groups', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: '', condition: '', text: '' }],
+            [
+              { field: '', condition: '', text: '' },
+              { field: variable('Second'), condition: 'equals', text: 'yes' },
+              { field: variable('Third'), condition: 'equals', text: 'no' },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('Second is equal to yes')
+  })
+
+  it('tolerates a group with no rows array', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts({
+          conditions: [{}],
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('marks typed values as literals and the operator as a connective', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Amount'),
+            condition: 'gte',
+            text: 'Finance & Corporate Services Division',
+          },
+        ],
+      ]),
+    )
+
+    expect(typesOf(parts)).toEqual(['variable', 'text', 'text', 'literal'])
+    // The operator phrase is a `text` part so the header leaves it intact; the
+    // typed value is a `literal` so the header may truncate it.
+    expect(parts.find((part) => part.type === 'text')).toEqual({
+      type: 'text',
+      text: ' is greater than or equal to',
+    })
+  })
+
+  it('keeps literal runs around a variable as literals', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: 'Name',
+            condition: 'contains',
+            text: `Hi ${variable('Nickname')} !`,
+          },
+        ],
+      ]),
+    )
+
+    expect(typesOf(parts)).toEqual([
+      'literal',
+      'text',
+      'text',
+      'literal',
+      'variable',
+      'literal',
+    ])
+  })
+
+  it('marks the placeholder as a connective so it is never truncated', () => {
+    expect(typesOf(getConditionBlockPreviewParts(undefined))).toEqual(['text'])
+  })
+
+  it('marks where in the sentence each part sits', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Name'),
+            condition: 'equals',
+            text: `Hi ${variable('Nickname')}`,
+          },
+        ],
+      ]),
+    )
+
+    const positions = parts
+      .filter(
+        (
+          part,
+        ): part is Extract<
+          ConditionPreviewPart,
+          { type: 'variable' | 'literal' }
+        > => part.type === 'variable' || part.type === 'literal',
+      )
+      .map((part) => part.position)
+
+    // field variable, then the value's literal prefix and its variable
+    expect(positions).toEqual(['leading', 'trailing', 'trailing'])
+  })
+
+  it('marks a typed field leading and a typed value trailing', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([[{ field: 'Age', condition: 'lt', text: '18' }]]),
+    )
+
+    expect(parts).toEqual([
+      { type: 'literal', text: 'Age', position: 'leading' },
+      { type: 'text', text: ' is less than' },
+      { type: 'text', text: ' ' },
+      { type: 'literal', text: '18', position: 'trailing' },
+    ])
+  })
+})
+
+describe('getForEachBlockPreviewParts', () => {
+  it('falls back to a prompt when no list is set', () => {
+    const prompt = [{ type: 'text', text: 'Specify list' }]
+
+    expect(getForEachBlockPreviewParts(undefined)).toEqual(prompt)
+    expect(getForEachBlockPreviewParts({} as IJSONObject)).toEqual(prompt)
+    expect(
+      getForEachBlockPreviewParts({ items: '   ' } as unknown as IJSONObject),
+    ).toEqual(prompt)
+    expect(
+      getForEachBlockPreviewParts({ items: 12 } as unknown as IJSONObject),
+    ).toEqual(prompt)
+  })
+
+  it('reads as a sentence with "item" and the list name emphasised', () => {
+    const parts = getForEachBlockPreviewParts({
+      items: variable('Rows'),
+    } as unknown as IJSONObject)
+
+    expect(asText(parts)).toBe('For every item in Rows')
+    expect(parts).toEqual([
+      { type: 'text', text: 'For every ' },
+      { type: 'emphasis', text: 'item' },
+      { type: 'text', text: ' in ' },
+      {
+        type: 'variable',
+        id: `step.${STEP_ID}.Rows`,
+        label: 'Rows',
+        position: 'trailing',
+      },
+    ])
+  })
+
+  it('accepts a plain list name', () => {
+    expect(
+      asText(
+        getForEachBlockPreviewParts({
+          items: 'my rows',
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('For every item in my rows')
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
@@ -48,8 +48,7 @@ describe('truncateConditionLabel', () => {
   })
 
   it('leaves interior whitespace alone', () => {
-    // Only the trailing edge of the cut is tidied; the label is otherwise
-    // rendered as the form author wrote it.
+    // The label is otherwise rendered as the form author wrote it.
     expect(truncateConditionLabel('Finance & Corporate  Services')).toBe(
       'Finance & Corporate  Se…',
     )

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_CONDITION_LABEL_LENGTH,
+  truncateConditionLabel,
+} from '../truncateConditionLabel'
+
+describe('truncateConditionLabel', () => {
+  it('leaves a label that already fits untouched', () => {
+    expect(truncateConditionLabel('Application status')).toBe(
+      'Application status',
+    )
+    expect(truncateConditionLabel('')).toBe('')
+  })
+
+  it('keeps a label of exactly the budget intact', () => {
+    const exact = 'FormSG Payments - Amount'
+    expect(exact).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(truncateConditionLabel(exact)).toBe(exact)
+  })
+
+  it('cuts one character short to make room for the ellipsis', () => {
+    expect(truncateConditionLabel('2. What is your full name?')).toBe(
+      '2. What is your full na…',
+    )
+    expect(truncateConditionLabel('2. What is your full name?')).toHaveLength(
+      MAX_CONDITION_LABEL_LENGTH,
+    )
+  })
+
+  it('drops a trailing separator so the ellipsis does not dangle', () => {
+    // FormSG table cell: the cut lands right after " - ".
+    expect(
+      truncateConditionLabel('2. Row 1 Postal Code - Delivery addresses'),
+    ).toBe('2. Row 1 Postal Code…')
+  })
+
+  it('drops a trailing space', () => {
+    // The cut lands on the space before "(before tax)".
+    expect(truncateConditionLabel('Household income range (before tax)')).toBe(
+      'Household income range…',
+    )
+  })
+
+  it('drops a trailing opening bracket', () => {
+    const label = `${'A'.repeat(22)}(before tax)`
+    expect(truncateConditionLabel(label)).toBe(`${'A'.repeat(22)}…`)
+  })
+
+  it('leaves interior whitespace alone', () => {
+    // Only the trailing edge of the cut is tidied; the label is otherwise
+    // rendered as the form author wrote it.
+    expect(truncateConditionLabel('Finance & Corporate  Services')).toBe(
+      'Finance & Corporate  Se…',
+    )
+  })
+
+  it('cuts a label whose tail is all separators back to the ellipsis', () => {
+    expect(truncateConditionLabel(`${'-'.repeat(30)}`)).toBe('…')
+  })
+
+  it('still truncates a long label with no separator to trim', () => {
+    expect(truncateConditionLabel('a3f1c2e8-4b7d-4e91-9f2c-1d8e5a7b3c04')).toBe(
+      'a3f1c2e8-4b7d-4e91-9f2c…',
+    )
+    expect(truncateConditionLabel('data.results.0.customer.email')).toBe(
+      'data.results.0.customer…',
+    )
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
@@ -1,40 +1,23 @@
 import type { ConditionPreviewPart } from './getConditionBlockPreview'
 import { truncateConditionLabel } from './truncateConditionLabel'
 
-/** A preview part paired with the text the header should actually render. */
 export type ConditionSentencePart = ConditionPreviewPart & { display: string }
 
 export interface ConditionSentence {
   parts: ConditionSentencePart[]
-  /** The whole sentence, untruncated, for the tooltip. */
   fullSentence: string
-  /**
-   * Whether a leading part was shortened. Trailing parts are cut by layout
-   * instead, which only the rendered box can report.
-   */
+  /** Whether a leading part was shortened. Only layout cuts trailing parts. */
   isLeadingTruncated: boolean
 }
 
-/**
- * Resolves a variable's real label from its `{{step.<id>.<path>}}` reference,
- * or undefined when it can't be resolved.
- */
+/** Resolves a variable's real label from its `{{step.<id>.<path>}}` id. */
 export type ResolveVariableLabel = (id: string) => string | undefined
 
 /**
  * Turns preview parts into what the header renders.
  *
- * A variable part's own `label` is only the last segment of its dataOut path —
- * `answer` for every FormSG question, a raw column UUID for every Tile — so the
- * real label is resolved through `resolveVariableLabel`, backed by the same
- * metadata the variable picker and the rich-text pills use. That metadata comes
- * from the pipe's last test execution, so an untested pipe resolves nothing and
- * falls back to the path segment.
- *
- * Only leading parts are length-capped. A trailing part is last in the
- * sentence, so letting it run on hides nothing — the block's width and its
- * two-line clamp cut it at whatever the card can actually show. Spill from a
- * leading part would instead push the operator and the value out of view.
+ * IMPORTANT: a variable part's `label` is only the last path segment, so the
+ * real label comes from `resolveVariableLabel`.
  */
 export function buildConditionSentence(
   badgeLabel: string,

--- a/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
@@ -1,0 +1,76 @@
+import type { ConditionPreviewPart } from './getConditionBlockPreview'
+import { truncateConditionLabel } from './truncateConditionLabel'
+
+/** A preview part paired with the text the header should actually render. */
+export type ConditionSentencePart = ConditionPreviewPart & { display: string }
+
+export interface ConditionSentence {
+  parts: ConditionSentencePart[]
+  /** The whole sentence, untruncated, for the tooltip. */
+  fullSentence: string
+  /**
+   * Whether a leading part was shortened. Trailing parts are cut by layout
+   * instead, which only the rendered box can report.
+   */
+  isLeadingTruncated: boolean
+}
+
+/**
+ * Resolves a variable's real label from its `{{step.<id>.<path>}}` reference,
+ * or undefined when it can't be resolved.
+ */
+export type ResolveVariableLabel = (id: string) => string | undefined
+
+/**
+ * Turns preview parts into what the header renders.
+ *
+ * A variable part's own `label` is only the last segment of its dataOut path —
+ * `answer` for every FormSG question, a raw column UUID for every Tile — so the
+ * real label is resolved through `resolveVariableLabel`, backed by the same
+ * metadata the variable picker and the rich-text pills use. That metadata comes
+ * from the pipe's last test execution, so an untested pipe resolves nothing and
+ * falls back to the path segment.
+ *
+ * Only leading parts are length-capped. A trailing part is last in the
+ * sentence, so letting it run on hides nothing — the block's width and its
+ * two-line clamp cut it at whatever the card can actually show. Spill from a
+ * leading part would instead push the operator and the value out of view.
+ */
+export function buildConditionSentence(
+  badgeLabel: string,
+  previewParts: ConditionPreviewPart[],
+  resolveVariableLabel: ResolveVariableLabel,
+): ConditionSentence {
+  let isLeadingTruncated = false
+  const plain: string[] = []
+
+  const parts = previewParts.map((part): ConditionSentencePart => {
+    if (part.type === 'text' || part.type === 'emphasis') {
+      plain.push(part.text)
+      return { ...part, display: part.text }
+    }
+
+    const full =
+      part.type === 'variable'
+        ? resolveVariableLabel(part.id) ?? part.label
+        : part.text
+
+    plain.push(full)
+
+    if (part.position === 'trailing') {
+      return { ...part, display: full }
+    }
+
+    const display = truncateConditionLabel(full)
+    if (display !== full) {
+      isLeadingTruncated = true
+    }
+    return { ...part, display }
+  })
+
+  return {
+    parts,
+    fullSentence: `${badgeLabel} ${plain.join('').trim()}`,
+    isLeadingTruncated,
+  }
+}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
@@ -1,22 +1,18 @@
-import type { IConditionRow, IJSONObject, IMultiRowGroup } from '@plumber/types'
+import type { IJSONObject } from '@plumber/types'
+
+import { z } from 'zod'
 
 /**
- * Where a part sits in the sentence, which is what decides whether it may
- * spill. Only `leading` parts — the ones with the operator and the value still
- * to come after them — are length-capped. A `trailing` part is last, so it is
- * left to run on and the block's own width clips it: no character budget can
- * know how much room a given card has.
+ * Where a part sits in the sentence, which decides whether it may spill.
+ *
+ * IMPORTANT: only `leading` parts are length-capped, since the block's own
+ * width clips a `trailing` part.
  */
 export type ConditionSentencePosition = 'leading' | 'trailing'
 
 export type ConditionPreviewPart =
-  /**
-   * Our own sentence connective — the operator phrase, joining spaces, the
-   * "Specify condition" placeholder. Never truncated: cutting "is greater than
-   * or equal to" loses the meaning of the condition itself.
-   */
+  /** Sentence connective, never cut, since a clipped operator loses meaning. */
   | { type: 'text'; text: string }
-  /** A value the user typed, on either end of the sentence. */
   | { type: 'literal'; text: string; position: ConditionSentencePosition }
   | {
       type: 'variable'
@@ -24,7 +20,6 @@ export type ConditionPreviewPart =
       label: string
       position: ConditionSentencePosition
     }
-  /** Bold non-variable word (e.g. "item" in "For every item in …"). */
   | { type: 'emphasis'; text: string }
 
 const EMPTY_CONDITION_PREVIEW: ConditionPreviewPart[] = [
@@ -35,14 +30,47 @@ const EMPTY_FOR_EACH_PREVIEW: ConditionPreviewPart[] = [
   { type: 'text', text: 'Specify list' },
 ]
 
+// Not `GLOBAL_VARIABLE_REGEX` from RichTextEditor/utils.ts, which captures the
+// whole match rather than the path segment.
 const STEP_VARIABLE_GLOBAL_REGEX =
   /\{\{step\.[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\.([^}|]+)(?:\|[^}]+)?\}\}/gi
 
 /**
- * The verb phrase for each condition operator, in both polarities. Both forms
- * are spelled out rather than derived by prefixing "is not", since not every
- * operator takes that prefix — "contains" negates to "does not contain", not
- * "is not contains".
+ * Lenient read of the parameters a half-configured step holds.
+ *
+ * IMPORTANT: every field falls back instead of throwing, so a malformed
+ * parameter previews as the placeholder rather than breaking the editor.
+ */
+const previewTextSchema = z
+  .union([z.string(), z.number(), z.boolean()])
+  .transform(String)
+  .catch('')
+
+const conditionRowSchema = z.object({
+  field: previewTextSchema,
+  is: previewTextSchema,
+  condition: previewTextSchema,
+  text: previewTextSchema,
+})
+
+const conditionGroupsSchema = z
+  .array(
+    z
+      .object({ rows: z.array(conditionRowSchema).catch([]) })
+      .catch({ rows: [] }),
+  )
+  .catch([])
+
+const forEachItemsSchema = z.string().catch('')
+
+type ConditionRowPreview = z.infer<typeof conditionRowSchema>
+
+/**
+ * The verb phrase for each condition operator, re-spelling the option labels in
+ * the backend's `get-condition-args.ts`, which the header cannot read.
+ *
+ * IMPORTANT: both polarities are spelled out, since "contains" negates to
+ * "does not contain", not "is not contains".
  */
 const OPERATOR_PHRASES: Record<
   string,
@@ -73,16 +101,10 @@ const OPERATOR_PHRASES: Record<
 export function getConditionBlockPreviewParts(
   parameters: IJSONObject | undefined,
 ): ConditionPreviewPart[] {
-  const groups = parameters?.conditions as
-    | IMultiRowGroup<IConditionRow>[]
-    | undefined
-
-  if (!Array.isArray(groups) || groups.length === 0) {
-    return EMPTY_CONDITION_PREVIEW
-  }
+  const groups = conditionGroupsSchema.parse(parameters?.conditions)
 
   for (const group of groups) {
-    for (const row of group.rows ?? []) {
+    for (const row of group.rows) {
       const parts = formatConditionRow(row)
       if (parts.length > 0) {
         return parts
@@ -96,17 +118,17 @@ export function getConditionBlockPreviewParts(
 export function getForEachBlockPreviewParts(
   parameters: IJSONObject | undefined,
 ): ConditionPreviewPart[] {
-  const items = parameters?.items
-  if (typeof items !== 'string' || items.trim().length === 0) {
+  const items = forEachItemsSchema.parse(parameters?.items).trim()
+  if (items.length === 0) {
     return EMPTY_FOR_EACH_PREVIEW
   }
 
-  const itemParts = valueToParts(items.trim(), 'trailing')
+  const itemParts = valueToParts(items, 'trailing')
   if (itemParts.length === 0) {
     return EMPTY_FOR_EACH_PREVIEW
   }
 
-  // Paper 2ZC: "For every item in {list}" — "item" and the list name are bold.
+  // "item" is emphasised alongside the list name, though it is not a variable.
   return [
     { type: 'text', text: 'For every ' },
     { type: 'emphasis', text: 'item' },
@@ -115,19 +137,15 @@ export function getForEachBlockPreviewParts(
   ]
 }
 
-function formatConditionRow(
-  row: Partial<IConditionRow>,
-): ConditionPreviewPart[] {
-  const fieldParts = valueToParts(stringifyValue(row.field), 'leading')
+function formatConditionRow(row: ConditionRowPreview): ConditionPreviewPart[] {
+  const fieldParts = valueToParts(row.field, 'leading')
   const isNegated = row.is === 'not'
   const operatorKey = row.condition
   const operatorPhrase = getOperatorPhrase(operatorKey, isNegated)
   // "empty" is the one operator with nothing to compare against, so any value
   // left over in the row from a previous operator choice is not shown.
   const valueParts =
-    operatorKey === 'empty'
-      ? []
-      : valueToParts(stringifyValue(row.text), 'trailing')
+    operatorKey === 'empty' ? [] : valueToParts(row.text, 'trailing')
 
   if (fieldParts.length === 0 && !operatorPhrase && valueParts.length === 0) {
     return []
@@ -136,7 +154,6 @@ function formatConditionRow(
   const parts: ConditionPreviewPart[] = [...fieldParts]
 
   if (operatorPhrase) {
-    // Space before the phrase when a field pill/text precedes it.
     parts.push({
       type: 'text',
       text: fieldParts.length > 0 ? ` ${operatorPhrase}` : operatorPhrase,
@@ -144,7 +161,6 @@ function formatConditionRow(
   }
 
   if (valueParts.length > 0) {
-    // Space before the value when the field/phrase already rendered.
     if (operatorPhrase || fieldParts.length > 0) {
       parts.push({ type: 'text', text: ' ' })
     }
@@ -154,11 +170,7 @@ function formatConditionRow(
   return parts
 }
 
-/**
- * Splits raw parameter text into literal and variable parts. Step UUIDs are
- * dropped from the label (last path segment only). Everything this emits came
- * from the user, so plain runs are `literal`, not `text`.
- */
+/** Splits user-typed parameter text into `literal` and `variable` parts. */
 function valueToParts(
   raw: string,
   position: ConditionSentencePosition,
@@ -185,7 +197,7 @@ function valueToParts(
 
     const segments = path.split('.').filter(Boolean)
     const label = segments[segments.length - 1] ?? path
-    // Strip surrounding {{ }} for the lookup id used by stepsWithVars.
+    // varInfoMap is keyed without the surrounding {{ }}.
     const id = full.slice(2, -2).split('|')[0]
 
     parts.push({ type: 'variable', id, label, position })
@@ -196,7 +208,6 @@ function valueToParts(
     parts.push({ type: 'literal', text: raw.slice(lastIndex), position })
   }
 
-  // A value with no variables in it at all.
   if (parts.length === 0 && raw.trim()) {
     parts.push({ type: 'literal', text: raw.trim(), position })
   }
@@ -205,14 +216,10 @@ function valueToParts(
 }
 
 /**
- * An unmapped operator key still previews, spelled out as-is behind "is" — a
- * new backend operator shows up in the header as something readable rather
- * than vanishing from the sentence.
+ * Spells an unmapped operator behind "is", so a new backend operator still
+ * previews instead of vanishing.
  */
-function getOperatorPhrase(
-  operatorKey: string | undefined,
-  isNegated: boolean,
-): string {
+function getOperatorPhrase(operatorKey: string, isNegated: boolean): string {
   if (!operatorKey) {
     return ''
   }
@@ -223,17 +230,4 @@ function getOperatorPhrase(
   }
 
   return isNegated ? `is not ${operatorKey}` : `is ${operatorKey}`
-}
-
-function stringifyValue(value: unknown): string {
-  if (value == null) {
-    return ''
-  }
-  if (typeof value === 'string') {
-    return value
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return String(value)
-  }
-  return ''
 }

--- a/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
@@ -1,0 +1,239 @@
+import type { IConditionRow, IJSONObject, IMultiRowGroup } from '@plumber/types'
+
+/**
+ * Where a part sits in the sentence, which is what decides whether it may
+ * spill. Only `leading` parts — the ones with the operator and the value still
+ * to come after them — are length-capped. A `trailing` part is last, so it is
+ * left to run on and the block's own width clips it: no character budget can
+ * know how much room a given card has.
+ */
+export type ConditionSentencePosition = 'leading' | 'trailing'
+
+export type ConditionPreviewPart =
+  /**
+   * Our own sentence connective — the operator phrase, joining spaces, the
+   * "Specify condition" placeholder. Never truncated: cutting "is greater than
+   * or equal to" loses the meaning of the condition itself.
+   */
+  | { type: 'text'; text: string }
+  /** A value the user typed, on either end of the sentence. */
+  | { type: 'literal'; text: string; position: ConditionSentencePosition }
+  | {
+      type: 'variable'
+      id: string
+      label: string
+      position: ConditionSentencePosition
+    }
+  /** Bold non-variable word (e.g. "item" in "For every item in …"). */
+  | { type: 'emphasis'; text: string }
+
+const EMPTY_CONDITION_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Specify condition' },
+]
+
+const EMPTY_FOR_EACH_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Specify list' },
+]
+
+const STEP_VARIABLE_GLOBAL_REGEX =
+  /\{\{step\.[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\.([^}|]+)(?:\|[^}]+)?\}\}/gi
+
+/**
+ * The verb phrase for each condition operator, in both polarities. Both forms
+ * are spelled out rather than derived by prefixing "is not", since not every
+ * operator takes that prefix — "contains" negates to "does not contain", not
+ * "is not contains".
+ */
+const OPERATOR_PHRASES: Record<
+  string,
+  { affirmative: string; negative: string }
+> = {
+  equals: { affirmative: 'is equal to', negative: 'is not equal to' },
+  empty: { affirmative: 'is empty', negative: 'is not empty' },
+  contains: { affirmative: 'contains', negative: 'does not contain' },
+  begins: { affirmative: 'begins with', negative: 'does not begin with' },
+  gt: { affirmative: 'is greater than', negative: 'is not greater than' },
+  gte: {
+    affirmative: 'is greater than or equal to',
+    negative: 'is not greater than or equal to',
+  },
+  lt: { affirmative: 'is less than', negative: 'is not less than' },
+  lte: {
+    affirmative: 'is less than or equal to',
+    negative: 'is not less than or equal to',
+  },
+  before: { affirmative: 'is before', negative: 'is not before' },
+  after: { affirmative: 'is after', negative: 'is not after' },
+}
+
+/**
+ * Structured preview of a toolbox condition step for the block header.
+ * Variables are separate parts so the header can bold / truncate them.
+ */
+export function getConditionBlockPreviewParts(
+  parameters: IJSONObject | undefined,
+): ConditionPreviewPart[] {
+  const groups = parameters?.conditions as
+    | IMultiRowGroup<IConditionRow>[]
+    | undefined
+
+  if (!Array.isArray(groups) || groups.length === 0) {
+    return EMPTY_CONDITION_PREVIEW
+  }
+
+  for (const group of groups) {
+    for (const row of group.rows ?? []) {
+      const parts = formatConditionRow(row)
+      if (parts.length > 0) {
+        return parts
+      }
+    }
+  }
+
+  return EMPTY_CONDITION_PREVIEW
+}
+
+export function getForEachBlockPreviewParts(
+  parameters: IJSONObject | undefined,
+): ConditionPreviewPart[] {
+  const items = parameters?.items
+  if (typeof items !== 'string' || items.trim().length === 0) {
+    return EMPTY_FOR_EACH_PREVIEW
+  }
+
+  const itemParts = valueToParts(items.trim(), 'trailing')
+  if (itemParts.length === 0) {
+    return EMPTY_FOR_EACH_PREVIEW
+  }
+
+  // Paper 2ZC: "For every item in {list}" — "item" and the list name are bold.
+  return [
+    { type: 'text', text: 'For every ' },
+    { type: 'emphasis', text: 'item' },
+    { type: 'text', text: ' in ' },
+    ...itemParts,
+  ]
+}
+
+function formatConditionRow(
+  row: Partial<IConditionRow>,
+): ConditionPreviewPart[] {
+  const fieldParts = valueToParts(stringifyValue(row.field), 'leading')
+  const isNegated = row.is === 'not'
+  const operatorKey = row.condition
+  const operatorPhrase = getOperatorPhrase(operatorKey, isNegated)
+  // "empty" is the one operator with nothing to compare against, so any value
+  // left over in the row from a previous operator choice is not shown.
+  const valueParts =
+    operatorKey === 'empty'
+      ? []
+      : valueToParts(stringifyValue(row.text), 'trailing')
+
+  if (fieldParts.length === 0 && !operatorPhrase && valueParts.length === 0) {
+    return []
+  }
+
+  const parts: ConditionPreviewPart[] = [...fieldParts]
+
+  if (operatorPhrase) {
+    // Space before the phrase when a field pill/text precedes it.
+    parts.push({
+      type: 'text',
+      text: fieldParts.length > 0 ? ` ${operatorPhrase}` : operatorPhrase,
+    })
+  }
+
+  if (valueParts.length > 0) {
+    // Space before the value when the field/phrase already rendered.
+    if (operatorPhrase || fieldParts.length > 0) {
+      parts.push({ type: 'text', text: ' ' })
+    }
+    parts.push(...valueParts)
+  }
+
+  return parts
+}
+
+/**
+ * Splits raw parameter text into literal and variable parts. Step UUIDs are
+ * dropped from the label (last path segment only). Everything this emits came
+ * from the user, so plain runs are `literal`, not `text`.
+ */
+function valueToParts(
+  raw: string,
+  position: ConditionSentencePosition,
+): ConditionPreviewPart[] {
+  if (!raw) {
+    return []
+  }
+
+  const parts: ConditionPreviewPart[] = []
+  let lastIndex = 0
+
+  for (const match of raw.matchAll(STEP_VARIABLE_GLOBAL_REGEX)) {
+    const full = match[0]
+    const path = match[1]
+    const index = match.index ?? 0
+
+    if (index > lastIndex) {
+      parts.push({
+        type: 'literal',
+        text: raw.slice(lastIndex, index),
+        position,
+      })
+    }
+
+    const segments = path.split('.').filter(Boolean)
+    const label = segments[segments.length - 1] ?? path
+    // Strip surrounding {{ }} for the lookup id used by stepsWithVars.
+    const id = full.slice(2, -2).split('|')[0]
+
+    parts.push({ type: 'variable', id, label, position })
+    lastIndex = index + full.length
+  }
+
+  if (lastIndex < raw.length) {
+    parts.push({ type: 'literal', text: raw.slice(lastIndex), position })
+  }
+
+  // A value with no variables in it at all.
+  if (parts.length === 0 && raw.trim()) {
+    parts.push({ type: 'literal', text: raw.trim(), position })
+  }
+
+  return parts
+}
+
+/**
+ * An unmapped operator key still previews, spelled out as-is behind "is" — a
+ * new backend operator shows up in the header as something readable rather
+ * than vanishing from the sentence.
+ */
+function getOperatorPhrase(
+  operatorKey: string | undefined,
+  isNegated: boolean,
+): string {
+  if (!operatorKey) {
+    return ''
+  }
+
+  const phrases = OPERATOR_PHRASES[operatorKey]
+  if (phrases) {
+    return isNegated ? phrases.negative : phrases.affirmative
+  }
+
+  return isNegated ? `is not ${operatorKey}` : `is ${operatorKey}`
+}
+
+function stringifyValue(value: unknown): string {
+  if (value == null) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  return ''
+}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
@@ -1,0 +1,39 @@
+/**
+ * Budget for the field half of a condition sentence — the half that has
+ * something after it. Capping it is what guarantees the operator and the value
+ * still get shown; the value half is deliberately left uncapped and clipped by
+ * the block's own width instead (see ConditionBlockHeader).
+ *
+ * At the 320px minimum block width, two lines of body-2 hold roughly 76
+ * characters, so 24 leaves the operator and a useful amount of value visible
+ * alongside the keyword badge.
+ *
+ * Deliberately a character count rather than a CSS `max-width`: `ch` units
+ * measure the "0" glyph, and in a proportional font that buys wildly different
+ * amounts of real text, which defeats the point of reserving a known share.
+ */
+export const MAX_CONDITION_LABEL_LENGTH = 24
+
+/**
+ * Trailing characters worth dropping before the ellipsis. FormSG builds labels
+ * like "2. Row 1 Postal Code - Delivery addresses", where the cut lands right
+ * after the separator and would otherwise read "2. Row 1 Postal Code - …".
+ */
+const TRAILING_SEPARATORS = /[\s\-–—,.:;/(&]+$/
+
+/**
+ * Shortens one part of the sentence to the shared budget. Returns the label
+ * unchanged when it already fits, so callers can compare the two to tell
+ * whether anything was actually cut.
+ */
+export function truncateConditionLabel(label: string): string {
+  if (label.length <= MAX_CONDITION_LABEL_LENGTH) {
+    return label
+  }
+
+  const cut = label
+    .slice(0, MAX_CONDITION_LABEL_LENGTH - 1)
+    .replace(TRAILING_SEPARATORS, '')
+
+  return `${cut}…`
+}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
@@ -1,31 +1,19 @@
 /**
- * Budget for the field half of a condition sentence — the half that has
- * something after it. Capping it is what guarantees the operator and the value
- * still get shown; the value half is deliberately left uncapped and clipped by
- * the block's own width instead (see ConditionBlockHeader).
+ * Character budget for the field half of a condition sentence, so the operator
+ * and the value stay visible.
  *
- * At the 320px minimum block width, two lines of body-2 hold roughly 76
- * characters, so 24 leaves the operator and a useful amount of value visible
- * alongside the keyword badge.
- *
- * Deliberately a character count rather than a CSS `max-width`: `ch` units
- * measure the "0" glyph, and in a proportional font that buys wildly different
- * amounts of real text, which defeats the point of reserving a known share.
+ * IMPORTANT: a `ch` max-width would measure the "0" glyph, which buys
+ * unpredictable amounts of proportional text.
  */
 export const MAX_CONDITION_LABEL_LENGTH = 24
 
 /**
- * Trailing characters worth dropping before the ellipsis. FormSG builds labels
- * like "2. Row 1 Postal Code - Delivery addresses", where the cut lands right
- * after the separator and would otherwise read "2. Row 1 Postal Code - …".
+ * Trailing characters worth dropping before the ellipsis, so a cut FormSG
+ * label does not read "2. Row 1 Postal Code - …".
  */
 const TRAILING_SEPARATORS = /[\s\-–—,.:;/(&]+$/
 
-/**
- * Shortens one part of the sentence to the shared budget. Returns the label
- * unchanged when it already fits, so callers can compare the two to tell
- * whether anything was actually cut.
- */
+/** Shortens one part of the sentence to the shared budget. */
 export function truncateConditionLabel(label: string): string {
   if (label.length <= MAX_CONDITION_LABEL_LENGTH) {
     return label


### PR DESCRIPTION
## Stack Context

This sub-stack (#2028–#2032) makes a nested condition block state its condition in plain language. Today an `IF` / `CONTINUE IF` / `REPEAT` block shows an app icon plus a generic caption, and if-then repeats the condition a second time in a card directly underneath — so you cannot tell two sibling branches apart without opening both drawers.

By the end of the sub-stack each block renders a keyword badge plus a live sentence built from the step's own parameters. All behind the existing `feature_if_then_then` flag; V1 output is unchanged.

| PR | |
|---|---|
| **#2028 (this one)** | preview helpers, no UI |
| #2029 | `ConditionBlockHeader` + `conditionBlockStyles` |
| #2030 | `CONTINUE IF` block + the `asConditionBlock` prop |
| #2031 | `IF` block header |
| #2032 | `REPEAT` block header + for-each renderer split |

## What?

Three pure helpers and their tests. No call sites yet — nothing renders differently after this PR.

- **`getConditionBlockPreview`** — parses `step.parameters.conditions` (and for-each's `items`) into styled parts: `text` connectives, `literal` user input, `variable`, `emphasis`. Resolves `{{step.<uuid>.<path>}}` down to its last path segment and drops `|modifier` suffixes. Marks each part `position: 'leading' | 'trailing'`.
- **`truncateConditionLabel`** — 24-char cap, trimming trailing separators before the ellipsis so you don't get `Question 1 -…`.
- **`buildConditionSentence`** — assembles parts into a sentence. Takes a `resolveVariableLabel` callback rather than a `varInfoMap`, so it has no React or GraphQL dependency and is testable as a plain function.

40 tests (23 / 9 / 8).

## Why?

Splitting the parsing out first keeps it honest: the sentence-building rules are where the fiddly cases live (empty rows, missing operators, unresolvable variables, modifier suffixes), and they are much easier to pin down as pure functions than by rendering a component and reading the DOM.

### Truncation policy — deliberate, please don't "fix" it

Only **leading** parts are character-capped, so the operator and the value can never be pushed out of view. **Trailing** parts (the comparison value; for-each's list name) are left to spill and get clipped by the card width via a 2-line clamp in #2029. That is why parts carry `position` at all.

The consequence for #2029: a tooltip cannot be gated on the character cap alone, because the trailing half is cut by layout rather than by count — it has to measure the rendered box too.

## Known gap

`getConditionBlockPreviewParts` returns on the **first non-empty row of the first group** (caps: 10 groups × 10 rows). A block with 8 ANDed checks therefore renders as one, with nothing signalling the other 7.

Not addressed here because the fix is a copy decision, not a parsing one: groups are OR'd and rows within a group are AND'd, so a bare `+7` would mislead. Sketch for a follow-up — `… and 2 more` for extra rows, `… or 2 more` for extra groups, `+N more conditions` when both. Happy to take direction on the wording.








<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds pure helpers for converting condition and for-each parameters into structured plain-language previews, resolving display labels, and truncating leading labels without changing current UI behavior.
- Parses condition rows and repeat-list parameters into typed preview parts.
- Builds full and display-ready condition sentences through a callback-based variable-label resolver.
- Adds focused tests for parsing, sentence construction, fallback behavior, and truncation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts | Adds lenient parameter parsing and structured preview-part generation consistent with current condition schemas and operators. |
| packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts | Adds pure sentence assembly, variable-label resolution, and deliberate leading-part truncation reporting. |
| packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts | Adds the shared 24-character truncation policy with separator cleanup before ellipses. |
| packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts | Covers malformed and partial parameters, operators, variables, modifiers, part positioning, and for-each previews. |
| packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts | Covers variable resolution, fallback labels, selective truncation, and full sentence generation. |
| packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts | Covers boundary lengths and cleanup of separators, spaces, and brackets at truncation points. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore(editor): tighten condition-preview..."](https://github.com/opengovsg/plumber/commit/b3d1aa8a0f7bef6e8edd79dc880420d6ecf371ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59432630)</sub>

<!-- /greptile_comment -->