### PR TITLE
PLU-743: [IF-THEN-THEN-V2-19] Shared condition block header

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -43,14 +43,10 @@ export const blockActionButtonStyles = {
 }
 
 /**
- * The strip a condition block's actions are overlaid in, and the width that
- * strip occupies. The two live together because the header reserves `widthPx`
- * of text padding to keep the sentence out from under the buttons — change the
- * padding, the gap or `blockActionButtonStyles.boxSize` without changing the
- * total and the text silently slides back under them.
+ * The strip a condition block's actions are overlaid in.
  *
- * Sized for the widest case (a duplicate and a delete), so a single-button
- * block over-reserves by one button rather than losing text.
+ * IMPORTANT: `BLOCK_ACTIONS_OVERLAY_WIDTH_PX` must change with these values,
+ * or the header's reserved padding stops clearing the buttons.
  */
 export const blockActionsOverlayStyles = {
   pl: 2, // 8px
@@ -58,7 +54,10 @@ export const blockActionsOverlayStyles = {
   gap: 1, // 4px
 }
 
-/** 8 + 32 + 4 + 32 + 16, from the values directly above. */
+/**
+ * 8 + 32 + 4 + 32 + 16, from `blockActionsOverlayStyles` and
+ * `blockActionButtonStyles.boxSize`.
+ */
 export const BLOCK_ACTIONS_OVERLAY_WIDTH_PX = 92
 
 export const branchStyles = {
@@ -75,13 +74,11 @@ export const branchStyles = {
 }
 
 /**
- * The card a condition block (IF / CONTINUE IF / REPEAT) draws: a grey header
- * strip flush to the top and side edges, over a white body holding the steps.
- * Distinct from `branchStyles`, which an if-then V1 branch still uses.
+ * The card a condition block (IF / CONTINUE IF / REPEAT) draws, distinct from
+ * `branchStyles` which an if-then V1 branch still uses.
  */
 export const conditionBlockStyles = {
-  // No padding of its own, so the header can sit flush. Body padding lives on
-  // `body` instead.
+  // No padding of its own, so the header can sit flush.
   container: {
     alignItems: 'stretch',
     bg: 'white',

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -42,6 +42,25 @@ export const blockActionButtonStyles = {
   colorScheme: 'secondary',
 }
 
+/**
+ * The strip a condition block's actions are overlaid in, and the width that
+ * strip occupies. The two live together because the header reserves `widthPx`
+ * of text padding to keep the sentence out from under the buttons — change the
+ * padding, the gap or `blockActionButtonStyles.boxSize` without changing the
+ * total and the text silently slides back under them.
+ *
+ * Sized for the widest case (a duplicate and a delete), so a single-button
+ * block over-reserves by one button rather than losing text.
+ */
+export const blockActionsOverlayStyles = {
+  pl: 2, // 8px
+  pr: 4, // 16px
+  gap: 1, // 4px
+}
+
+/** 8 + 32 + 4 + 32 + 16, from the values directly above. */
+export const BLOCK_ACTIONS_OVERLAY_WIDTH_PX = 92
+
 export const branchStyles = {
   container: {
     alignItems: 'center',
@@ -51,6 +70,41 @@ export const branchStyles = {
     overflow: 'hidden',
     px: 3,
     py: 3,
+    w: '100%',
+  },
+}
+
+/**
+ * The card a condition block (IF / CONTINUE IF / REPEAT) draws: a grey header
+ * strip flush to the top and side edges, over a white body holding the steps.
+ * Distinct from `branchStyles`, which an if-then V1 branch still uses.
+ */
+export const conditionBlockStyles = {
+  // No padding of its own, so the header can sit flush. Body padding lives on
+  // `body` instead.
+  container: {
+    alignItems: 'stretch',
+    bg: 'white',
+    borderRadius: 'lg',
+    direction: 'column' as FlexProps['direction'],
+    overflow: 'hidden',
+    w: '100%',
+  },
+  header: {
+    bg: 'base.divider.subtle',
+    borderRadius: 'none',
+    px: 4,
+    py: 3,
+    minH: 12,
+    w: '100%',
+  },
+  body: {
+    alignItems: 'stretch',
+    bg: 'white',
+    direction: 'column' as FlexProps['direction'],
+    px: 3,
+    pt: 4,
+    pb: 0,
     w: '100%',
   },
 }

--- a/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
@@ -21,7 +21,7 @@ import {
 import { buildConditionSentence } from '../helpers/buildConditionSentence'
 import type { ConditionPreviewPart } from '../helpers/getConditionBlockPreview'
 
-interface ConditionBlockHeaderProps {
+interface BlockHeaderProps {
   badgeLabel: string
   previewParts: ConditionPreviewPart[]
   stepId: string
@@ -30,23 +30,18 @@ interface ConditionBlockHeaderProps {
 }
 
 /**
- * Shared header for nested condition blocks (IF / CONTINUE IF / REPEAT):
- * pink keyword badge as an inline span in the plain-language preview. Click
- * opens the step drawer.
+ * Shared header for nested condition blocks (IF / CONTINUE IF / REPEAT).
  *
- * Actions overlay the trailing edge rather than sitting beside the text, so
- * revealing them on hover doesn't reflow the sentence. The cost is that they
- * cover the tail of the text, so the text reserves room for them at the widths
- * where they are always visible (see `pr` below); on desktop they only appear
- * on hover, and the tooltip covers what they hide.
+ * IMPORTANT: the actions overlay the trailing edge, so revealing them on hover
+ * does not reflow the sentence.
  */
-export default function ConditionBlockHeader({
+export default function BlockHeader({
   badgeLabel,
   previewParts,
   stepId,
   isSelected = false,
   actions,
-}: ConditionBlockHeaderProps): JSX.Element {
+}: BlockHeaderProps): JSX.Element {
   const {
     currentStepId,
     isDrawerOpen,
@@ -98,12 +93,8 @@ export default function ConditionBlockHeader({
     [badgeLabel, previewParts, varInfoMap],
   )
 
-  /**
-   * Whether the clamp is hiding anything. Needed because the value half is now
-   * cut by layout rather than by character count, which no amount of measuring
-   * the string can predict — so the rendered box is asked directly, and again
-   * whenever it is resized (opening the drawer re-flows every block).
-   */
+  // The value half is cut by layout, so only the rendered box can report a
+  // clamp.
   const clampedTextRef = useRef<HTMLParagraphElement>(null)
   const [isClamped, setIsClamped] = useState(false)
 
@@ -135,8 +126,7 @@ export default function ConditionBlockHeader({
         onClick={handleClick}
       >
         <Tooltip
-          // Only when something was actually cut: a tooltip repeating text
-          // already fully on screen is noise.
+          // A tooltip repeating text already fully on screen is noise.
           isDisabled={!isLeadingTruncated && !isClamped}
           label={fullSentence}
           placement="top-start"
@@ -150,9 +140,8 @@ export default function ConditionBlockHeader({
             noOfLines={2}
             textStyle="body-2"
             color="base.content.medium"
-            // Room for the actions overlay only at the widths where it is always
-            // on. Reserving it on desktop too would cost a quarter of the line
-            // at the 320px minimum to buttons that are usually hidden.
+            // Reserved only at the widths where the overlay is always on,
+            // since desktop hides it until hover.
             pr={{
               base: actions ? `${BLOCK_ACTIONS_OVERLAY_WIDTH_PX}px` : 0,
               lg: 0,
@@ -174,8 +163,6 @@ export default function ConditionBlockHeader({
               {badgeLabel}
             </Text>
             {parts.map((part, index) => {
-              // Connectives and typed values read as ordinary prose; only
-              // variables (and the for-each keyword) are picked out in bold.
               if (part.type === 'text' || part.type === 'literal') {
                 return <span key={`${part.type}-${index}`}>{part.display}</span>
               }
@@ -208,7 +195,7 @@ export default function ConditionBlockHeader({
             alignItems="center"
             {...blockActionsOverlayStyles}
             bg={headerBg}
-            // Always on for touch; fade in over the text on desktop hover.
+            // Always on for touch, since there is no hover there.
             opacity={{ base: 1, lg: 0 }}
             pointerEvents={{ base: 'auto', lg: 'none' }}
             transition="opacity 0.15s ease-in-out"

--- a/packages/frontend/src/components/FlowStepGroup/components/ConditionBlockHeader.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/ConditionBlockHeader.tsx
@@ -1,0 +1,235 @@
+import type { ReactNode } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { Flex, Text, Tooltip } from '@chakra-ui/react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+
+import UnsavedChangesAlert from '../../Editor/components/UnsavedChangesAlert'
+import {
+  BLOCK_ACTIONS_OVERLAY_WIDTH_PX,
+  blockActionsOverlayStyles,
+  conditionBlockStyles,
+} from '../Content/IfThen/styles'
+import { buildConditionSentence } from '../helpers/buildConditionSentence'
+import type { ConditionPreviewPart } from '../helpers/getConditionBlockPreview'
+
+interface ConditionBlockHeaderProps {
+  badgeLabel: string
+  previewParts: ConditionPreviewPart[]
+  stepId: string
+  isSelected?: boolean
+  actions?: ReactNode
+}
+
+/**
+ * Shared header for nested condition blocks (IF / CONTINUE IF / REPEAT):
+ * pink keyword badge as an inline span in the plain-language preview. Click
+ * opens the step drawer.
+ *
+ * Actions overlay the trailing edge rather than sitting beside the text, so
+ * revealing them on hover doesn't reflow the sentence. The cost is that they
+ * cover the tail of the text, so the text reserves room for them at the widths
+ * where they are always visible (see `pr` below); on desktop they only appear
+ * on hover, and the tooltip covers what they hide.
+ */
+export default function ConditionBlockHeader({
+  badgeLabel,
+  previewParts,
+  stepId,
+  isSelected = false,
+  actions,
+}: ConditionBlockHeaderProps): JSX.Element {
+  const {
+    currentStepId,
+    isDrawerOpen,
+    onDrawerClose,
+    onDrawerOpen,
+    setCurrentStepId,
+    varInfoMap,
+  } = useContext(EditorContext)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: () => {
+      setCurrentStepId(stepId)
+      onDrawerOpen()
+    },
+  })
+
+  const handleClick = useCallback(() => {
+    if (isDrawerOpen && currentStepId === stepId) {
+      setCurrentStepId(null)
+      onDrawerClose()
+      return
+    }
+
+    handleProceed()
+  }, [
+    currentStepId,
+    handleProceed,
+    isDrawerOpen,
+    onDrawerClose,
+    setCurrentStepId,
+    stepId,
+  ])
+
+  const headerBg = isSelected ? 'primary.50' : conditionBlockStyles.header.bg
+
+  const { parts, fullSentence, isLeadingTruncated } = useMemo(
+    () =>
+      buildConditionSentence(
+        badgeLabel,
+        previewParts,
+        (id) => varInfoMap.get(`{{${id}}}`)?.label,
+      ),
+    [badgeLabel, previewParts, varInfoMap],
+  )
+
+  /**
+   * Whether the clamp is hiding anything. Needed because the value half is now
+   * cut by layout rather than by character count, which no amount of measuring
+   * the string can predict — so the rendered box is asked directly, and again
+   * whenever it is resized (opening the drawer re-flows every block).
+   */
+  const clampedTextRef = useRef<HTMLParagraphElement>(null)
+  const [isClamped, setIsClamped] = useState(false)
+
+  useEffect(() => {
+    const element = clampedTextRef.current
+    if (!element) {
+      return
+    }
+
+    const measure = () =>
+      setIsClamped(element.scrollHeight > element.clientHeight + 1)
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [parts])
+
+  return (
+    <>
+      <Flex
+        {...conditionBlockStyles.header}
+        position="relative"
+        role="group"
+        alignItems="center"
+        cursor="pointer"
+        bg={headerBg}
+        _hover={{ bg: 'interaction.muted.neutral.hover' }}
+        onClick={handleClick}
+      >
+        <Tooltip
+          // Only when something was actually cut: a tooltip repeating text
+          // already fully on screen is noise.
+          isDisabled={!isLeadingTruncated && !isClamped}
+          label={fullSentence}
+          placement="top-start"
+          openDelay={300}
+          hasArrow
+        >
+          <Text
+            ref={clampedTextRef}
+            flex="1"
+            minW={0}
+            noOfLines={2}
+            textStyle="body-2"
+            color="base.content.medium"
+            // Room for the actions overlay only at the widths where it is always
+            // on. Reserving it on desktop too would cost a quarter of the line
+            // at the 320px minimum to buttons that are usually hidden.
+            pr={{
+              base: actions ? `${BLOCK_ACTIONS_OVERLAY_WIDTH_PX}px` : 0,
+              lg: 0,
+            }}
+          >
+            <Text
+              as="span"
+              display="inline-flex"
+              alignItems="center"
+              verticalAlign="text-bottom"
+              px={2}
+              py="2px"
+              mr={2}
+              borderRadius="md"
+              bg="primary.100"
+              color="primary.500"
+              textStyle="caption-3"
+            >
+              {badgeLabel}
+            </Text>
+            {parts.map((part, index) => {
+              // Connectives and typed values read as ordinary prose; only
+              // variables (and the for-each keyword) are picked out in bold.
+              if (part.type === 'text' || part.type === 'literal') {
+                return <span key={`${part.type}-${index}`}>{part.display}</span>
+              }
+
+              return (
+                <Text
+                  as="span"
+                  key={
+                    part.type === 'emphasis'
+                      ? `em-${index}`
+                      : `var-${part.id}-${index}`
+                  }
+                  fontWeight="700"
+                  color="base.content.strong"
+                >
+                  {part.display}
+                </Text>
+              )
+            })}
+          </Text>
+        </Tooltip>
+
+        {actions && (
+          <Flex
+            position="absolute"
+            top={0}
+            right={0}
+            bottom={0}
+            zIndex={1}
+            alignItems="center"
+            {...blockActionsOverlayStyles}
+            bg={headerBg}
+            // Always on for touch; fade in over the text on desktop hover.
+            opacity={{ base: 1, lg: 0 }}
+            pointerEvents={{ base: 'auto', lg: 'none' }}
+            transition="opacity 0.15s ease-in-out"
+            _groupHover={{
+              opacity: 1,
+              pointerEvents: 'auto',
+              bg: 'interaction.muted.neutral.hover',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {actions}
+          </Flex>
+        )}
+      </Flex>
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={discardChanges}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Stack Context

This sub-stack (#2028–#2032) makes a nested condition block state its condition in plain language instead of showing an app icon and a generic caption. #2028 carries the full breakdown. This PR adds the header component that #2030, #2031 and #2032 all render.

## What?

- **`ConditionBlockHeader`** — pink keyword badge as an inline span in the sentence, click to open the step drawer behind the unsaved-changes guard. Resolves variable labels through `varInfoMap` and delegates the sentence to `buildConditionSentence` from #2028.
- **`conditionBlockStyles`** — the card a condition block draws: grey header strip flush to the top and side edges, over a white body holding the steps.
- **`blockActionsOverlayStyles`** + **`BLOCK_ACTIONS_OVERLAY_WIDTH_PX`**.

No call sites yet — the component is unused until #2030.

## Why?

All three blocks (`IF`, `CONTINUE IF`, `REPEAT`) need the same header, and it carries enough behaviour — click-to-open, unsaved-changes guard, label resolution, clamp measurement — that three copies would drift.

### Actions overlay the text instead of sitting beside it

If the buttons sat next to the sentence, revealing them on hover would reflow the text, so it would visibly jump every time your pointer crossed the block. Instead they are absolutely positioned over the trailing edge.

The cost is that they cover the tail of the sentence. The text reserves `BLOCK_ACTIONS_OVERLAY_WIDTH_PX` of padding only at the widths where the buttons are always on (touch); on desktop they fade in on hover and the tooltip covers what they hide. Reserving that space on desktop too would cost a quarter of the line at the 320px minimum, for buttons that are usually hidden.

`blockActionsOverlayStyles` and the width constant live side by side on purpose: change the padding, the gap or `blockActionButtonStyles.boxSize` without changing the total, and the text silently slides back under the buttons with no test to catch it. The width is sized for the widest case (duplicate + delete), so a single-button block over-reserves by one button rather than losing text.

### The tooltip has to measure, not just count

Per #2028's truncation policy, only leading parts are character-capped; trailing parts are clipped by layout via the 2-line clamp. So the tooltip is gated on **either** a leading cut (known from the helper) **or** a measured clamp — `scrollHeight > clientHeight`, re-measured through a `ResizeObserver` because opening the drawer re-flows every block on the canvas.

### `conditionBlockStyles` is new, not a rename of `branchStyles`

`branchStyles` is still consumed by if-then **V1** branches and by the AI Builder steps preview. Redefining it would change both. The two objects will converge only when the V1 path is deleted.

## Not tested

Render-and-measure behaviour, and this area of the repo has no render tests to extend. The three pure helpers underneath it are covered by #2028's 40 tests; what is left here is DOM measurement and Chakra styling.










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a reusable condition-block header and shared styling for upcoming IF, CONTINUE IF, and REPEAT integrations.
- Builds plain-language condition previews with variable-label resolution and measured truncation tooltips.
- Adds drawer-toggle behavior and an overlay for condition-block actions.
- Adds shared condition-block container, header, body, and action-overlay styles.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the currently reachable code.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/components/ConditionBlockHeader.tsx | Adds the shared condition preview header, tooltip measurement, drawer interaction, and action overlay; the previously reported interaction issues remain. |
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts | Adds condition-block card styles and shared action-overlay dimensions without introducing a blocking failure. |

</details>

<sub>Reviews (5): Last reviewed commit: ["chore(editor): tighten condition-block h..."](https://github.com/opengovsg/plumber/commit/36f563ad9dd126cbd47e0942754c42ee34297c1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59432629)</sub>

<!-- /greptile_comment -->