### PR TITLE
PLU-743: [IF-THEN-THEN-V2-20] Render only-continue-if as a CONTINUE IF block

### DIFF
--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -2,9 +2,11 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 
+import OnlyContinueIf from '@/components/FlowStepGroup/Content/OnlyContinueIf'
 import { SortableItemContext } from '@/components/SortableList/components/SortableItem'
 import { MrfContext } from '@/contexts/MrfContext'
 import { FlowStep } from '@/exports/components'
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
 
 import { AddStepButton } from './AddStepButton'
 import { DisabledFlowStep } from './DisabledFlowStep'
@@ -19,6 +21,7 @@ export default function FlowStepWithAddButton({
     isDisabled = false,
     showEmptyAction = false,
   },
+  asConditionBlock = false,
 }: {
   step: IStep
   isLastStep: boolean
@@ -31,6 +34,12 @@ export default function FlowStepWithAddButton({
     isDisabled: boolean
     showEmptyAction: boolean
   }
+  /**
+   * Draw an only-continue-if step as a CONTINUE IF condition block instead of
+   * an ordinary step card. Set by the if-then V2 render path only, so the flag
+   * is read once by StepsList rather than by every step in the list.
+   */
+  asConditionBlock?: boolean
 }) {
   const { disabledMrfStepToDisplay } = useContext(MrfContext)
   const { isOverlay, isSorting } = useContext(SortableItemContext)
@@ -39,13 +48,22 @@ export default function FlowStepWithAddButton({
 
   return (
     <>
-      <FlowStep
-        step={step}
-        isLastStep={isLastStep}
-        isNested={isNested}
-        // only allow reordering if there are more than 1 action steps
-        allowReorder={allowReorder}
-      />
+      {asConditionBlock && isOnlyContinueIfStep(step) ? (
+        <OnlyContinueIf
+          step={step}
+          isLastStep={isLastStep}
+          isNested={isNested}
+          allowReorder={allowReorder}
+        />
+      ) : (
+        <FlowStep
+          step={step}
+          isLastStep={isLastStep}
+          isNested={isNested}
+          // only allow reordering if there are more than 1 action steps
+          allowReorder={allowReorder}
+        />
+      )}
       {/* Hide the add step button and dividers for the drag overlay */}
       {!isOverlay && (
         <AddStepButton

--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -34,11 +34,7 @@ export default function FlowStepWithAddButton({
     isDisabled: boolean
     showEmptyAction: boolean
   }
-  /**
-   * Draw an only-continue-if step as a CONTINUE IF condition block instead of
-   * an ordinary step card. Set by the if-then V2 render path only, so the flag
-   * is read once by StepsList rather than by every step in the list.
-   */
+  /** Draw an only-continue-if step as a CONTINUE IF condition block. */
   asConditionBlock?: boolean
 }) {
   const { disabledMrfStepToDisplay } = useContext(MrfContext)

--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -230,6 +230,7 @@ export function StepsList({ isNested }: StepsListProps) {
                     allowReorder={canReorderBlocks}
                     stepsBeforeGroup={[]}
                     groupedSteps={[]}
+                    asConditionBlock
                     addButtonProps={{
                       isHidden: readOnly || !!isOverlay,
                       isDisabled: false,

--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -230,6 +230,7 @@ export function StepsList({ isNested }: StepsListProps) {
                     allowReorder={canReorderBlocks}
                     stepsBeforeGroup={[]}
                     groupedSteps={[]}
+                    // Reads the if-then V2 gate once here, not per step.
                     asConditionBlock
                     addButtonProps={{
                       isHidden: readOnly || !!isOverlay,

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -24,10 +24,18 @@ interface DeleteStepButtonProps {
   step: IStep
   stepName: string
   displayPosition?: number
+  /** Skip FlowStep’s hover-reveal CSS — parent already controls visibility. */
+  alwaysVisible?: boolean
 }
 
 export default function DeleteStepButton(props: DeleteStepButtonProps) {
-  const { isNested, step, stepName, displayPosition } = props
+  const {
+    isNested,
+    step,
+    stepName,
+    displayPosition,
+    alwaysVisible = false,
+  } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
   const customBody = stepName
     ? `Are you sure you want to delete step **${
@@ -139,8 +147,10 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
           icon={<BiTrash />}
           minHeight={isNested ? 6 : 8}
           minWidth={isNested ? 6 : 8}
-          className={isMobile ? undefined : 'hover-remove-button'}
-          visibility={isMobile ? 'visible' : 'hidden'}
+          className={
+            isMobile || alwaysVisible ? undefined : 'hover-remove-button'
+          }
+          visibility={isMobile || alwaysVisible ? 'visible' : 'hidden'}
         />
       </Flex>
 

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -24,7 +24,7 @@ interface DeleteStepButtonProps {
   step: IStep
   stepName: string
   displayPosition?: number
-  /** Skip FlowStep’s hover-reveal CSS — parent already controls visibility. */
+  /** Skip FlowStep's hover-reveal CSS, since the parent controls visibility. */
   alwaysVisible?: boolean
 }
 

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -15,7 +15,7 @@ import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 interface DuplicateStepButtonProps {
   isNested?: boolean
   step: IStep
-  /** Skip FlowStep’s hover-reveal CSS — parent already controls visibility. */
+  /** Skip FlowStep's hover-reveal CSS, since the parent controls visibility. */
   alwaysVisible?: boolean
 }
 

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -15,10 +15,12 @@ import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 interface DuplicateStepButtonProps {
   isNested?: boolean
   step: IStep
+  /** Skip FlowStep’s hover-reveal CSS — parent already controls visibility. */
+  alwaysVisible?: boolean
 }
 
 export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
-  const { isNested, step } = props
+  const { isNested, step, alwaysVisible = false } = props
 
   const { flow, isMobile, onDrawerOpen, setCurrentStepId } =
     useContext(EditorContext)
@@ -84,8 +86,10 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
           icon={<BiDuplicate />}
           minHeight={isNested ? 6 : 8}
           minWidth={isNested ? 6 : 8}
-          className={isMobile ? undefined : 'hover-remove-button'}
-          visibility={isMobile ? 'visible' : 'hidden'}
+          className={
+            isMobile || alwaysVisible ? undefined : 'hover-remove-button'
+          }
+          visibility={isMobile || alwaysVisible ? 'visible' : 'hidden'}
         />
       </Tooltip>
       <UnsavedChangesAlert

--- a/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
@@ -1,0 +1,199 @@
+import { IStep } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+import { BiSolidErrorCircle } from 'react-icons/bi'
+import { Box, Flex, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
+
+import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
+import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
+import DeleteStepButton from '@/components/FlowStep/components/DeleteStepButton'
+import DuplicateStepButton from '@/components/FlowStep/components/DuplicateStepButton'
+import FlowStepWrapper from '@/components/FlowStep/FlowStepWrapper'
+import { DragHandle } from '@/components/SortableList/components'
+import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
+import { EditorContext } from '@/contexts/Editor'
+import { getFlowStepHeaderWidth } from '@/helpers/editor'
+import { useStepMetadata } from '@/hooks/useStepMetadata'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+
+import ConditionBlockHeader from '../../components/ConditionBlockHeader'
+import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
+import { conditionBlockStyles } from '../IfThen/styles'
+
+interface OnlyContinueIfProps {
+  step: IStep
+  isNested?: boolean
+  allowReorder?: boolean
+  canChildStepsReorder?: boolean
+  /** When true, omit the caption — nothing follows this step to gate. */
+  isLastStep?: boolean
+}
+
+/**
+ * An only-continue-if step drawn like the IF / REPEAT condition headers: a
+ * CONTINUE IF badge and a live condition preview. Unlike those two it holds no
+ * steps — the ones it gates are its siblings below — so a caption under the
+ * card spells out that a failed check stops the flow there.
+ */
+export default function OnlyContinueIf({
+  step,
+  isNested = false,
+  allowReorder = true,
+  canChildStepsReorder = false,
+  isLastStep = false,
+}: OnlyContinueIfProps): JSX.Element {
+  const { currentStepId, isDrawerOpen, isMobile, readOnly } =
+    useContext(EditorContext)
+  const {
+    displayPosition,
+    isDeletable,
+    shouldShowDragHandle,
+    stepName,
+    warnsMrfNoGate,
+  } = useStepMetadata(step, allowReorder)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: () => undefined,
+  })
+
+  const isSelected = currentStepId === step.id
+  const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
+  const nestedHandleOffset =
+    isNested && shouldShowDragHandle ? NESTED_DRAG_HANDLE_WIDTH / 2 : 0
+
+  const previewParts = useMemo(
+    () => getConditionBlockPreviewParts(step.parameters),
+    [step.parameters],
+  )
+
+  return (
+    <FlowStepWrapper
+      canChildStepsReorder={canChildStepsReorder}
+      allowReorder={allowReorder}
+      isDrawerOpen={isDrawerOpen}
+      isReadOnly={readOnly}
+    >
+      <Flex flexDir="column" w="100%" alignItems="center">
+        <Flex
+          pos="relative"
+          alignItems="center"
+          w={headerWidth}
+          minW={MIN_FLOW_STEP_WIDTH}
+          flexDir="column"
+        >
+          {warnsMrfNoGate && (
+            <Box
+              borderColor={
+                isSelected ? 'base.content.brand' : 'base.divider.medium'
+              }
+              borderRadius="lg"
+              borderWidth="1px"
+              borderBottomRadius="none"
+              borderBottomWidth={0}
+              w="100%"
+              overflow="hidden"
+            >
+              <Infobox
+                icon={<BiSolidErrorCircle />}
+                variant="warning"
+                style={{
+                  borderBottomLeftRadius: '0',
+                  borderBottomRightRadius: '0',
+                }}
+              >
+                This won&rsquo;t stop the next respondent. FormSG still sends
+                them the form. &ldquo;Only continue if&rdquo; only skips the
+                Plumber steps below.
+              </Infobox>
+            </Box>
+          )}
+          <Flex w="100%" alignItems="center" pos="relative">
+            <Flex
+              {...conditionBlockStyles.container}
+              display={isMobile ? 'block' : 'flex'}
+              flex={nestedHandleOffset ? undefined : '1'}
+              flexShrink={nestedHandleOffset ? 0 : undefined}
+              w={
+                nestedHandleOffset
+                  ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+                  : undefined
+              }
+              ml={nestedHandleOffset ? `${nestedHandleOffset}px` : undefined}
+              minW="0"
+              overflow="hidden"
+              borderWidth="1px"
+              borderTopWidth={warnsMrfNoGate ? 0 : '1px'}
+              borderColor={
+                isSelected ? 'base.content.brand' : 'base.divider.medium'
+              }
+              borderTopRadius={warnsMrfNoGate ? 'none' : 'lg'}
+            >
+              <ConditionBlockHeader
+                badgeLabel="CONTINUE IF"
+                previewParts={previewParts}
+                stepId={step.id}
+                isSelected={isSelected}
+                actions={
+                  isDeletable && !readOnly ? (
+                    <>
+                      <DuplicateStepButton
+                        alwaysVisible
+                        isNested={isNested}
+                        step={step}
+                      />
+                      <DeleteStepButton
+                        alwaysVisible
+                        isNested={isNested}
+                        step={step}
+                        displayPosition={displayPosition}
+                        stepName={stepName}
+                      />
+                    </>
+                  ) : undefined
+                }
+              />
+            </Flex>
+            {shouldShowDragHandle &&
+              (isNested ? (
+                <DragHandle isNested={isNested} onWarningOpen={onWarningOpen} />
+              ) : (
+                <Box position="absolute" left="100%" alignSelf="center">
+                  <DragHandle onWarningOpen={onWarningOpen} />
+                </Box>
+              ))}
+          </Flex>
+        </Flex>
+
+        {!isLastStep && (
+          <Text
+            mt={3}
+            mb={1}
+            textAlign="center"
+            fontSize="0.6875rem"
+            lineHeight="0.875rem"
+            letterSpacing="0.03em"
+            textTransform="uppercase"
+            fontWeight="500"
+            color="base.divider.strong"
+          >
+            Otherwise flow stops here
+          </Text>
+        )}
+      </Flex>
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={discardChanges}
+      />
+    </FlowStepWrapper>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
@@ -17,7 +17,7 @@ import { getFlowStepHeaderWidth } from '@/helpers/editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
-import ConditionBlockHeader from '../../components/ConditionBlockHeader'
+import BlockHeader from '../../components/BlockHeader'
 import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
 import { conditionBlockStyles } from '../IfThen/styles'
 
@@ -26,15 +26,15 @@ interface OnlyContinueIfProps {
   isNested?: boolean
   allowReorder?: boolean
   canChildStepsReorder?: boolean
-  /** When true, omit the caption — nothing follows this step to gate. */
+  /** When true, omit the caption, since nothing follows this step to gate. */
   isLastStep?: boolean
 }
 
 /**
- * An only-continue-if step drawn like the IF / REPEAT condition headers: a
- * CONTINUE IF badge and a live condition preview. Unlike those two it holds no
- * steps — the ones it gates are its siblings below — so a caption under the
- * card spells out that a failed check stops the flow there.
+ * An only-continue-if step drawn like the IF / REPEAT condition headers.
+ *
+ * IMPORTANT: it holds no steps of its own, so a caption spells out that a
+ * failed check stops the flow there.
  */
 export default function OnlyContinueIf({
   step,
@@ -135,7 +135,7 @@ export default function OnlyContinueIf({
               }
               borderTopRadius={warnsMrfNoGate ? 'none' : 'lg'}
             >
-              <ConditionBlockHeader
+              <BlockHeader
                 badgeLabel="CONTINUE IF"
                 previewParts={previewParts}
                 stepId={step.id}

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -4,8 +4,10 @@ import { useContext } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
 
 import { HoverAddStepButton } from '../Content/IfThen/HoverAddStepButton'
+import OnlyContinueIf from '../Content/OnlyContinueIf'
 
 interface GroupStepWithAddButtonProps {
   step: IStep
@@ -15,6 +17,12 @@ interface GroupStepWithAddButtonProps {
   allowReorder?: boolean
   showEmptyAction?: boolean
   canChildStepsReorder?: boolean
+  /**
+   * Draw an only-continue-if step as a CONTINUE IF condition block instead of
+   * an ordinary step card. Set by the if-then V2 render paths only, so the flag
+   * is read once by the parent rather than by every step in the list.
+   */
+  asConditionBlock?: boolean
 }
 
 export default function GroupStepWithAddButton(
@@ -28,19 +36,30 @@ export default function GroupStepWithAddButton(
     allowReorder,
     showEmptyAction,
     canChildStepsReorder,
+    asConditionBlock = false,
   } = props
   const { isDrawerOpen, readOnly } = useContext(EditorContext)
 
   return (
     <>
-      <FlowStep
-        step={step}
-        // branch steps are always nested
-        isNested={true}
-        isLastStep={isLastStep}
-        allowReorder={allowReorder}
-        canChildStepsReorder={canChildStepsReorder}
-      />
+      {asConditionBlock && isOnlyContinueIfStep(step) ? (
+        <OnlyContinueIf
+          step={step}
+          isLastStep={isLastStep}
+          isNested={true}
+          allowReorder={allowReorder}
+          canChildStepsReorder={canChildStepsReorder}
+        />
+      ) : (
+        <FlowStep
+          step={step}
+          // branch steps are always nested
+          isNested={true}
+          isLastStep={isLastStep}
+          allowReorder={allowReorder}
+          canChildStepsReorder={canChildStepsReorder}
+        />
+      )}
       {!isOverlay && (
         <HoverAddStepButton
           isDisabled={readOnly || !canAddStep}

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -17,11 +17,7 @@ interface GroupStepWithAddButtonProps {
   allowReorder?: boolean
   showEmptyAction?: boolean
   canChildStepsReorder?: boolean
-  /**
-   * Draw an only-continue-if step as a CONTINUE IF condition block instead of
-   * an ordinary step card. Set by the if-then V2 render paths only, so the flag
-   * is read once by the parent rather than by every step in the list.
-   */
+  /** Draw an only-continue-if step as a CONTINUE IF condition block. */
   asConditionBlock?: boolean
 }
 


### PR DESCRIPTION
## Stack Context

This sub-stack (#2028–#2032) makes a nested condition block state its condition in plain language instead of showing an app icon and a generic caption. #2028 carries the full breakdown.

This is the first PR in the sub-stack where anything changes on screen, and it introduces the `asConditionBlock` prop that #2031 and #2032 also consume.

## What?

An only-continue-if step now renders as a `CONTINUE IF` condition block.

- **`Content/OnlyContinueIf`** — the gate step in condition-block shape, using `ConditionBlockHeader` from #2029.
- **`asConditionBlock`** on `GroupStepWithAddButton` and `FlowStepWithAddButton` — defaults to `false`, set by `StepsList` only.
- **`alwaysVisible`** on `DeleteStepButton` and `DuplicateStepButton` — defaults to `false`.

## Why?

`CONTINUE IF` is the smallest of the three blocks, so it is the cheapest place to prove the header end to end before rewiring if-then (#2031) and for-each (#2032).

Unlike those two it keeps a caption of its own, because it holds no steps: there is no body underneath for the block to explain itself with, so the sentence alone would leave you guessing what happens when the condition is false.

### Why `asConditionBlock` is a prop rather than a flag read in place

`OnlyContinueIf` and `FlowStep` are chosen between at the step level, but the decision is a property of the **render path**, not of the step: only the V2 paths draw condition blocks. Reading `useIfThenV2Enabled` inside the step component would mean every step in the list evaluating the flag to answer a question its parent already knows. So the parent passes it down, and the flag is read once.

Both props default to current behaviour, so this is additive — nothing outside the V2 path changes.

### Why `alwaysVisible`

Delete and duplicate normally reveal themselves through `FlowStep`'s `hover-remove-button` CSS. Inside a condition block the actions overlay already owns visibility (see #2029), so the two mechanisms fight: the button stays `visibility: hidden` while its container is fading in. `alwaysVisible` opts out of the inner rule and lets the overlay decide.

## Known duplication

Roughly 140 of `OnlyContinueIf`'s 199 lines mirror `FlowStep` — `useStepMetadata`, `FlowStepWrapper`, the width calc, the `NESTED_DRAG_HANDLE_WIDTH / 2` offset, the MRF infobox, `DragHandle` placement, the unsaved-changes guard.

The clean fix is a header slot on `FlowStep`, which already takes `stepNameOverride`, `isContainerHeader`, `isClickable` and `hideDisplayPosition` — so it is clearly the intended extension point. Deferred because `FlowStep` renders **every** step in the editor, and I would rather not put that blast radius in the same PR as a new block type. Happy to do it as a follow-up if you would rather it not linger.








<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renders V2 only-continue-if steps as `CONTINUE IF` condition blocks while preserving the legacy render path.
- Adds a dedicated condition-block presentation with condition preview, actions, drag handling, warning content, and stop-flow caption.
- Passes the new render mode through editor step wrappers.
- Allows condition-block overlays to control delete and duplicate button visibility.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx | Introduces the dedicated only-continue-if condition-block UI while retaining existing metadata, drag, warning, action, and unsaved-change behavior. |
| packages/frontend/src/components/Editor/components/StepsList.tsx | Enables condition-block rendering only within the existing If-Then V2 branch. |
| packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx | Selects the new condition-block component for matching steps when explicitly requested. |
| packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx | Adds an opt-in nested rendering path while preserving the existing default behavior. |
| packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx | Adds an opt-in mode allowing the parent overlay to control action visibility. |
| packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx | Adds the corresponding opt-in visibility behavior for duplicate actions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StepsList] --> B{If-Then V2 enabled?}
    B -- No --> C[Render legacy FlowStep]
    B -- Yes --> D[Pass asConditionBlock]
    D --> E{Only-continue-if step?}
    E -- No --> C
    E -- Yes --> F[Render CONTINUE IF block]
    F --> G[Condition preview and actions]
    F --> H{Last top-level step?}
    H -- No --> I[Show stop-flow caption]
    H -- Yes --> J[Omit caption]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore(editor): tighten CONTINUE IF block..."](https://github.com/opengovsg/plumber/commit/dacdfe4c2db54ce54e7e7e339abd6745adb2e649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59432633)</sub>

<!-- /greptile_comment -->