### PR TITLE
PLU-743: [IF-THEN-THEN-V2-21] If-then V2 header states its own condition

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -21,6 +21,9 @@ interface HoverAddStepButtonProps {
   isLastStep: boolean
   prevStep: IStep
   showEmptyAction?: boolean
+  // Drops the vertical connector above an empty-state add card (e.g. flush
+  // under an if-then / for-each header).
+  hideLeadingConnector?: boolean
   step: IStep
   allowReorder?: boolean
   canChildStepsReorder?: boolean
@@ -41,6 +44,7 @@ export function HoverAddStepButton(
     isLastStep,
     prevStep,
     showEmptyAction,
+    hideLeadingConnector,
     step,
     allowReorder,
     canChildStepsReorder,
@@ -67,9 +71,14 @@ export function HoverAddStepButton(
     <>
       {showEmptyAction ? (
         <Flex flexDir="column" alignItems="center" mb={1}>
-          <Flex h="2rem">
-            <Divider orientation="vertical" borderColor="base.divider.strong" />
-          </Flex>
+          {!hideLeadingConnector && (
+            <Flex h="2rem">
+              <Divider
+                orientation="vertical"
+                borderColor="base.divider.strong"
+              />
+            </Flex>
+          )}
           <EmptyFlowStepHeader
             isNested={true}
             isTrigger={false}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -21,8 +21,7 @@ interface HoverAddStepButtonProps {
   isLastStep: boolean
   prevStep: IStep
   showEmptyAction?: boolean
-  // Drops the vertical connector above an empty-state add card (e.g. flush
-  // under an if-then / for-each header).
+  // Drops the vertical connector above an empty-state add card.
   hideLeadingConnector?: boolean
   step: IStep
   allowReorder?: boolean

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -25,21 +25,20 @@ import { SortableList } from '@/components/SortableList'
 import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { FlowStep } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
-import getStepName from '@/helpers/getStepName'
 import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
+import ConditionBlockHeader from '../../components/ConditionBlockHeader'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
-import { flowStepGroupStyles } from '../../styles'
+import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
 
 import { AddAfterBlockButton } from './AddAfterBlockButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
-import { blockActionButtonStyles, branchStyles } from './styles'
+import { blockActionButtonStyles, conditionBlockStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 
 interface IfThenProps {
@@ -59,11 +58,14 @@ interface ReorderItem {
 }
 
 /**
- * Drawn as the same grouped box as an if-then V1 group, despite having only
- * one branch, so the two variants read as the same thing in the editor.
+ * A single-branch if-then block: the condition step (the if-then action) plus
+ * the steps that run when it passes. An empty block shows the add-first-step
+ * placeholder.
  *
- * The interior reuses the shared display building blocks, so a step's own
- * add/reorder affordances behave exactly as they do elsewhere in the editor.
+ * Drawn as a grey well with an IF badge header. Clicking the header opens the
+ * condition drawer — there is no separate condition card or branch-name field.
+ * Block-level affordances live in the header (delete / duplicate), beside the
+ * box (drag to reorder) and below it (add a step after the block).
  */
 export default function IfThen({
   block,
@@ -72,7 +74,6 @@ export default function IfThen({
 }: IfThenProps): JSX.Element {
   const { ifThenStep, children } = block
   const {
-    allApps,
     currentStepId,
     flow,
     isDrawerOpen,
@@ -103,11 +104,10 @@ export default function IfThen({
     groupingActions ?? new Set<string>(),
   )
 
-  // Reuses getStepName rather than re-deriving the same rule here, so a
-  // leftover V1 block's branchName keeps showing in the header exactly as it
-  // does in the drawer title below. isIfThenV2Enabled is hardcoded true: this
-  // component only ever mounts on the flag-ON render fork.
-  const headerLabel = getStepName(allApps, ifThenStep, true).stepName
+  const conditionPreviewParts = getConditionBlockPreviewParts(
+    ifThenStep.parameters,
+  )
+  const isSelected = currentStepId === ifThenStep.id
 
   // IMPORTANT: assumes allowReorder already excludes read-only. The caller
   // (StepsList) folds that in before passing it down.
@@ -231,7 +231,7 @@ export default function IfThen({
           minW={MIN_FLOW_STEP_WIDTH}
         >
           <Flex
-            {...flowStepGroupStyles.container}
+            {...conditionBlockStyles.container}
             display={isMobile ? 'block' : 'flex'}
             // Lets the box give up room to the inline drag handle below
             // instead of overflowing the slot.
@@ -249,198 +249,88 @@ export default function IfThen({
             }
             ml={blockHandleOffset ? `${blockHandleOffset}px` : undefined}
             minW="0"
-            // The header and branch run edge to edge, so the box clips them to
-            // its own rounded corners.
             overflow="hidden"
-            // The box carries the selected-state border its flush header drops.
+            borderWidth="1px"
             borderColor={
-              currentStepId === ifThenStep.id
-                ? 'base.content.brand'
-                : 'base.divider.medium'
+              isSelected ? 'base.content.brand' : 'base.divider.medium'
             }
           >
-            {/*
-              The header stands in for the whole block, not a step of its own to
-              configure. So it takes the block's name and drops click-to-configure
-              and its own border, letting the box read as one step rather than a
-              card holding cards.
-
-              Delete/duplicate are overlaid on the header's trailing edge
-              instead of laid out beside it, since hidden-until-hover buttons
-              would otherwise reserve width and pull the header in. They're
-              siblings of the header rather than children, so a click on them
-              never bubbles into the condition card's open-the-drawer handler.
-
-              Being overlaid means they sit outside the header's own padding, so
-              they re-create a step's trailing inset and button metrics
-              themselves (see FlowStep's header) to line up with the delete icon
-              of the steps above and below the block.
-            */}
-            <Flex alignItems="center" w="100%" role="group" pos="relative">
-              <FlowStep
-                step={ifThenStep}
-                stepNameOverride={headerLabel}
-                isContainerHeader
-                isClickable={false}
-                isNested={true}
-                isLastStep={isEmptyBlock}
-                allowReorder={false}
-              />
-
-              {!readOnly && (
-                <Flex
-                  pos="absolute"
-                  top={0}
-                  bottom={0}
-                  // The inset and gap a step's header gives its own
-                  // duplicate/delete pair. Insetting the overlay rather than
-                  // padding it keeps the strip beside the buttons part of the
-                  // header, so clicking there still opens the drawer.
-                  right={4}
-                  gap={1}
-                  alignItems="center"
-                  opacity={{ base: 1, lg: 0 }}
-                  _groupHover={{ opacity: 1 }}
-                >
-                  {canDuplicateBranch && (
+            <ConditionBlockHeader
+              badgeLabel="IF"
+              previewParts={conditionPreviewParts}
+              stepId={ifThenStep.id}
+              isSelected={isSelected}
+              actions={
+                !readOnly ? (
+                  <>
+                    {canDuplicateBranch && (
+                      <IconButton
+                        {...blockActionButtonStyles}
+                        onClick={onDuplicate}
+                        aria-label="Duplicate if-then"
+                        icon={<BiDuplicate />}
+                        isLoading={isDuplicatingBranch}
+                        isDisabled={isDuplicatingBranch || isDeletingBlock}
+                      />
+                    )}
                     <IconButton
                       {...blockActionButtonStyles}
-                      onClick={onDuplicate}
-                      aria-label="Duplicate if-then"
-                      icon={<BiDuplicate />}
-                      isLoading={isDuplicatingBranch}
-                      isDisabled={isDuplicatingBranch || isDeletingBlock}
-                    />
-                  )}
-                  <IconButton
-                    {...blockActionButtonStyles}
-                    onClick={openDeleteConfirmation}
-                    aria-label="Delete if-then"
-                    icon={<BiTrash />}
-                    isLoading={isDeletingBlock}
-                    isDisabled={isDeletingBlock || isDuplicatingBranch}
-                  />
-                </Flex>
-              )}
-            </Flex>
-
-            {/*
-              The condition step renders again here as a normal card, matching
-              how an if-then V1 branch draws its condition card and steps in one
-              panel. An empty block keeps this panel and placeholder rather than
-              looking like a different component.
-
-              The panel is white, not branchStyles.container's usual grey, since
-              a single-branch box doesn't need to visually separate branches the
-              way an if-then V1 group's side-by-side branches do.
-            */}
-            <Flex
-              {...branchStyles.container}
-              bg="white"
-              borderRadius="none"
-              // pb drops by the placeholder's own 4px bottom margin so the
-              // empty-block panel stays evenly padded overall.
-              pb={isEmptyBlock ? 2 : 3}
-            >
-              <Flex w="100%" flexDir="column">
-                {/*
-                  This is the same condition step the header above renders, now
-                  as a normal, clickable card. It drops its own name and
-                  position number since the header already carries both.
-                */}
-                <FlowStep
-                  step={ifThenStep}
-                  stepNameOverride="Condition"
-                  hideDisplayPosition
-                  isNested={true}
-                  isLastStep={false}
-                  allowReorder={false}
-                  // Matches the width sibling cards give up for their own drag
-                  // handles, exactly as an if-then V1 branch's condition card
-                  // does, so the condition card isn't wider than the cards
-                  // below it.
-                  canChildStepsReorder={children.length > 1}
-                />
-
-                {isEmptyBlock ? (
-                  // The placeholder card is `w="100%"`, which only resolves to the
-                  // panel's width because this column stretches it; left to the
-                  // block box, whose items are centred, it would shrink to fit its
-                  // own text.
-                  <HoverAddStepButton
-                    isDisabled={readOnly}
-                    isDrawerOpen={isDrawerOpen}
-                    isLastStep={true}
-                    prevStep={ifThenStep}
-                    showEmptyAction={true}
-                    step={ifThenStep}
-                    allowReorder={false}
-                    // The if-then step, this card's anchor, sits outside its
-                    // own block. This step sits inside it.
-                    anchorPlacement="inside-if-then-block"
-                  />
-                ) : (
-                  <>
-                    {/*
-                      Every other card-to-card transition in this panel has a
-                      connector; the condition card is no exception, so a
-                      populated block can insert a step directly after it too.
-                    */}
-                    <HoverAddStepButton
-                      // Reuses isDisabled for the sole-blank-placeholder edge
-                      // case (see isSoleBlankPlaceholder). pointerEvents: none
-                      // keeps the connector but makes the hover-+ itself inert.
-                      isDisabled={readOnly || isSoleBlankPlaceholder}
-                      isDrawerOpen={isDrawerOpen}
-                      isLastStep={false}
-                      prevStep={ifThenStep}
-                      step={ifThenStep}
-                      allowReorder={false}
-                      canChildStepsReorder={children.length > 1}
-                      // Same reasoning as the empty-block placeholder above:
-                      // this step also lands inside the block.
-                      anchorPlacement="inside-if-then-block"
-                    />
-                    <SortableList
-                      items={children.map((step, index) => ({
-                        id: step.id,
-                        step,
-                        index,
-                      }))}
-                      onChange={handleReorderSteps}
-                      renderItem={(item, isOverlay) => {
-                        const { step, index } = item
-                        const isLastStep = index === children.length - 1
-
-                        // Every step, last one included, gets the same hover +
-                        // to append after it — matching how a for-each body
-                        // (and an if-then V1 branch) appends, rather than the
-                        // last step handing off to its own separate,
-                        // always-visible "Add step" card.
-                        return (
-                          <SortableList.Item id={item.id}>
-                            <Flex w="100%" flexDir="column">
-                              <GroupStepWithAddButton
-                                step={step}
-                                // Same sole-blank-placeholder edge case as
-                                // the leading HoverAddStepButton above: no
-                                // trailing hover-+ after it either, so the
-                                // card reads as an empty block's own
-                                // add-first-step placeholder rather than a
-                                // populated block's last member.
-                                canAddStep={!isSoleBlankPlaceholder}
-                                isLastStep={isLastStep}
-                                isOverlay={isOverlay}
-                                allowReorder={children.length > 1}
-                              />
-                            </Flex>
-                          </SortableList.Item>
-                        )
-                      }}
+                      onClick={openDeleteConfirmation}
+                      aria-label="Delete if-then"
+                      icon={<BiTrash />}
+                      isLoading={isDeletingBlock}
+                      isDisabled={isDeletingBlock || isDuplicatingBranch}
                     />
                   </>
-                )}
-              </Flex>
+                ) : undefined
+              }
+            />
+
+            {/*
+              White content band under the flush grey header. Steps (and the
+              empty-state placeholder) live here with their own padding.
+            */}
+            <Flex {...conditionBlockStyles.body} pb={isEmptyBlock ? 2 : 3}>
+              {isEmptyBlock ? (
+                <HoverAddStepButton
+                  isDisabled={readOnly}
+                  isDrawerOpen={isDrawerOpen}
+                  isLastStep={true}
+                  prevStep={ifThenStep}
+                  showEmptyAction={true}
+                  hideLeadingConnector
+                  step={ifThenStep}
+                  allowReorder={false}
+                />
+              ) : (
+                <SortableList
+                  items={children.map((step, index) => ({
+                    id: step.id,
+                    step,
+                    index,
+                  }))}
+                  onChange={handleReorderSteps}
+                  renderItem={(item, isOverlay) => {
+                    const { step, index } = item
+                    const isLastStep = index === children.length - 1
+
+                    return (
+                      <SortableList.Item id={item.id}>
+                        <Flex w="100%" flexDir="column">
+                          <GroupStepWithAddButton
+                            step={step}
+                            asConditionBlock
+                            canAddStep={!isSoleBlankPlaceholder}
+                            isLastStep={isLastStep}
+                            isOverlay={isOverlay}
+                            allowReorder={children.length > 1}
+                          />
+                        </Flex>
+                      </SortableList.Item>
+                    )
+                  }}
+                />
+              )}
             </Flex>
 
             <MenuAlertDialog

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -32,7 +32,7 @@ import { getFlowStepHeaderWidth } from '@/helpers/editor'
 import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
-import ConditionBlockHeader from '../../components/ConditionBlockHeader'
+import BlockHeader from '../../components/BlockHeader'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
 import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
 
@@ -58,14 +58,8 @@ interface ReorderItem {
 }
 
 /**
- * A single-branch if-then block: the condition step (the if-then action) plus
- * the steps that run when it passes. An empty block shows the add-first-step
- * placeholder.
- *
- * Drawn as a grey well with an IF badge header. Clicking the header opens the
- * condition drawer — there is no separate condition card or branch-name field.
- * Block-level affordances live in the header (delete / duplicate), beside the
- * box (drag to reorder) and below it (add a step after the block).
+ * A single-branch if-then block: the condition step plus the steps that run
+ * when it passes.
  */
 export default function IfThen({
   block,
@@ -104,8 +98,9 @@ export default function IfThen({
     groupingActions ?? new Set<string>(),
   )
 
-  const conditionPreviewParts = getConditionBlockPreviewParts(
-    ifThenStep.parameters,
+  const conditionPreviewParts = useMemo(
+    () => getConditionBlockPreviewParts(ifThenStep.parameters),
+    [ifThenStep.parameters],
   )
   const isSelected = currentStepId === ifThenStep.id
 
@@ -255,7 +250,7 @@ export default function IfThen({
               isSelected ? 'base.content.brand' : 'base.divider.medium'
             }
           >
-            <ConditionBlockHeader
+            <BlockHeader
               badgeLabel="IF"
               previewParts={conditionPreviewParts}
               stepId={ifThenStep.id}
@@ -286,10 +281,6 @@ export default function IfThen({
               }
             />
 
-            {/*
-              White content band under the flush grey header. Steps (and the
-              empty-state placeholder) live here with their own padding.
-            */}
             <Flex {...conditionBlockStyles.body} pb={isEmptyBlock ? 2 : 3}>
               {isEmptyBlock ? (
                 <HoverAddStepButton


### PR DESCRIPTION
## Stack Context

This sub-stack (#2028–#2032) makes a nested condition block state its condition in plain language instead of showing an app icon and a generic caption. #2028 carries the full breakdown.

This PR is the payoff for if-then: it consumes `ConditionBlockHeader` (#2029) and `asConditionBlock` (#2030).

## What?

The `IF` block header becomes the condition. Net **removal** of ~100 lines.

- Removed the old container header — app icon plus generic caption.
- Removed the separate "Condition" card that sat directly underneath it.
- `hideLeadingConnector` on `HoverAddStepButton`.

## Why?

A V2 if-then block previously said the same thing twice, a few pixels apart: a caption at the top, then a condition card below it. Neither told you which branch you were looking at without opening the drawer. Folding the condition into the header removes the duplication and answers the question in the same space.

`hideLeadingConnector` exists because of what the removal exposes. The empty-state add card renders a vertical connector above itself to link it to whatever is above. With the condition card gone, the thing above is the header — so the connector dangled off the header's bottom edge into the padding, attached to nothing. The prop drops it for the flush case; every other caller keeps the connector.

V1 branches keep the old chrome, and this path is behind the existing `feature_if_then_then` flag.

## ⚠️ Note for the reviewer of #2002 (branch name deprecation)

**This PR removes #2002's only visible consumer.**

#2002 made the V2 block header render `getStepName(allApps, ifThenStep, true).stepName` — that call is where "fold `branchName` into `stepName`" actually showed up on screen. This PR replaces that header with the condition preview, so those lines are gone.

Nothing functional breaks:

- the backend `branchName` field change (`required: false`) is untouched
- the drawer title still goes through `getStepName`

But since the two PRs are stacked, the combined diff makes #2002 look like it changes nothing user-visible. Flagging so that reads as intentional rather than as a bad merge.








<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the V2 if-then container header and separate condition card with a condition-bearing header.
- Adds an option to hide the empty-state add card’s leading connector.
- Renders child steps using the condition-block presentation.
- Retains the existing block actions, reordering, deletion, and duplication behavior.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not appear safe to merge until empty-block additions are classified as inside the if-then block and populated blocks regain a first-child insertion point.

The empty-state add control still anchors to the condition step without an explicit inside-block placement, exposing choices prohibited within an if-then block, while populated blocks still provide add controls only after existing children and therefore cannot insert a new first child.

**Files Needing Attention:** packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx | Consolidates the V2 condition into the block header, but the previously reported empty-block classification and first-child insertion failures remain. |
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx | Adds an optional presentation-only switch for suppressing the empty-state card’s leading connector. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore(editor): tighten if-then V2 block ..."](https://github.com/opengovsg/plumber/commit/8489a79bb43e14bc8351ca862f44d4ef9a1b1ecd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59432634)</sub>

<!-- /greptile_comment -->