### PR TITLE
PLU-743: [IF-THEN-THEN-V2-22] REPEAT block header + for-each renderer split

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
@@ -18,19 +18,14 @@ interface ForEachV1Props {
 }
 
 /**
- * The original for-each body: the loop's condition drawn as a step card of its
- * own, with any if-then group below it recursed back through FlowStepGroup.
- * FlowStepGroup draws the app-icon-and-caption box (and the delete button)
- * around this, so neither lives here.
- *
- * Retired wholesale once the if-then V2 flag is fully rolled out — at which
- * point this file and FlowStepGroup's fork both go.
+ * The for-each V1 body, retired wholesale once the if-then V2 flag is fully
+ * rolled out, along with FlowStepGroup's fork.
  */
 export default function ForEachV1(props: ForEachV1Props) {
   const { groupedSteps } = props
   const { flow } = useContext(EditorContext)
-  // Only for isLoading: FlowStepGroup already decided we are on the V1 path,
-  // but the nested group must not render until the flag has actually resolved.
+  // Only for isLoading, since the nested group must not render before the flag
+  // resolves.
   const { isLoading: isIfThenV2Loading } = useIfThenV2Enabled()
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
@@ -1,0 +1,127 @@
+import { IStep } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+import { Flex } from '@chakra-ui/react'
+
+import { SortableList } from '@/components/SortableList'
+import { EditorContext } from '@/contexts/Editor'
+import { FlowStepGroup } from '@/exports/components'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
+import useReorderSteps from '@/hooks/useReorderSteps'
+
+import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+
+interface ForEachV1Props {
+  groupedSteps: IStep[][]
+  stepsBeforeGroup: IStep[]
+}
+
+/**
+ * The original for-each body: the loop's condition drawn as a step card of its
+ * own, with any if-then group below it recursed back through FlowStepGroup.
+ * FlowStepGroup draws the app-icon-and-caption box (and the delete button)
+ * around this, so neither lives here.
+ *
+ * Retired wholesale once the if-then V2 flag is fully rolled out — at which
+ * point this file and FlowStepGroup's fork both go.
+ */
+export default function ForEachV1(props: ForEachV1Props) {
+  const { groupedSteps } = props
+  const { flow } = useContext(EditorContext)
+  // Only for isLoading: FlowStepGroup already decided we are on the V1 path,
+  // but the nested group must not render until the flag has actually resolved.
+  const { isLoading: isIfThenV2Loading } = useIfThenV2Enabled()
+  const { handleReorderUpdate } = useReorderSteps(flow.id)
+
+  const forEachSteps = groupedSteps[0]
+  const ifThenSteps = useMemo(() => {
+    if (groupedSteps.length === 1) {
+      return []
+    }
+    return groupedSteps.slice(1)
+  }, [groupedSteps])
+
+  // NOTE: groupedSteps includes for-each and if-then actions
+  // so groupedSteps === 1 means that there is only the for-each action
+  const nonForEachActionSteps = forEachSteps.filter(
+    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.ForEach,
+  )
+  const hasNoActionSteps =
+    nonForEachActionSteps.length === 0 && groupedSteps.length === 1
+
+  const { conditionStep, actionSteps } = useMemo(() => {
+    const conditionStep = forEachSteps[0]
+    const actionSteps = forEachSteps.slice(1)
+
+    return { conditionStep, actionSteps }
+  }, [forEachSteps])
+
+  const handleReorderSteps = async (items: any[]) => {
+    const forEachPosition = conditionStep.position
+    const stepPositions = items.map((item, index) => ({
+      id: item.id,
+      position: forEachPosition + index + 1, // index is 0-based
+      type: item.step.type,
+    }))
+
+    try {
+      handleReorderUpdate(stepPositions)
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
+  return (
+    <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
+      <Flex flexDir="column" w="100%" px={4} py={3}>
+        <GroupStepWithAddButton
+          step={conditionStep}
+          canAddStep={true}
+          isLastStep={hasNoActionSteps}
+          allowReorder={false}
+          showEmptyAction={hasNoActionSteps}
+          // So the header reserves width for a sibling item's drag handle.
+          canChildStepsReorder={actionSteps.length > 1}
+        />
+        <SortableList
+          items={actionSteps.map((step, index) => ({
+            id: step.id,
+            step,
+            index,
+          }))}
+          onChange={handleReorderSteps}
+          renderItem={(item, isOverlay) => {
+            const { step, index } = item
+            const isLastStep =
+              index === actionSteps.length - 1 && ifThenSteps.length === 0
+            return (
+              <SortableList.Item id={item.id}>
+                <Flex w="100%" flexDir="column">
+                  <GroupStepWithAddButton
+                    step={step}
+                    canAddStep={true}
+                    isLastStep={isLastStep}
+                    isOverlay={isOverlay}
+                    allowReorder={actionSteps.length > 1}
+                  />
+                </Flex>
+              </SortableList.Item>
+            )
+          }}
+        />
+
+        {ifThenSteps.length > 0 && !isIfThenV2Loading && (
+          <FlowStepGroup
+            stepsBeforeGroup={forEachSteps}
+            groupedSteps={ifThenSteps}
+          />
+        )}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -1,7 +1,9 @@
 import { IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
+import { BiTrash } from 'react-icons/bi'
 import { Flex } from '@chakra-ui/react'
+import { IconButton } from '@opengovsg/design-system-react'
 
 import {
   buildStepsList,
@@ -11,35 +13,42 @@ import {
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { FlowStepGroup } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
-import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
+import ConditionBlockHeader from '../../components/ConditionBlockHeader'
+import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+import { getForEachBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
+import useDeleteStepConfirmation from '../../hooks/useDeleteStepConfirmation'
+import { HoverAddStepButton } from '../IfThen/HoverAddStepButton'
 import IfThen from '../IfThen/IfThen'
+import { blockActionButtonStyles, conditionBlockStyles } from '../IfThen/styles'
 
 interface ForEachProps {
   groupedSteps: IStep[][]
   stepsBeforeGroup: IStep[]
 }
 
+/**
+ * A for-each loop as a condition block: a REPEAT badge and the plain-language
+ * list preview stand in for the condition step, so the loop reads as one
+ * sentence rather than a captioned box wrapping a card. Same shape as an
+ * if-then V2 block.
+ *
+ * Only rendered on the flag-ON path — see ForEachV1 for the old body, and
+ * FlowStepGroup for the fork between them.
+ */
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
-  const { flow, readOnly } = useContext(EditorContext)
+  const { currentStepId, flow, isDrawerOpen, onDrawerClose, readOnly } =
+    useContext(EditorContext)
   const { groupingActions } = useContext(StepsToDisplayContext)
-  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
-    useIfThenV2Enabled()
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 
   const forEachSteps = groupedSteps[0]
-  const ifThenSteps = useMemo(() => {
-    if (groupedSteps.length === 1) {
-      return []
-    }
-    return groupedSteps.slice(1)
-  }, [groupedSteps])
+  const conditionStep = forEachSteps[0]
 
   // NOTE: groupedSteps includes for-each and if-then actions
   // so groupedSteps === 1 means that there is only the for-each action
@@ -49,32 +58,6 @@ export default function ForEach(props: ForEachProps) {
   const hasNoActionSteps =
     nonForEachActionSteps.length === 0 && groupedSteps.length === 1
 
-  const { conditionStep, actionSteps } = useMemo(() => {
-    const conditionStep = forEachSteps[0]
-    const actionSteps = forEachSteps.slice(1)
-
-    return { conditionStep, actionSteps }
-  }, [forEachSteps])
-
-  const handleReorderSteps = async (items: any[]) => {
-    const forEachPosition = conditionStep.position
-    const stepPositions = items.map((item, index) => ({
-      id: item.id,
-      position: forEachPosition + index + 1, // index is 0-based
-      type: item.step.type,
-    }))
-
-    try {
-      handleReorderUpdate(stepPositions)
-    } catch (error) {
-      console.error(
-        'Error updating step positions: ',
-        error,
-        JSON.stringify(stepPositions),
-      )
-    }
-  }
-
   // Every non-condition step in the body shares one reorder domain, matching
   // the top-level list — a plain step immediately next to an if-then V2
   // block must be able to swap with it, not be stuck in a separate list. A
@@ -82,8 +65,8 @@ export default function ForEach(props: ForEachProps) {
   // within the block's own SortableList (in IfThen), never into this one.
   const bodySteps = useMemo(() => groupedSteps.flat().slice(1), [groupedSteps])
 
-  const ifThenBlockItems = useMemo(() => {
-    if (!isIfThenV2Enabled || bodySteps.length === 0) {
+  const blockItems = useMemo(() => {
+    if (bodySteps.length === 0) {
       return []
     }
     return buildStepsList(
@@ -92,24 +75,22 @@ export default function ForEach(props: ForEachProps) {
     ).filter(
       (item): item is IfThenBlock | SingleStep => item.type !== 'forEachBlock',
     )
-  }, [isIfThenV2Enabled, bodySteps, groupingActions])
+  }, [bodySteps, groupingActions])
 
-  const hasIfThenBlockItem = ifThenBlockItems.some(
-    (item) => item.type === 'ifThenBlock',
-  )
+  const hasBlock = blockItems.some((item) => item.type === 'ifThenBlock')
 
-  const sortableBlockItems = useMemo(
+  const sortableItems = useMemo(
     () =>
-      ifThenBlockItems.map((item) => ({
+      blockItems.map((item) => ({
         id: item.type === 'ifThenBlock' ? item.ifThenStep.id : item.step.id,
         item,
       })),
-    [ifThenBlockItems],
+    [blockItems],
   )
-  const canReorderBlocks = !readOnly && ifThenBlockItems.length > 1
-  const lastBlockItemId = sortableBlockItems[sortableBlockItems.length - 1]?.id
+  const canReorder = !readOnly && blockItems.length > 1
+  const lastItemId = sortableItems[sortableItems.length - 1]?.id
 
-  const handleReorderBlockItems = async (
+  const handleReorder = async (
     reordered: Array<{ id: string; item: IfThenBlock | SingleStep }>,
   ) => {
     const reorderedSteps = reordered.flatMap(({ item }) =>
@@ -134,31 +115,64 @@ export default function ForEach(props: ForEachProps) {
     }
   }
 
+  const {
+    cancelRef,
+    isOpen: isDeleteConfirmationOpen,
+    onClose: closeDeleteConfirmation,
+    onDelete: deleteForEach,
+    openDeleteConfirmation,
+  } = useDeleteStepConfirmation(TOOLBOX_ACTIONS.ForEach, groupedSteps)
+
+  const handleForEachDelete = useCallback(async () => {
+    await deleteForEach()
+    onDrawerClose()
+  }, [deleteForEach, onDrawerClose])
+
+  const isSelected = currentStepId === conditionStep.id
+
   return (
-    <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
-      <Flex flexDir="column" w="100%" px={4} py={3}>
-        <GroupStepWithAddButton
-          step={conditionStep}
-          canAddStep={true}
-          isLastStep={hasNoActionSteps}
-          allowReorder={false}
-          showEmptyAction={hasNoActionSteps}
-          // True when either sibling list has a reorderable item, so the
-          // header still reserves width for that item's drag handle.
-          canChildStepsReorder={actionSteps.length > 1 || canReorderBlocks}
-        />
-        {isIfThenV2Enabled ? (
-          <Flex
-            flexDir="column"
-            w="100%"
-            gap={hasIfThenBlockItem ? 2 : undefined}
-          >
+    <Flex
+      {...conditionBlockStyles.container}
+      borderWidth="1px"
+      borderColor={isSelected ? 'base.content.brand' : 'base.divider.medium'}
+    >
+      <ConditionBlockHeader
+        badgeLabel="REPEAT"
+        previewParts={getForEachBlockPreviewParts(conditionStep.parameters)}
+        stepId={conditionStep.id}
+        isSelected={isSelected}
+        actions={
+          readOnly ? undefined : (
+            <IconButton
+              {...blockActionButtonStyles}
+              onClick={openDeleteConfirmation}
+              aria-label="Delete for each action"
+              icon={<BiTrash />}
+            />
+          )
+        }
+      />
+
+      <Flex {...conditionBlockStyles.body}>
+        {hasNoActionSteps ? (
+          <HoverAddStepButton
+            isDisabled={readOnly}
+            isDrawerOpen={isDrawerOpen}
+            isLastStep={true}
+            prevStep={conditionStep}
+            showEmptyAction={true}
+            hideLeadingConnector
+            step={conditionStep}
+            allowReorder={false}
+          />
+        ) : (
+          <Flex flexDir="column" w="100%" gap={hasBlock ? 2 : undefined}>
             <SortableList
-              items={sortableBlockItems}
-              onChange={handleReorderBlockItems}
+              items={sortableItems}
+              onChange={handleReorder}
               renderItem={(sortableItem, isOverlay) => {
                 const { id, item } = sortableItem
-                const isLastItem = id === lastBlockItemId
+                const isLastItem = id === lastItemId
 
                 if (item.type === 'ifThenBlock') {
                   return (
@@ -166,24 +180,25 @@ export default function ForEach(props: ForEachProps) {
                       <IfThen
                         block={item}
                         isLastBlock={isLastItem}
-                        allowReorder={canReorderBlocks}
+                        allowReorder={canReorder}
                       />
                     </SortableList.Item>
                   )
                 }
 
                 // A plain step around if-then V2 blocks in the body — an
-                // explicit endStepId marker can end a block before the
-                // body's last step, unlike a derived if-then V1 extent.
+                // explicit endStepId marker can end a block before the body's
+                // last step, unlike a derived if-then V1 extent.
                 return (
                   <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
                     <Flex w="100%" flexDir="column">
                       <GroupStepWithAddButton
                         step={item.step}
+                        asConditionBlock
                         canAddStep={true}
                         isLastStep={isLastItem}
                         isOverlay={isOverlay}
-                        allowReorder={canReorderBlocks}
+                        allowReorder={canReorder}
                       />
                     </Flex>
                   </SortableList.Item>
@@ -191,44 +206,17 @@ export default function ForEach(props: ForEachProps) {
               }}
             />
           </Flex>
-        ) : (
-          <>
-            <SortableList
-              items={actionSteps.map((step, index) => ({
-                id: step.id,
-                step,
-                index,
-              }))}
-              onChange={handleReorderSteps}
-              renderItem={(item, isOverlay) => {
-                const { step, index } = item
-                const isLastStep =
-                  index === actionSteps.length - 1 && ifThenSteps.length === 0
-                return (
-                  <SortableList.Item id={item.id}>
-                    <Flex w="100%" flexDir="column">
-                      <GroupStepWithAddButton
-                        step={step}
-                        canAddStep={true}
-                        isLastStep={isLastStep}
-                        isOverlay={isOverlay}
-                        allowReorder={actionSteps.length > 1}
-                      />
-                    </Flex>
-                  </SortableList.Item>
-                )
-              }}
-            />
-
-            {ifThenSteps.length > 0 && !isIfThenV2Loading && (
-              <FlowStepGroup
-                stepsBeforeGroup={forEachSteps}
-                groupedSteps={ifThenSteps}
-              />
-            )}
-          </>
         )}
       </Flex>
+
+      <DeleteConfirmationDialog
+        name="For each"
+        cancelRef={cancelRef}
+        isOpen={isDeleteConfirmationOpen}
+        onClose={closeDeleteConfirmation}
+        onDelete={handleForEachDelete}
+        onCancel={closeDeleteConfirmation}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -17,7 +17,7 @@ import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
-import ConditionBlockHeader from '../../components/ConditionBlockHeader'
+import BlockHeader from '../../components/BlockHeader'
 import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
 import { getForEachBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
@@ -32,13 +32,8 @@ interface ForEachProps {
 }
 
 /**
- * A for-each loop as a condition block: a REPEAT badge and the plain-language
- * list preview stand in for the condition step, so the loop reads as one
- * sentence rather than a captioned box wrapping a card. Same shape as an
- * if-then V2 block.
- *
- * Only rendered on the flag-ON path — see ForEachV1 for the old body, and
- * FlowStepGroup for the fork between them.
+ * A for-each V2 loop drawn as a REPEAT condition block, picked over
+ * `ForEachV1` by `FlowStepGroup`.
  */
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
@@ -130,15 +125,20 @@ export default function ForEach(props: ForEachProps) {
 
   const isSelected = currentStepId === conditionStep.id
 
+  const previewParts = useMemo(
+    () => getForEachBlockPreviewParts(conditionStep.parameters),
+    [conditionStep.parameters],
+  )
+
   return (
     <Flex
       {...conditionBlockStyles.container}
       borderWidth="1px"
       borderColor={isSelected ? 'base.content.brand' : 'base.divider.medium'}
     >
-      <ConditionBlockHeader
+      <BlockHeader
         badgeLabel="REPEAT"
-        previewParts={getForEachBlockPreviewParts(conditionStep.parameters)}
+        previewParts={previewParts}
         stepId={conditionStep.id}
         isSelected={isSelected}
         actions={

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -9,12 +9,14 @@ import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/S
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth, getToolboxIcon } from '@/helpers/editor'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 import { MIN_FLOW_STEP_WIDTH } from '../Editor/constants'
 
 import DeleteConfirmationDialog from './components/DeleteConfirmationDialog'
 import Error from './Content/Error'
 import ForEach from './Content/ForEach'
+import ForEachV1 from './Content/ForEach/ForEachV1'
 import IfThenV1 from './Content/IfThen/IfThenV1'
 import useDeleteStepConfirmation from './hooks/useDeleteStepConfirmation'
 import { flowStepGroupStyles } from './styles'
@@ -28,6 +30,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
   const { groupedSteps, stepsBeforeGroup } = props
   const { isDrawerOpen, isMobile, onDrawerClose, readOnly } =
     useContext(EditorContext)
+  const { isEnabled: isIfThenV2Enabled } = useIfThenV2Enabled()
 
   const { stepGroupType, stepGroupCaption } = useMemo(() => {
     let stepGroupType: string | null = null
@@ -71,22 +74,47 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
     (step) => step.key === TOOLBOX_ACTIONS.ForEach,
   )
 
+  const outerWidth =
+    isInsideForEach && stepsBeforeGroup.length > 2 && !isDrawerOpen
+      ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+      : '100%'
+
+  const widthSlot = {
+    display: isMobile ? 'block' : 'flex',
+    w: getFlowStepHeaderWidth(isDrawerOpen, isMobile),
+    minW: MIN_FLOW_STEP_WIDTH,
+  }
+
+  /**
+   * A V2 for-each draws its own REPEAT-badge card — including its own delete
+   * button — so it takes a bare width slot instead of the app-icon-and-caption
+   * chrome below. Once the flag retires, that chrome, ForEachV1 and this fork
+   * all go together.
+   */
+  if (stepGroupType === TOOLBOX_ACTIONS.ForEach && isIfThenV2Enabled) {
+    return (
+      <Flex
+        w={outerWidth}
+        alignItems="center"
+        justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
+      >
+        <Flex {...widthSlot}>
+          <ForEach
+            groupedSteps={groupedSteps}
+            stepsBeforeGroup={stepsBeforeGroup}
+          />
+        </Flex>
+      </Flex>
+    )
+  }
+
   return (
     <Flex
-      w={
-        isInsideForEach && stepsBeforeGroup.length > 2 && !isDrawerOpen
-          ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
-          : '100%'
-      }
+      w={outerWidth}
       alignItems="center"
       justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
     >
-      <Flex
-        {...flowStepGroupStyles.container}
-        display={isMobile ? 'block' : 'flex'}
-        w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
-        minW={MIN_FLOW_STEP_WIDTH}
-      >
+      <Flex {...flowStepGroupStyles.container} {...widthSlot}>
         <Box {...flowStepGroupStyles.header} w="100%">
           <Flex
             px={4}
@@ -134,7 +162,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
           />
         ) : stepGroupType === TOOLBOX_ACTIONS.ForEach ? (
           <>
-            <ForEach
+            <ForEachV1
               groupedSteps={groupedSteps}
               stepsBeforeGroup={stepsBeforeGroup}
             />

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -86,10 +86,11 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
   }
 
   /**
-   * A V2 for-each draws its own REPEAT-badge card — including its own delete
-   * button — so it takes a bare width slot instead of the app-icon-and-caption
-   * chrome below. Once the flag retires, that chrome, ForEachV1 and this fork
-   * all go together.
+   * A for-each V2 draws its own REPEAT-badge card and delete button, so it
+   * takes a bare width slot instead of the chrome below.
+   *
+   * IMPORTANT: that chrome, `ForEachV1` and this fork all go once the flag
+   * retires.
    */
   if (stepGroupType === TOOLBOX_ACTIONS.ForEach && isIfThenV2Enabled) {
     return (


### PR DESCRIPTION
## Stack Context

This sub-stack (#2028–#2032) makes a nested condition block state its condition in plain language instead of showing an app icon and a generic caption. #2028 carries the full breakdown. This is the last PR in the sub-stack — it does for `REPEAT` what #2031 did for `IF`.

## What?

- **Split `ForEach`** into `ForEachV1` (the V1 body) and `ForEach` (the V2 `REPEAT` card), mirroring the existing `IfThenV1` / `IfThen` pair.
- **`FlowStepGroup`** early-returns for a V2 for-each instead of wrapping the V1 chrome in a ternary.
- Dropped a **double `useDeleteStepConfirmation`** call and a dead `canReorderBlocks` term.

## Why?

Same reasoning as #2031, applied to for-each: the header states the list being iterated instead of an app icon and a caption.

### Why split the component rather than branch inside it

The V1 and V2 for-each layouts differ in their outer chrome, not just their contents — V2 draws its own header and its own delete button and therefore wants a bare width slot, while V1 wants the app-icon-and-caption wrapper. Expressing that as conditionals inside one component means every JSX block reading as "which era am I in?", which is exactly what `IfThenV1` / `IfThen` already avoids by splitting. This makes the two for-each renderers match the two if-then ones.

It also makes the flag's retirement a delete rather than an untangle: the V1 chrome in `FlowStepGroup`, `ForEachV1`, and the early-return fork all go together, in one commit, with nothing left to unpick.

### The two incidental fixes

Both surfaced while splitting, and both are in the code this PR is already rewriting:

- **`useDeleteStepConfirmation` ran twice** — once in `ForEach` and once in `FlowStepGroup` — and one of the two was always unused, since only one of them rendered the dialog for any given path. Harmless but confusing to read, and it would have been silently duplicated into both halves of the split.
- **`canReorderBlocks`** was a dead term on the V1 path.

Say the word if you would rather these were their own PR and I will pull them out.






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits the legacy and V2 for-each renderers so V2 loops use the new REPEAT condition-block presentation while legacy flows retain their existing chrome.
- Adds a dedicated `ForEachV1` renderer for the legacy layout.
- Makes `FlowStepGroup` select the appropriate renderer based on the V2 feature flag.
- Moves the V2 header, deletion control, body rendering, and unified nested-block reordering into `ForEach`.
- Removes the redundant deletion-hook invocation and obsolete reorder condition.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx | Extracts the legacy for-each body while preserving its action rendering, reordering, and loading guard for nested groups. |
| packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx | Implements the V2 REPEAT card with its condition preview, deletion flow, empty state, and unified sortable body. |
| packages/frontend/src/components/FlowStepGroup/index.tsx | Selects the V2 REPEAT renderer under the feature flag and otherwise retains the legacy wrapper and renderer. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Flow steps ready] --> B{First grouped step}
  B -->|REPEAT and V2 enabled| C[Render bare width slot]
  C --> D[ForEach V2 REPEAT card]
  B -->|REPEAT and V2 disabled| E[Render legacy group chrome]
  E --> F[ForEachV1 body]
  B -->|IF| G[Render legacy group chrome]
  G --> H[IfThenV1 body]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(editor): tighten for-each V2 comme..."](https://github.com/opengovsg/plumber/commit/e927c21ce50f5a7fe295ffcb6f58212158923092) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59432635)</sub>

<!-- /greptile_comment -->