### PR TITLE
PLU-845 feat(pair): let Process image continue when the file is missing

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/process-image.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/process-image.test.ts
@@ -1,0 +1,147 @@
+import { type IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+  generateObject: vi.fn(),
+  getImageContent: vi.fn(),
+}))
+
+vi.mock('@/helpers/pair', () => ({
+  engineProvider: {
+    chat: vi.fn().mockReturnValue({}),
+  },
+}))
+
+vi.mock('ai', () => ({
+  generateObject: mocks.generateObject,
+}))
+
+vi.mock('@/apps/pair/common/get-image-content', () => ({
+  getImageContent: mocks.getImageContent,
+}))
+
+import processImageAction from '@/apps/pair/actions/process-image'
+
+const responseFields = [
+  {
+    fieldName: 'Signature present',
+    description: 'Whether the image contains a handwritten signature',
+  },
+  {
+    fieldName: 'Document type',
+    description: 'Type of document in the image',
+  },
+]
+
+describe('Process image action', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      user: { email: 'user@open.gov.sg' },
+      flow: { id: 'flow-id' },
+      step: {
+        id: 'step-id',
+        appKey: 'pair',
+        key: processImageAction.key,
+        parameters: {},
+      },
+      execution: { id: 'execution-id', testRun: false },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fails by default when no image is provided', async () => {
+    $.step.parameters = {
+      image: [],
+      responseFields,
+    }
+
+    await expect(processImageAction.run($)).rejects.toThrowError(StepError)
+    expect(mocks.generateObject).not.toHaveBeenCalled()
+    expect(mocks.getImageContent).not.toHaveBeenCalled()
+  })
+
+  it('fails when continueIfNoFile is false and no image is provided', async () => {
+    $.step.parameters = {
+      image: [''],
+      continueIfNoFile: false,
+      responseFields,
+    }
+
+    await expect(processImageAction.run($)).rejects.toThrowError(StepError)
+    expect(mocks.generateObject).not.toHaveBeenCalled()
+  })
+
+  it('continues with blank outputs when continueIfNoFile is true and no image is provided', async () => {
+    $.step.parameters = {
+      image: [],
+      continueIfNoFile: true,
+      responseFields,
+    }
+
+    await processImageAction.run($)
+
+    expect(mocks.generateObject).not.toHaveBeenCalled()
+    expect(mocks.getImageContent).not.toHaveBeenCalled()
+    expect(mocks.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        Signature_present: '',
+        Document_type: '',
+      },
+    })
+  })
+
+  it('continues with blank outputs when continueIfNoFile is true and the image value is blank', async () => {
+    $.step.parameters = {
+      image: [''],
+      continueIfNoFile: true,
+      responseFields,
+    }
+
+    await processImageAction.run($)
+
+    expect(mocks.generateObject).not.toHaveBeenCalled()
+    expect(mocks.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        Signature_present: '',
+        Document_type: '',
+      },
+    })
+  })
+
+  it('still processes the image when continueIfNoFile is true and an image is provided', async () => {
+    mocks.getImageContent.mockResolvedValue([{ type: 'image', image: 'data' }])
+    mocks.generateObject.mockResolvedValue({
+      object: {
+        Signature_present: 'yes',
+        Document_type: 'invoice',
+      },
+    })
+
+    $.step.parameters = {
+      image: ['s3-id-123'],
+      continueIfNoFile: true,
+      responseFields,
+    }
+
+    await processImageAction.run($)
+
+    expect(mocks.getImageContent).toHaveBeenCalledWith('s3-id-123')
+    expect(mocks.generateObject).toHaveBeenCalled()
+    expect(mocks.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        Signature_present: 'yes',
+        Document_type: 'invoice',
+      },
+    })
+  })
+})

--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
@@ -16,6 +16,7 @@ describe('process-image schema', () => {
       })
       assert(result.success === true)
       assert(result.data.image[0] === 's3-id-123')
+      assert(result.data.continueIfNoFile === false)
     })
 
     it('should reject empty image array', () => {
@@ -32,6 +33,81 @@ describe('process-image schema', () => {
       if (!result.success) {
         expect(result.error.issues[0].message).toBe('An image must be selected')
       }
+    })
+
+    it('should reject a blank image value by default', () => {
+      const result = schema.safeParse({
+        image: [''],
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('An image must be selected')
+      }
+    })
+
+    it('should reject empty image array when continueIfNoFile is false', () => {
+      const result = schema.safeParse({
+        image: [],
+        continueIfNoFile: false,
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === false)
+    })
+
+    it('should accept empty image array when continueIfNoFile is true', () => {
+      const result = schema.safeParse({
+        image: [],
+        continueIfNoFile: true,
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.continueIfNoFile === true)
+      assert(result.data.image.length === 0)
+    })
+
+    it('should accept a blank image value when continueIfNoFile is true', () => {
+      const result = schema.safeParse({
+        image: [''],
+        continueIfNoFile: true,
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === true)
+    })
+
+    it('should still accept a real image when continueIfNoFile is true', () => {
+      const result = schema.safeParse({
+        image: ['s3-id-123'],
+        continueIfNoFile: true,
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.image[0] === 's3-id-123')
     })
 
     it('should reject multiple images', () => {

--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -13,7 +13,7 @@ import Step from '@/models/step'
 import getDataOutMetadata from '../../common/get-data-out-metadata'
 import { getImageContent } from '../../common/get-image-content'
 
-import { schema } from './schema'
+import { hasProvidedImage, schema } from './schema'
 
 const model = engineProvider.chat(appConfig.pair.foundry.imageModel)
 
@@ -60,6 +60,29 @@ const action: IRawAction = {
         },
       ],
     },
+    {
+      label: 'How should we handle a missing image/file?',
+      key: 'continueIfNoFile',
+      type: 'boolean-radio' as const,
+      required: true,
+      description:
+        'This can happen when the file comes from an optional FormSG field that is left blank.',
+      value: false,
+      options: [
+        {
+          label: 'Continue without it',
+          description:
+            "This step's outputs will be blank, and the rest of your pipe still runs. Choose this if your later steps work with a blank value.",
+          value: true,
+        },
+        {
+          label: 'Stop and fail this execution',
+          description:
+            'This execution stops here and is marked as failed. Other executions are not affected. Choose this if your later steps need the file.',
+          value: false,
+        },
+      ],
+    },
   ],
 
   doesFileProcessing: (step: Step) => {
@@ -79,7 +102,16 @@ const action: IRawAction = {
         GenericSolution.ReconfigureInvalidField,
       )
     }
-    const { image, responseFields } = validatedParameters.data
+    const { image, responseFields, continueIfNoFile } = validatedParameters.data
+
+    if (!hasProvidedImage(image) && continueIfNoFile) {
+      $.setActionItem({
+        raw: Object.fromEntries(
+          responseFields.map((field) => [field.fieldName, '']),
+        ) as IJSONObject,
+      })
+      return
+    }
 
     try {
       const schemaShape: Record<string, z.ZodTypeAny> = {}

--- a/packages/backend/src/apps/pair/actions/process-image/schema.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/schema.ts
@@ -7,50 +7,60 @@ import {
 
 const TOTAL_DESCRIPTION_LENGTH_LIMIT = 10_000
 
-export const schema = z.object({
-  // NOTE: this is an array because the attachment field returns an array
-  image: z
-    .array(z.string())
-    .min(1, { message: 'An image must be selected' })
-    .refine((value) => value.length === 1, {
-      message: 'Only one image allowed',
-    }),
-  responseFields: z
-    .array(
-      z
-        .object({
-          fieldName: outputFieldNameSchema,
+export function hasProvidedImage(image: string[] | undefined): boolean {
+  return Array.isArray(image) && image.some((id) => id.trim() !== '')
+}
 
-          description: z
-            .string()
-            .min(1, { message: 'Description is required' }),
-        })
-        .transform((field) => ({
-          ...toSanitizedOutputFieldNamePair(field.fieldName),
-          description: field.description,
-        })),
-    )
-    .min(1, { message: 'At least one response field is required' })
-    .refine(
-      (fields) => {
-        // After transformation, check uniqueness of sanitized field names
-        const names = fields.map((f) => f.fieldName.toLowerCase())
-        return new Set(names).size === names.length
-      },
-      {
-        message: 'Output names must be unique (case-insensitive)',
-      },
-    )
-    .refine(
-      (fields) => {
-        const totalLength = fields.reduce(
-          (sum, field) => sum + field.description.length,
-          0,
-        )
-        return totalLength <= TOTAL_DESCRIPTION_LENGTH_LIMIT
-      },
-      {
-        message: `Total length of all descriptions cannot exceed ${TOTAL_DESCRIPTION_LENGTH_LIMIT} characters`,
-      },
-    ),
-})
+export const schema = z
+  .object({
+    continueIfNoFile: z.boolean().default(false),
+    // NOTE: this is an array because the attachment field returns an array
+    image: z.array(z.string()).max(1, { message: 'Only one image allowed' }),
+    responseFields: z
+      .array(
+        z
+          .object({
+            fieldName: outputFieldNameSchema,
+
+            description: z
+              .string()
+              .min(1, { message: 'Description is required' }),
+          })
+          .transform((field) => ({
+            ...toSanitizedOutputFieldNamePair(field.fieldName),
+            description: field.description,
+          })),
+      )
+      .min(1, { message: 'At least one response field is required' })
+      .refine(
+        (fields) => {
+          // After transformation, check uniqueness of sanitized field names
+          const names = fields.map((f) => f.fieldName.toLowerCase())
+          return new Set(names).size === names.length
+        },
+        {
+          message: 'Output names must be unique (case-insensitive)',
+        },
+      )
+      .refine(
+        (fields) => {
+          const totalLength = fields.reduce(
+            (sum, field) => sum + field.description.length,
+            0,
+          )
+          return totalLength <= TOTAL_DESCRIPTION_LENGTH_LIMIT
+        },
+        {
+          message: `Total length of all descriptions cannot exceed ${TOTAL_DESCRIPTION_LENGTH_LIMIT} characters`,
+        },
+      ),
+  })
+  .superRefine((data, ctx) => {
+    if (!hasProvidedImage(data.image) && !data.continueIfNoFile) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'An image must be selected',
+        path: ['image'],
+      })
+    }
+  })


### PR DESCRIPTION
## Stack Context

This stack is the Pair plumber flow. This PR sits on `feat/pair-plumber-flow/fe-cleanup` and adds a missing-file option to Process image.

## Why?

Optional FormSG attachment fields can be blank. Process image always failed in that case, so pipes that still work without the file could not continue.

Users can now choose to continue with blank outputs, or stop and fail the execution. Existing steps have no `continueIfNoFile` stored. The schema defaults that to `false`, so they keep failing until someone opts in.

## What?

- Boolean radio after the outputs table: continue without the file, or fail this execution.
- If continue is selected and no file is present, skip the model call and write empty strings for each output.
- Blank or empty attachment values count as missing, not as a selected file.

## Test plan

- [ ] New Process image step shows the radio after outputs, defaulted to fail.
- [ ] Optional FormSG attachment left blank + fail: execution fails.
- [ ] Same setup + continue: execution succeeds, outputs are empty, later steps run.
- [ ] Image present + continue: image is still processed as before.
- [ ] Old Process image step (no stored flag) still fails when the file is missing.
