### PR TITLE
chore: support separate vapt ses

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -55,6 +55,14 @@
     {
       "name": "DD_PROFILING_ENABLED",
       "value": "true"
+    },
+    {
+      "name": "SES_FROM_ADDRESS",
+      "value": "info@plumber.gov.sg"
+    },
+    {
+      "name": "SES_REGION",
+      "value": "ap-southeast-2"
     }
   ],
   "secrets": [

--- a/packages/backend/.env-example
+++ b/packages/backend/.env-example
@@ -68,6 +68,8 @@ M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS=1000
 #                               # .env-example is also loaded by integration tests,
 #                               # and AWS_ACCESS_KEY_ID/SECRET above would conflict.
 SES_ROLE_ARN=...
+SES_FROM_ADDRESS=admin@example.gov.sg
+SES_REGION=ap-southeast-1
 # SES_CONFIGURATION_SET=        # omit in dev — no bounce routing
 # SQS_QUEUE_URL=                # omit in dev — poller won't start
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,6 @@
     "readme:db:rollback": "This command rolls back the last migration BATCH, which might include more than one migration.",
     "db:rollback": "npm run db -- migrate:rollback",
     "db:migrate": "npm run db -- migrate:latest",
-    "postsetup": "ts-node src/db/dynamodb_seeds/create_table.ts",
     "readme:dynamodb:seed": "echo 'Seeds the specified table with 10k rows, use with -- <YOUR_TABLE_ID>'",
     "dynamodb:seed": "ts-node src/db/dynamodb_seeds/seed_rows.ts",
     "readme:dynamodb:setup": "echo 'Run this function to create the required tile table in dynamodb locally.'",

--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -877,13 +877,13 @@ describe('send transactional email', () => {
         { input: { FromEmailAddress: string } },
       ]
       expect(sentCommand.input.FromEmailAddress).toBe(
-        '"Acme, Inc" <info@plumber.gov.sg>',
+        '"Acme, Inc" <admin@example.gov.sg>',
       )
 
       // ...but dataOut shows the clean, unquoted form.
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: expect.objectContaining({
-          from: 'Acme, Inc <info@plumber.gov.sg>',
+          from: 'Acme, Inc <admin@example.gov.sg>',
         }),
       })
     })

--- a/packages/backend/src/config/__tests__/app.test.ts
+++ b/packages/backend/src/config/__tests__/app.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Each test re-imports app.ts, which would otherwise re-run dotenv and restore
+// the real .env values on top of the stubbed ones.
+vi.mock('dotenv/config', () => ({}))
+
+const SES_ENV_KEYS = [
+  'SES_FROM_ADDRESS',
+  'SES_REGION',
+  'SES_ACCESS_KEY_ID',
+  'SES_SECRET_ACCESS_KEY',
+] as const
+
+type SesEnv = Partial<Record<(typeof SES_ENV_KEYS)[number], string>>
+
+async function loadSesConfig(env: SesEnv) {
+  for (const key of SES_ENV_KEYS) {
+    vi.stubEnv(key, env[key])
+  }
+  vi.resetModules()
+  const { default: appConfig } = await import('@/config/app')
+  return appConfig.ses
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('appConfig.ses', () => {
+  describe('from address and region', () => {
+    it('reads both from the environment', async () => {
+      const ses = await loadSesConfig({
+        SES_FROM_ADDRESS: 'noreply@agency.gov.sg',
+        SES_REGION: 'ap-southeast-1',
+      })
+
+      expect(ses.fromAddress).toBe('noreply@agency.gov.sg')
+      expect(ses.region).toBe('ap-southeast-1')
+    })
+
+    it('does not fall back to a hardcoded address or region', async () => {
+      const ses = await loadSesConfig({})
+
+      expect(ses.fromAddress).toBeUndefined()
+      expect(ses.region).toBeUndefined()
+    })
+  })
+
+  describe('explicit credentials', () => {
+    it('sets credentials when both the access key and the secret are given', async () => {
+      const ses = await loadSesConfig({
+        SES_ACCESS_KEY_ID: 'AKIAVAPT',
+        SES_SECRET_ACCESS_KEY: 'vapt-secret',
+      })
+
+      expect(ses.credentials).toEqual({
+        accessKeyId: 'AKIAVAPT',
+        secretAccessKey: 'vapt-secret',
+      })
+    })
+
+    // Leaving credentials unset is what makes the SDK fall back to the default
+    // provider chain (SSO/task role), so a half-configured pair must not
+    // produce a partial credentials object.
+    it('leaves credentials unset when neither is given', async () => {
+      const ses = await loadSesConfig({})
+
+      expect(ses.credentials).toBeUndefined()
+    })
+
+    it('leaves credentials unset when only the access key is given', async () => {
+      const ses = await loadSesConfig({ SES_ACCESS_KEY_ID: 'AKIAVAPT' })
+
+      expect(ses.credentials).toBeUndefined()
+    })
+
+    it('leaves credentials unset when only the secret is given', async () => {
+      const ses = await loadSesConfig({ SES_SECRET_ACCESS_KEY: 'vapt-secret' })
+
+      expect(ses.credentials).toBeUndefined()
+    })
+  })
+})

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config'
 import '@/types/luxon-extensions'
 
+import type { AwsCredentialIdentity } from '@aws-sdk/types'
 import { Settings as LuxonSettings } from 'luxon'
 import { URL } from 'node:url'
 
@@ -92,6 +93,10 @@ type AppConfig = {
     roleArn: string
     configurationSet?: string
     sqsQueueUrl?: string
+    /**
+     * Only used for special scenarios (e.g. no SSO)
+     */
+    credentials?: AwsCredentialIdentity
   }
   archiveEnabled: boolean
 }
@@ -197,12 +202,19 @@ const appConfig: AppConfig = {
   },
   // AWS postman SES
   ses: {
-    fromAddress: 'info@plumber.gov.sg',
-    region: 'ap-southeast-2',
+    fromAddress: process.env.SES_FROM_ADDRESS,
+    region: process.env.SES_REGION,
     roleArn: process.env.SES_ROLE_ARN,
     ...(process.env.SES_CONFIGURATION_SET && {
       configurationSet: process.env.SES_CONFIGURATION_SET,
     }),
+    ...(process.env.SES_ACCESS_KEY_ID &&
+      process.env.SES_SECRET_ACCESS_KEY && {
+        credentials: {
+          accessKeyId: process.env.SES_ACCESS_KEY_ID,
+          secretAccessKey: process.env.SES_SECRET_ACCESS_KEY,
+        },
+      }),
     sqsQueueUrl: process.env.SQS_QUEUE_URL || undefined,
   },
   archiveEnabled: process.env.ARCHIVE_ENABLED === 'true',

--- a/packages/backend/src/helpers/__tests__/ses-consumer.test.ts
+++ b/packages/backend/src/helpers/__tests__/ses-consumer.test.ts
@@ -11,7 +11,15 @@ const mocks = vi.hoisted(() => ({
   processSesEvent: vi.fn(),
   loggerInfo: vi.fn(),
   loggerError: vi.fn(),
+  sqsClient: vi.fn(),
   sqsQueueUrl: 'https://sqs.ap-southeast-1.amazonaws.com/123/ses-events',
+  sesCredentials: undefined as
+    | { accessKeyId: string; secretAccessKey: string }
+    | undefined,
+}))
+
+vi.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: mocks.sqsClient,
 }))
 
 vi.mock('sqs-consumer', () => ({
@@ -42,6 +50,9 @@ vi.mock('@/config/app', () => ({
       get sqsQueueUrl() {
         return mocks.sqsQueueUrl
       },
+      get credentials() {
+        return mocks.sesCredentials
+      },
     },
   },
 }))
@@ -68,8 +79,10 @@ describe('SES consumer wiring', () => {
     mocks.processSesEvent.mockReset()
     mocks.loggerInfo.mockClear()
     mocks.loggerError.mockClear()
+    mocks.sqsClient.mockClear()
     mocks.sqsQueueUrl =
       'https://sqs.ap-southeast-1.amazonaws.com/123/ses-events'
+    mocks.sesCredentials = undefined
   })
 
   afterEach(() => {
@@ -102,6 +115,35 @@ describe('SES consumer wiring', () => {
     expect(createOptions.batchSize).toBe(10)
     expect(createOptions.waitTimeSeconds).toBe(20)
     expect(typeof createOptions.handleMessage).toBe('function')
+  })
+
+  it('polls with the explicit credentials when they are configured', async () => {
+    mocks.sesCredentials = {
+      accessKeyId: 'AKIAVAPT',
+      secretAccessKey: 'vapt-secret',
+    }
+
+    const { startSesConsumer } = await importFresh()
+    startSesConsumer()
+
+    expect(mocks.sqsClient).toHaveBeenCalledWith({
+      credentials: mocks.sesCredentials,
+      region: 'ap-southeast-1',
+    })
+    expect(mocks.consumerCreate.mock.calls[0][0].sqs).toBeInstanceOf(
+      mocks.sqsClient,
+    )
+  })
+
+  // Undefined credentials are what make the SDK fall back to the default
+  // provider chain (SSO locally, task role in ECS).
+  it('polls with undefined credentials when none are configured', async () => {
+    const { startSesConsumer } = await importFresh()
+    startSesConsumer()
+
+    const sqsOptions = mocks.sqsClient.mock.calls[0][0]
+    expect(sqsOptions).toHaveProperty('credentials', undefined)
+    expect(sqsOptions).toHaveProperty('region', 'ap-southeast-1')
   })
 
   it('is idempotent — second call does not re-create the consumer', async () => {

--- a/packages/backend/src/helpers/__tests__/ses-email-helper.test.ts
+++ b/packages/backend/src/helpers/__tests__/ses-email-helper.test.ts
@@ -1,6 +1,61 @@
-import { describe, expect, it } from 'vitest'
+import type { AwsCredentialIdentity } from '@aws-sdk/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { formatFromAddress } from '../ses-email-helper'
+
+const mocks = vi.hoisted(() => {
+  const send = vi.fn(async () => ({}))
+  return {
+    send,
+    sesV2Client: vi.fn((_config: unknown) => ({ send })),
+    sendEmailCommand: vi.fn((input: unknown) => ({ input })),
+    fromTemporaryCredentials: vi.fn(
+      (_params: unknown) => 'temporary-credentials-provider',
+    ),
+    getSuppressedEmails: vi.fn(async () => [] as string[]),
+    sesConfig: {
+      fromAddress: 'admin@example.gov.sg',
+      region: 'ap-southeast-1',
+      roleArn: 'arn:aws:iam::123456789012:role/ses-sender',
+      credentials: undefined as AwsCredentialIdentity | undefined,
+    },
+  }
+})
+
+vi.mock('@aws-sdk/client-sesv2', () => ({
+  SESv2Client: mocks.sesV2Client,
+  SendEmailCommand: mocks.sendEmailCommand,
+}))
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+  fromTemporaryCredentials: mocks.fromTemporaryCredentials,
+}))
+
+vi.mock('@/config/app', () => ({
+  default: {
+    get ses() {
+      return mocks.sesConfig
+    },
+  },
+}))
+
+vi.mock('@/models/email-suppression-entry', () => ({
+  default: { getSuppressedEmails: mocks.getSuppressedEmails },
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({ getLdFlagValue: vi.fn() }))
+
+vi.mock('@/helpers/metrics', () => ({ incrementMetric: vi.fn() }))
+
+vi.mock('@/helpers/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+}))
+
+// getSesClient memoises its client, so every test needs a fresh module.
+async function importFresh() {
+  vi.resetModules()
+  return import('../ses-email-helper')
+}
 
 describe('formatFromAddress', () => {
   it('leaves a simple display name unquoted', () => {
@@ -28,5 +83,101 @@ describe('formatFromAddress', () => {
     expect(formatFromAddress('A, "B" \\C', 'a@b.gov.sg')).toBe(
       '"A, \\"B\\" \\\\C" <a@b.gov.sg>',
     )
+  })
+})
+
+describe('getSesClient', () => {
+  beforeEach(() => {
+    mocks.sesV2Client.mockClear()
+    mocks.fromTemporaryCredentials.mockClear()
+    mocks.sesConfig.region = 'ap-southeast-1'
+    mocks.sesConfig.credentials = undefined
+  })
+
+  it('builds the client in the configured region', async () => {
+    mocks.sesConfig.region = 'ap-southeast-2'
+
+    const { getSesClient } = await importFresh()
+    getSesClient()
+
+    expect(mocks.sesV2Client).toHaveBeenCalledTimes(1)
+    expect(mocks.sesV2Client.mock.calls[0][0]).toMatchObject({
+      region: 'ap-southeast-2',
+      credentials: 'temporary-credentials-provider',
+    })
+  })
+
+  it('always assumes the configured role', async () => {
+    const { getSesClient } = await importFresh()
+    getSesClient()
+
+    expect(mocks.fromTemporaryCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: {
+          RoleArn: 'arn:aws:iam::123456789012:role/ses-sender',
+          ExternalId: 'plumber-ses-access',
+        },
+      }),
+    )
+  })
+
+  it('uses the explicit credentials as master credentials when configured', async () => {
+    mocks.sesConfig.credentials = {
+      accessKeyId: 'AKIAVAPT',
+      secretAccessKey: 'vapt-secret',
+    }
+
+    const { getSesClient } = await importFresh()
+    getSesClient()
+
+    expect(mocks.fromTemporaryCredentials.mock.calls[0][0]).toMatchObject({
+      masterCredentials: {
+        accessKeyId: 'AKIAVAPT',
+        secretAccessKey: 'vapt-secret',
+      },
+    })
+  })
+
+  // An undefined masterCredentials is what makes the SDK resolve the role via
+  // the default provider chain (SSO locally, task role in ECS).
+  it('leaves master credentials undefined when none are configured', async () => {
+    const { getSesClient } = await importFresh()
+    getSesClient()
+
+    expect(mocks.fromTemporaryCredentials.mock.calls[0][0]).toHaveProperty(
+      'masterCredentials',
+      undefined,
+    )
+  })
+
+  it('memoises the client across calls', async () => {
+    const { getSesClient } = await importFresh()
+
+    expect(getSesClient()).toBe(getSesClient())
+    expect(mocks.sesV2Client).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('sendEmailViaSes', () => {
+  beforeEach(() => {
+    mocks.send.mockClear()
+    mocks.sendEmailCommand.mockClear()
+    mocks.getSuppressedEmails.mockResolvedValue([])
+    mocks.sesConfig.fromAddress = 'admin@example.gov.sg'
+  })
+
+  it('sends from the configured from address', async () => {
+    mocks.sesConfig.fromAddress = 'noreply@agency.gov.sg'
+
+    const { sendEmailViaSes } = await importFresh()
+    await sendEmailViaSes({
+      subject: 'Hello',
+      body: '<p>Hi</p>',
+      recipient: 'someone@agency.gov.sg',
+    })
+
+    expect(mocks.sendEmailCommand.mock.calls[0][0]).toMatchObject({
+      FromEmailAddress: 'Plumber <noreply@agency.gov.sg>',
+    })
   })
 })

--- a/packages/backend/src/helpers/ses-consumer.ts
+++ b/packages/backend/src/helpers/ses-consumer.ts
@@ -35,7 +35,10 @@ export function startSesConsumer(): void {
   // Note that N consumers will be polling the same SQS queue with N ECS tasks, but each message goes to exactly one consumer, and the queue's visibility timeout prevents two from processing the same message.
   sesConsumer = Consumer.create({
     queueUrl,
-    sqs: new SQSClient({ region: 'ap-southeast-1' }),
+    sqs: new SQSClient({
+      credentials: appConfig.ses.credentials,
+      region: 'ap-southeast-1',
+    }),
     batchSize: 10,
     waitTimeSeconds: 20,
     // visibilityTimeout intentionally unset — owned by SQS queue config in

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -16,6 +16,7 @@ export function getSesClient(): SESv2Client {
     sesClient = new SESv2Client({
       region: appConfig.ses.region,
       credentials: fromTemporaryCredentials({
+        masterCredentials: appConfig.ses.credentials,
         params: {
           RoleArn: appConfig.ses.roleArn,
           ExternalId: 'plumber-ses-access',


### PR DESCRIPTION
# Context

We are currently hard-coded to use postman's prod SES. For scenarios like VAPT , we don't want to hit that; we should be hitting our own resources instead.

# Fix

Support using our own isolated SES and SQS for these scenarios - including assuming that the setup cannot use our AWS SSO (e.g. vendors doing VAPT on local dev).

# Tests

- Use access keys from an IAM user with SES access and check that I can send emails
- [Regression test] Check that I can still send using postman's SES.