### PR TITLE
fix: show variable pills in read-only rich-text step preview

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/RichTextEditorContext.tsx
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditorContext.tsx
@@ -4,6 +4,9 @@ interface RichTextEditorContextValue {
   closeSuggestions: () => void
   openSuggestions: () => void
   supportTableDisplay?: boolean
+  // Overrides the step name shown in a variable badge's tooltip, for
+  // contexts without the full EditorContext's `stepsWithVars`.
+  getVariableStepName?: (variableId: string) => string | undefined
 }
 
 export const RichTextEditorContext = createContext<RichTextEditorContextValue>({

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -7,10 +7,13 @@ import { NodeViewWrapper } from '@tiptap/react'
 import { EditorContext } from '@/contexts/Editor'
 import { POPOVER_OPACITY_MOTION_PROPS } from '@/theme/constants'
 
+import { RichTextEditorContext } from './RichTextEditorContext'
+
 const PLACEHOLDER_TEMPLATE_STEP_ID = '00000000-0000-0000-0000-000000000000'
 
 export const VariableBadge = ({ node }: { node: Node }) => {
   const { stepsWithVars } = useContext(EditorContext)
+  const { getVariableStepName } = useContext(RichTextEditorContext)
   // this happens when there is no value mapped properly
   const isEmpty = node.attrs.value === '' || node.attrs.value == null
   const value = String(node.attrs.value)
@@ -21,7 +24,9 @@ export const VariableBadge = ({ node }: { node: Node }) => {
   const stepId = node.attrs.id?.startsWith('step.')
     ? node.attrs.id.split('.')[1]
     : null
-  const step = stepsWithVars.find((step) => step.id === stepId)
+  const stepName =
+    getVariableStepName?.(node.attrs.id) ??
+    stepsWithVars.find((step) => step.id === stepId)?.name
 
   return (
     <NodeViewWrapper>
@@ -31,7 +36,7 @@ export const VariableBadge = ({ node }: { node: Node }) => {
         label={
           isEmpty && !isTemplate
             ? 'This is a missing variable, check your previous steps and reselect a variable'
-            : step?.name
+            : stepName
         }
         aria-label="variable badge tooltip"
       >

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -113,6 +113,7 @@ interface EditorProps {
   previewType?: TFieldPreviewType
   containerClassName?: string
   triggerContainerClassName?: string
+  getVariableStepName?: (variableId: string) => string | undefined
 }
 const Editor = ({
   onChange,
@@ -134,6 +135,7 @@ const Editor = ({
   previewType,
   containerClassName,
   triggerContainerClassName,
+  getVariableStepName,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
@@ -168,7 +170,9 @@ const Editor = ({
     Placeholder.configure({
       placeholder,
     }),
-    ...(isDisplayOnly ? [] : [StepVariable, TableVariable]),
+    // Registered even display-only, so variable spans render as chips.
+    StepVariable,
+    TableVariable,
     ImageResize.configure({
       inline: true,
       resizable: !isDisplayOnly,
@@ -243,6 +247,11 @@ const Editor = ({
       transformPastedHTML: (html) => {
         return substituteOldTemplates(html, varInfo)
       },
+      // Variable nodes are selectable atoms for editing; suppress that
+      // click-to-select in display-only mode so chips aren't "clickable".
+      handleClickOn: (_view, _pos, node) =>
+        isDisplayOnly &&
+        (node.type.name === 'variable' || node.type.name === 'tableVariable'),
     },
   })
   useEffect(() => {
@@ -317,8 +326,18 @@ const Editor = ({
   } = useDisclosure()
 
   const suggestionsContextValue = useMemo(
-    () => ({ closeSuggestions, openSuggestions, supportTableDisplay }),
-    [closeSuggestions, openSuggestions, supportTableDisplay],
+    () => ({
+      closeSuggestions,
+      openSuggestions,
+      supportTableDisplay,
+      getVariableStepName,
+    }),
+    [
+      closeSuggestions,
+      openSuggestions,
+      supportTableDisplay,
+      getVariableStepName,
+    ],
   )
 
   return (
@@ -336,6 +355,9 @@ const Editor = ({
         <div
           className={clsx('editor', containerClassName)}
           onClick={(e) => {
+            if (!editable) {
+              return
+            }
             e.stopPropagation()
             openSuggestions()
           }}

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -42,8 +42,11 @@ export function buildVariableInfoMapFromPaths(
 ): VariableInfoMap {
   const map: VariableInfoMap = new Map()
   for (const [path, value] of valuesByPath) {
+    // Fall back to the last path segment, not the full `step.<id>.<path>`
+    // string, which is what a variable chip would otherwise display.
+    const lastSegment = path.split('.').pop() ?? path
     map.set(`{{${path}}}`, {
-      label: labelsByPath.get(path) ?? path,
+      label: labelsByPath.get(path) ?? lastSegment,
       testRunValue: value,
     })
   }

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/RichTextPreview.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/RichTextPreview.tsx
@@ -4,6 +4,7 @@ import { BareEditor } from '@/components/RichTextEditor'
 
 interface RichTextPreviewProps {
   html: string
+  stepNameById: Map<string, string>
 }
 
 const ALLOWED_HREF_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:']
@@ -24,10 +25,24 @@ function sanitizeRichTextHtml(html: string): string {
   )
 }
 
+// A variable's `id` is `step.<stepId>.<path>`; look up by the bare step id.
+function getVariableStepName(
+  variableId: string,
+  stepNameById: Map<string, string>,
+): string | undefined {
+  if (!variableId.startsWith('step.')) {
+    return undefined
+  }
+  return stepNameById.get(variableId.split('.')[1])
+}
+
 // Renders resolved rich-text HTML (e.g. a Pair prompt or an email body)
 // inline and read-only via the same Tiptap renderer the editor uses, so tags
 // like tables render as they would when the flow runs.
-export default function RichTextPreview({ html }: RichTextPreviewProps) {
+export default function RichTextPreview({
+  html,
+  stepNameById,
+}: RichTextPreviewProps) {
   return (
     <Box
       w="full"
@@ -56,7 +71,8 @@ export default function RichTextPreview({ html }: RichTextPreviewProps) {
           minHeight: 'auto',
           maxHeight: 'none',
           fontSize: 'sm',
-          lineHeight: '1.6',
+          // Extra room so the padded variable badges don't overlap lines.
+          lineHeight: '2',
           color: 'base.content.default',
         },
       }}
@@ -67,8 +83,12 @@ export default function RichTextPreview({ html }: RichTextPreviewProps) {
         }}
         initialValue={sanitizeRichTextHtml(html)}
         editable={false}
+        variablesEnabled={false}
         isRich
         isDisplayOnly
+        getVariableStepName={(variableId) =>
+          getVariableStepName(variableId, stepNameById)
+        }
       />
     </Box>
   )

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -13,7 +13,7 @@ import { Box, Flex, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react'
 
 import {
   buildVariableInfoMapFromPaths,
-  substituteForPreview,
+  substituteOldTemplates,
 } from '@/components/RichTextEditor/utils'
 import { GET_DYNAMIC_DATA } from '@/graphql/queries/get-dynamic-data'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
@@ -307,7 +307,7 @@ export default function StepParameterRows({
         label: resolveFieldLabel(stepFields, key),
         isPreview,
         previewHtml: isPreview
-          ? substituteForPreview(String(value), variableInfoMap)
+          ? substituteOldTemplates(String(value), variableInfoMap)
           : undefined,
         // AI-provided labels are already a human-readable summary, so they
         // skip the Column/Value table too. Preview fields skip both, since
@@ -377,7 +377,10 @@ export default function StepParameterRows({
           }) => (
             <ParameterRow key={key} label={label}>
               {isPreview ? (
-                <RichTextPreview html={previewHtml ?? ''} />
+                <RichTextPreview
+                  html={previewHtml ?? ''}
+                  stepNameById={stepNameById}
+                />
               ) : columnValueRows && columnValueRows.length > 0 ? (
                 <ColumnValueTable
                   rows={columnValueRows}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/helpers/resolveFieldDisplayValue.ts
@@ -40,6 +40,7 @@ export function resolveFieldLabel(
 
 export type FieldWithOptions = {
   key?: string
+  type?: string
   options?: Array<{ label: string; value: string | number | boolean }>
   subFields?: FieldWithOptions[]
 }
@@ -98,7 +99,18 @@ export function resolveDisplayValue(
     | undefined
 
   if (Array.isArray(value)) {
-    return value
+    // `grouped-multirow` (e.g. if-then) persists as `[{ rows: [...] }, ...]`
+    // — groups of rows, not a flat row array — so unwrap groups first.
+    const rows =
+      field?.type === 'grouped-multirow'
+        ? value.flatMap((group) =>
+            Array.isArray((group as { rows?: unknown[] })?.rows)
+              ? (group as { rows: unknown[] }).rows
+              : [],
+          )
+        : value
+
+    return rows
       .map((item) => flattenRow(item, field?.subFields))
       .filter((line): line is string => line !== null && line !== '')
   }


### PR DESCRIPTION
## TL;DR

The AI Builder step preview's rich-text fields (e.g. an email body) showed variables as their flattened resolved value instead of a variable chip. This restores chips, and fixes a handful of issues that came with them.

## What changed?

- Swapped `substituteForPreview` for `substituteOldTemplates` in `StepParameterRows.tsx` so unresolved `{{step.x.y}}` references are rebuilt into `data-type="variable"` spans instead of flattened to plain text.
- Registered the `StepVariable`/`TableVariable` Tiptap extensions even in the editor's `isDisplayOnly` mode, so those spans render as chips.
- Made the chips fully inert in preview mode:
  - Passed `variablesEnabled={false}` so the suggestions popover doesn't render.
  - Guarded the editor container's click handler on `editable`.
  - Swallowed clicks on `variable`/`tableVariable` nodes via `handleClickOn` so they don't pick up ProseMirror's click-to-select highlight.
- Added a `getVariableStepName` override on `RichTextEditorContext` so a chip's tooltip can resolve its step name from the AI Builder page's own step data, since that route isn't wrapped in the full editor's `EditorContext`.
- Bumped the preview's line-height so the padded chips don't overlap adjacent lines.
- Fixed `resolveDisplayValue` to unwrap if-then's `grouped-multirow` conditions (`[{ rows: [...] }, ...]`) before flattening each row — previously the whole conditions row silently rendered nothing.
- Fixed `buildVariableInfoMapFromPaths`'s label fallback, which used the full `step.<id>.<path>` string instead of a readable fallback when a field had no real label metadata — this only started showing up once chips started reading `.label` again.

## Tests

- [ ] Open the AI Builder step preview for a step with a rich-text body field (e.g. an email) that references prior-step variables — confirm the variables render as chips, not resolved text.
- [ ] Confirm clicking a chip in the preview does nothing (no suggestions popover, no selection highlight).
- [ ] Hover a chip and confirm the tooltip shows the source step's name.
- [ ] Confirm lines with chips don't visually overlap adjacent lines.
- [ ] Open the preview for an if-then step with multiple condition groups — confirm each condition row renders with its variable references as pills.
- [ ] Confirm a variable chip with no configured field label shows a readable fallback (e.g. the field's path segment), not the raw `step.<uuid>.<path>` string.

## Deploy notes

None — frontend-only, no migrations or config changes.
