### PR TITLE
fix(formsg): trust attachment URLs per form env

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => {
     consoleError: vi.fn(),
     consoleWarn: vi.fn(),
     getSdk: vi.fn(() => mockSdk),
-    parseFormEnv: vi.fn(),
+    parseFormEnv: vi.fn(() => 'prod'),
     storeAttachmentInS3: vi.fn(() => 'mock-s3-id'),
     fetchFormSchema: vi.fn(() => null),
     decryptFormAttachmentsV3OrV4: vi.fn(() => ({})),
@@ -216,6 +216,69 @@ describe('decrypt form response - MRF specific', () => {
         },
         expect.any(Array),
       )
+    })
+
+    it('should trust attachment URLs under the form env-specific prefix for non-prod envs', async () => {
+      $.flow.hasFileProcessingActions = true
+      mocks.parseFormEnv.mockReturnValueOnce('staging')
+      $.request.body.data.attachmentDownloadUrls = {
+        attachField1:
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/123',
+      }
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        submissionSecretKey: 'mock-secret-key',
+        responses: {
+          attachField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+      mocks.decryptFormAttachmentsV3OrV4.mockResolvedValueOnce({
+        attachField1: {
+          filename: 'myfile.pdf',
+          content: Buffer.from('file content'),
+        },
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.decryptFormAttachmentsV3OrV4).toHaveBeenCalledWith(
+        mocks.getSdk(),
+        'mock-secret-key',
+        {
+          attachField1:
+            'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/123',
+        },
+        expect.any(Array),
+      )
+    })
+
+    it('should return verified: false when an attachment URL uses the prod prefix for a staging form', async () => {
+      $.flow.hasFileProcessingActions = true
+      mocks.parseFormEnv.mockReturnValueOnce('staging')
+      $.request.body.data.attachmentDownloadUrls = {
+        attachField1:
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
+      }
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        submissionSecretKey: 'mock-secret-key',
+        responses: {
+          attachField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({ verified: false, internalId: null })
+      expect(mocks.decryptFormAttachmentsV3OrV4).not.toHaveBeenCalled()
     })
 
     it('should return verified: false without downloading when an attachment URL is untrusted', async () => {

--- a/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
@@ -2,21 +2,54 @@ import { describe, expect, it } from 'vitest'
 
 import { areAttachmentUrlsTrusted } from '../../auth/trusted-attachment-urls'
 
-const TRUSTED_URL =
+const TRUSTED_PROD_URL =
   'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
+const TRUSTED_STAGING_URL =
+  'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
+const TRUSTED_UAT_URL =
+  'https://s3.ap-southeast-1.amazonaws.com/attachments.uat.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
 
 describe('areAttachmentUrlsTrusted', () => {
   it('accepts an empty map', () => {
-    expect(areAttachmentUrlsTrusted({})).toBe(true)
+    expect(areAttachmentUrlsTrusted({}, 'prod')).toBe(true)
   })
 
-  it('accepts FormSG bucket URLs', () => {
+  it('accepts FormSG bucket URLs for the prod env', () => {
     expect(
-      areAttachmentUrlsTrusted({
-        attachField1: TRUSTED_URL,
-        attachField2: `${TRUSTED_URL}?X-Amz-Signature=abc`,
-      }),
+      areAttachmentUrlsTrusted(
+        {
+          attachField1: TRUSTED_PROD_URL,
+          attachField2: `${TRUSTED_PROD_URL}?X-Amz-Signature=abc`,
+        },
+        'prod',
+      ),
     ).toBe(true)
+  })
+
+  it('accepts FormSG bucket URLs for the staging env', () => {
+    expect(
+      areAttachmentUrlsTrusted(
+        { attachField1: TRUSTED_STAGING_URL },
+        'staging',
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts FormSG bucket URLs for the uat env', () => {
+    expect(
+      areAttachmentUrlsTrusted({ attachField1: TRUSTED_UAT_URL }, 'uat'),
+    ).toBe(true)
+  })
+
+  it.each([
+    ['a staging URL against the prod env', TRUSTED_STAGING_URL, 'prod'],
+    ['a uat URL against the prod env', TRUSTED_UAT_URL, 'prod'],
+    ['a prod URL against the staging env', TRUSTED_PROD_URL, 'staging'],
+    ['a uat URL against the staging env', TRUSTED_UAT_URL, 'staging'],
+    ['a prod URL against the uat env', TRUSTED_PROD_URL, 'uat'],
+    ['a staging URL against the uat env', TRUSTED_STAGING_URL, 'uat'],
+  ] as const)('rejects %s', (_label, url, formEnv) => {
+    expect(areAttachmentUrlsTrusted({ attachField1: url }, formEnv)).toBe(false)
   })
 
   it.each([
@@ -49,15 +82,20 @@ describe('areAttachmentUrlsTrusted', () => {
     ['a malformed URL', 'not-a-url'],
     ['an empty string', ''],
   ])('rejects %s', (_label, untrustedUrl) => {
-    expect(areAttachmentUrlsTrusted({ attachField1: untrustedUrl })).toBe(false)
+    expect(
+      areAttachmentUrlsTrusted({ attachField1: untrustedUrl }, 'prod'),
+    ).toBe(false)
   })
 
   it('rejects the whole map when only one URL is untrusted', () => {
     expect(
-      areAttachmentUrlsTrusted({
-        attachField1: TRUSTED_URL,
-        attachField2: 'https://plumber.svc.cluster.local/a',
-      }),
+      areAttachmentUrlsTrusted(
+        {
+          attachField1: TRUSTED_PROD_URL,
+          attachField2: 'https://plumber.svc.cluster.local/a',
+        },
+        'prod',
+      ),
     ).toBe(false)
   })
 })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -103,7 +103,8 @@ export async function decryptFormResponse(
     return { verified: false, internalId: null }
   }
 
-  const formSgSdk = getSdk(parseFormEnv($))
+  const formEnv = parseFormEnv($)
+  const formSgSdk = getSdk(formEnv)
 
   const {
     headers,
@@ -153,7 +154,7 @@ export async function decryptFormResponse(
       // Checked before downloading anything, so a forged URL costs us no
       // requests. Returning here keeps it on the same 401 path as every other
       // untrusted payload, instead of surfacing a 500 and a stack trace.
-      if (!areAttachmentUrlsTrusted(data.attachmentDownloadUrls)) {
+      if (!areAttachmentUrlsTrusted(data.attachmentDownloadUrls, formEnv)) {
         logger.error({
           event: 'formsg-untrusted-attachment-url',
           formId: data.formId,

--- a/packages/backend/src/apps/formsg/auth/trusted-attachment-urls.ts
+++ b/packages/backend/src/apps/formsg/auth/trusted-attachment-urls.ts
@@ -1,11 +1,23 @@
-const TRUSTED_ORIGIN = 'https://s3.ap-southeast-1.amazonaws.com'
-const TRUSTED_PATH_PREFIX = '/attachments.form.gov.sg/'
+import type { FormEnv } from '../common/form-env'
 
-function isTrusted(url: string): boolean {
+const TRUSTED_ORIGIN = 'https://s3.ap-southeast-1.amazonaws.com'
+
+// Prod attachments sit directly under attachments.form.gov.sg, without a
+// `prod.` env segment, since that env predates the other form.gov.sg envs.
+function getTrustedPathPrefix(formEnv: FormEnv): string {
+  return formEnv === 'prod'
+    ? '/attachments.form.gov.sg/'
+    : `/attachments.${formEnv}.form.gov.sg/`
+}
+
+function isTrusted(url: string, formEnv: FormEnv): boolean {
   try {
     const { origin, pathname } = new URL(url)
 
-    return origin === TRUSTED_ORIGIN && pathname.startsWith(TRUSTED_PATH_PREFIX)
+    return (
+      origin === TRUSTED_ORIGIN &&
+      pathname.startsWith(getTrustedPathPrefix(formEnv))
+    )
   } catch {
     // Malformed enough that URL cannot parse it, so it is not FormSG's bucket.
     return false
@@ -21,6 +33,9 @@ function isTrusted(url: string): boolean {
  */
 export function areAttachmentUrlsTrusted(
   attachmentDownloadUrls: Record<string, string>,
+  formEnv: FormEnv,
 ): boolean {
-  return Object.values(attachmentDownloadUrls).every(isTrusted)
+  return Object.values(attachmentDownloadUrls).every((url) =>
+    isTrusted(url, formEnv),
+  )
 }


### PR DESCRIPTION
# Problem

We can't receive attachments from FormSG UAT or staging.

Root cause: FormSG sends UAT and staging attachments from a different bucket.

# Fix

Support form envs when validating attachment URLs.

# Tests

- Check that I can receive attachments from UAT
- [Regression check] Check that I can receive attachments from prod (in staging env).