### PR TITLE
chore(DX): harden supply chain 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,9 +13,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'pnpm'
@@ -32,7 +32,7 @@ runs:
       run: pnpm install --frozen-lockfile
 
     - name: Restore turbo cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .turbo
         # inputs.job-index disambiguates matrix legs sharing the same github.job, which would

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,20 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/packages/backend"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - production
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - staging-v2
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - uat
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -68,7 +68,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
         with:
           mask-password: 'true'
 
@@ -89,7 +89,7 @@ jobs:
           docker build . -t ${{ steps.ecr-image-uri.outputs.image }} --build-arg APP_ENV=${{ inputs.environment }} --secret id=NPM_TASKFORCESH_TOKEN
 
       - name: Scan built image with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@baab69e77b34f244adef1f702d0fd69f2b3bc545 # v1.6.0
         id: inspector
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload Scan Results
         id: upload-scan-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: |
             ${{ steps.inspector.outputs.inspector_scan_results }}
@@ -120,7 +120,7 @@ jobs:
 
       - name: Notify Slack if vulnerability threshold is exceeded
         if: steps.inspector.outputs.vulnerability_threshold_exceeded == '1'
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -159,10 +159,10 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -170,7 +170,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
         with:
           mask-password: 'true'
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: (Server) Fill in the new image ID in the Amazon ECS task definition
         id: server-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
         with:
           task-definition: ecs-task-definition.json
           container-name: server
@@ -209,14 +209,14 @@ jobs:
 
       - name: (Worker) Fill in the new image ID in the Amazon ECS task definition
         id: full-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
         with:
           task-definition: ${{ steps.server-task-def.outputs.task-definition }}
           container-name: worker
           image: ${{ steps.ecr-image-uri.outputs.image }}
 
       - name: Deploy Amazon ECS task definition to server
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@69e7aed9b8acdd75a6c585ac669c33831ab1b9a3 # v1.5.0
         with:
           task-definition: ${{ steps.full-task-def.outputs.task-definition }}
           cluster: ${{ inputs.ecs-cluster-name }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: (Archival) Fill in the new image ID in the Amazon ECS task definition
         id: archival-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@138c24f321fdbdf7edee4a685519d253cae2cdea # v1.9.0
         with:
           task-definition: ecs-archival-task-definition.json
           container-name: archival

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
         env:
           DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        uses: datadog/test-visibility-github-action@v2
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
         env:
           DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        uses: datadog/test-visibility-github-action@v2
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
         with:
           npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
         env:
           DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        uses: datadog/test-visibility-github-action@v2
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -10,6 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  supply-chain:
+    name: Supply chain verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: ./.github/actions/setup
+        with:
+          npm-taskforcesh-token: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
+      - name: Verify registry signatures
+        run: pnpm audit signatures
+      - name: Generate SBOM
+        run: pnpm sbom --sbom-format cyclonedx --prod --out sbom.cdx.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: sbom.cdx.json
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22-alpine as build
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 as build # 22-alpine
 
 ARG APP_ENV=prod
 ENV VITE_MODE=$APP_ENV
@@ -18,7 +18,7 @@ RUN pnpm run build
 # --legacy avoids requiring inject-workspace-packages=true workspace-wide just for this.
 RUN pnpm --filter backend deploy --legacy --prod ./deploy/backend
 
-FROM node:22-alpine as main
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 as main # 22-alpine
 
 WORKDIR /opt/plumber
 

--- a/Dockerfile.archival
+++ b/Dockerfile.archival
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22-alpine as build
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 as build # 22-alpine
 
 ARG APP_ENV=prod
 ENV VITE_MODE=$APP_ENV
@@ -18,7 +18,7 @@ RUN pnpm --filter backend-archive run build
 # --legacy avoids requiring inject-workspace-packages=true workspace-wide just for this.
 RUN pnpm --filter backend-archive deploy --legacy --prod ./deploy/backend-archive
 
-FROM node:22-alpine as main
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 as main # 22-alpine
 
 WORKDIR /opt/plumber
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "plumber",
+  "private": true,
   "license": "AGPL-3.0",
   "engines": {
     "pnpm": ">=12.1.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "packageManager": "pnpm@12.1.0",
   "scripts": {
-    "preinstall": "npx --yes only-allow pnpm",
+    "preinstall": "pnpm exec only-allow pnpm",
     "postinstall": "pnpm run gqlc",
     "setup": "node scripts/with-op-env.mjs --env setup pnpm --filter backend run setup",
     "dev": "node scripts/with-op-env.mjs turbo watch dev worker --continue",

--- a/packages/backend-archive/package.json
+++ b/packages/backend-archive/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backend-archive",
   "version": "1.83.0",
+  "private": true,
   "scripts": {
     "prebuild": "rimraf ./dist",
     "build": "tsc && tsc-alias",

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - plumber-redis:/var/lib/redis/
   tunnel:
-    image: cloudflare/cloudflared
+    image: cloudflare/cloudflared:2026.8.2
     restart: unless-stopped
     command: tunnel run --protocol http2
     environment:
@@ -78,7 +78,7 @@ services:
       echo 'logo uploaded to bucket'
       "
   dynamodb:
-    image: amazon/dynamodb-local
+    image: amazon/dynamodb-local:3.3.1
     ports:
       - '8000:8000'
     user: root

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "backend",
+  "private": true,
   "scripts": {
     "setup": "docker-compose -f docker-compose.dev.yml up -d",
     "teardown": "docker-compose -f docker-compose.dev.yml down",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frontend",
   "version": "1.83.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "wait-on tcp:${DEV_BACKEND_PORT:-3000} && vite --host --force",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@plumber/types",
+  "private": true,
   "description": "Shared types for plumber",
   "types": "./index.d.ts",
   "version": "1.83.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,59 @@ packages:
 
 engineStrict: true
 minimumReleaseAge: 2880
+minimumReleaseAgeIgnoreMissingTime: false
+
+# @taskforcesh/bullmq-pro is served from the private npm.taskforce.sh registry. Unauthenticated
+# access 401s locally, and even with CI's NPM_TASKFORCESH_TOKEN the manifest has no "time" field
+# at all (confirmed via ERR_PNPM_TRUST_DOWNGRADE, not just the release-age check) — this looks
+# like a structural gap in that registry's metadata rather than something a token fixes. Excluded
+# from both checks below; revisit if taskforce.sh ever starts serving publish timestamps.
+minimumReleaseAgeExclude:
+  - "@taskforcesh/bullmq-pro@7.44.0"
+
+registries:
+  default: "https://registry.npmjs.org/"
+
+blockExoticSubdeps: true
+
+strictDepBuilds: true
+
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 525600
+# Investigated 2026-08-24: both are legitimate maintainer-published patch releases that simply
+# didn't go through the project's usual npm Trusted Publisher (OIDC) CI pipeline for this one
+# version, not signs of account/package takeover.
+trustPolicyExclude:
+  # See minimumReleaseAgeExclude above — same private registry, same missing "time" metadata.
+  - "@taskforcesh/bullmq-pro@7.44.0"
+  # cytoscape.js 3.34.0 published via GitHub Actions OIDC; 3.34.1 published manually by the same
+  # longtime maintainer (maxkfranz) as a normal 9-commit patch (verified via GitHub compare diff,
+  # no script/dependency changes).
+  - "cytoscape@3.34.1"
+  # tiptap's 2.27.2 wave was published by _bdbch, a currently-listed @tiptap org maintainer,
+  # across ~20 packages simultaneously — the signature of a routine monorepo release, not an
+  # isolated account compromise.
+  - "@tiptap/core@2.27.2"
+  - "@tiptap/extension-blockquote@2.27.2"
+  - "@tiptap/extension-bold@2.27.2"
+  - "@tiptap/extension-bubble-menu@2.27.2"
+  - "@tiptap/extension-bullet-list@2.27.2"
+  - "@tiptap/extension-code-block@2.27.2"
+  - "@tiptap/extension-code@2.27.2"
+  - "@tiptap/extension-document@2.27.2"
+  - "@tiptap/extension-dropcursor@2.27.2"
+  - "@tiptap/extension-floating-menu@2.27.2"
+  - "@tiptap/extension-gapcursor@2.27.2"
+  - "@tiptap/extension-heading@2.27.2"
+  - "@tiptap/extension-history@2.27.2"
+  - "@tiptap/extension-horizontal-rule@2.27.2"
+  - "@tiptap/extension-italic@2.27.2"
+  - "@tiptap/extension-list-item@2.27.2"
+  - "@tiptap/extension-ordered-list@2.27.2"
+  - "@tiptap/extension-paragraph@2.27.2"
+  - "@tiptap/extension-strike@2.27.2"
+  - "@tiptap/extension-text@2.27.2"
+  - "@tiptap/pm@2.27.2"
 
 publicHoistPattern:
   - "graphql"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,11 @@ packages:
 
 engineStrict: true
 minimumReleaseAge: 2880
-minimumReleaseAgeIgnoreMissingTime: false
+# npm.taskforce.sh (bullmq-pro) omits the "time" field in packument metadata. false hard-fails
+# ERR_PNPM_MISSING_TIME for any such registry, including with minimumReleaseAgeExclude /
+# trustPolicyExclude. true skips age and trust-downgrade checks only when timestamps are absent;
+# packages on registries that publish "time" still get the full 48h minimumReleaseAge + trustPolicy.
+minimumReleaseAgeIgnoreMissingTime: true
 
 # @taskforcesh/bullmq-pro is served from the private npm.taskforce.sh registry. Unauthenticated
 # access 401s locally, and even with CI's NPM_TASKFORCESH_TOKEN the manifest has no "time" field

--- a/tools/load-tests/package.json
+++ b/tools/load-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@plumber/load-tests",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "index.js",
   "author": "",

--- a/tools/seeds/package.json
+++ b/tools/seeds/package.json
@@ -1,6 +1,7 @@
 {
   "name": "seeds",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Stack context

Stacks on `chore/pnpm-migration`. That PR moves us to pnpm. This one locks down how we install, build, and ship.

## What

Supply-chain hardening across pnpm config, CI, Docker, and Dependabot.

**pnpm (`pnpm-workspace.yaml`)**
- `minimumReleaseAge: 2880` (48h) with `trustPolicy: no-downgrade`
- `blockExoticSubdeps`, `strictDepBuilds`, explicit `registries.default`
- `minimumReleaseAgeIgnoreMissingTime: true` because npm.taskforce.sh omits `"time"` in packument metadata
- Documented exclusions for `@taskforcesh/bullmq-pro`, `cytoscape@3.34.1`, and `@tiptap/*@2.27.2` (investigated 2026-08-24, not takeovers)

**Install hook (`package.json`)**
- `only-allow` runs via `pnpm exec` instead of unpinned `npx`

**Workspace packages**
- All packages marked `"private": true` (nothing here is published)

**CI**
- New `supply-chain` job: `pnpm audit signatures` + CycloneDX SBOM artifact per build
- Third-party Actions pinned to full SHAs (version comment kept for Dependabot)
- Deploy callers declare `id-token: write` and `contents: read` explicitly
- Workflow default `permissions: contents: read`

**Dependabot**
- `github-actions` and `docker` ecosystems added (root + `packages/backend` for compose)
- Existing npm groups unchanged

**Docker**
- `Dockerfile*` `node:22-alpine` pinned by digest
- `docker-compose.dev.yml` dynamodb-local and cloudflared pinned to specific versions

## Upside

- A repointed Action tag or Docker `:latest` no longer silently changes what runs in CI or prod builds. Pins are explicit, and Dependabot can bump them.
- `pnpm audit signatures` fails the build on unsigned or tampered packages instead of us finding out from a blog post.
- Every CI run uploads an SBOM. If something lands in prod, we can diff artifacts instead of guessing from a stale lockfile.
- `trustPolicy: no-downgrade` + 48h release age blocks the common "publish a patch from a compromised account" path for npm packages that do publish timestamps.
- `only-allow` via `pnpm exec` closes the hole where `npx` could pull a different binary on every install.

## Test plan

- [ ] CI green on this branch (supply-chain job included)
- [ ] `pnpm install` works locally with `NPM_TASKFORCESH_TOKEN` set
- [ ] `pnpm audit signatures` passes
- [ ] SBOM artifact appears on a CI run
