### PR TITLE
fix(tiles): stop visual row duplication when reordering columns

### DIFF
--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -1,6 +1,6 @@
 import { ITableRow, ITableRowCsv } from '@plumber/types'
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ApolloError, useLazyQuery } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
 import { zipObject } from 'lodash'
@@ -69,13 +69,23 @@ export function useFetchAllRows({
 
   const cursorToContinueFrom = useRef<string>()
   const startTime = useRef<number>()
+  const fetchGenerationRef = useRef(0)
 
   const [fetchAllRowsQuery] = useLazyQuery(GET_ALL_ROWS, {
     fetchPolicy: 'cache-and-network',
   })
 
+  // Drop in-flight pages when switching tiles so they cannot append onto the new tile.
+  useEffect(() => {
+    fetchGenerationRef.current += 1
+    setRows([])
+    cursorToContinueFrom.current = undefined
+    setIsThroughputError(false)
+  }, [tableId])
+
   const fetchAllRows = useCallback(
     async (cursor?: string) => {
+      const generation = ++fetchGenerationRef.current
       startTime.current = performance.now()
       setIsFetching(true)
       let rowCount = 0
@@ -95,6 +105,9 @@ export function useFetchAllRows({
             },
             context: viewOnlyHeaders ? { headers: viewOnlyHeaders } : undefined,
           })
+          if (generation !== fetchGenerationRef.current) {
+            return
+          }
           if (error) {
             throw error
           }
@@ -112,6 +125,9 @@ export function useFetchAllRows({
           currentCursor = data?.getAllRows.stringifiedCursor ?? undefined
         } while (currentCursor)
       } catch (e) {
+        if (generation !== fetchGenerationRef.current) {
+          return
+        }
         if (
           e instanceof ApolloError &&
           parseGraphqlError(e).code === RATE_LIMITED
@@ -122,6 +138,9 @@ export function useFetchAllRows({
           setIsThroughputError(false)
         }
       } finally {
+        if (generation !== fetchGenerationRef.current) {
+          return
+        }
         datadogRum.setGlobalContextProperty(
           'tile_load_time',
           performance.now() - startTime.current,

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -138,15 +138,14 @@ export function useFetchAllRows({
           setIsThroughputError(false)
         }
       } finally {
-        if (generation !== fetchGenerationRef.current) {
-          return
+        if (generation === fetchGenerationRef.current) {
+          datadogRum.setGlobalContextProperty(
+            'tile_load_time',
+            performance.now() - startTime.current,
+          )
+          datadogRum.setGlobalContextProperty('tile_row_count', rowCount)
+          setIsFetching(false)
         }
-        datadogRum.setGlobalContextProperty(
-          'tile_load_time',
-          performance.now() - startTime.current,
-        )
-        datadogRum.setGlobalContextProperty('tile_row_count', rowCount)
-        setIsFetching(false)
       }
     },
     [fetchAllRowsQuery, tableId, urlViewOnlyKey, viewToken],

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -81,6 +81,8 @@ export function useFetchAllRows({
     setRows([])
     cursorToContinueFrom.current = undefined
     setIsThroughputError(false)
+    // Stale generations skip the finally block, so nothing else clears this if no new fetch follows.
+    setIsFetching(false)
   }, [tableId])
 
   const fetchAllRows = useCallback(

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -1,6 +1,6 @@
 import { ITableMetadata } from '@plumber/types'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { useParams } from 'react-router-dom'
 import { ApolloError, useQuery } from '@apollo/client'
@@ -65,13 +65,17 @@ export default function Tile(): JSX.Element | null {
       : undefined,
   })
   const ownRole = getTableData?.getTable?.role
+  const loadedTableId = getTableData?.getTable?.id
+  const refetchRowsRef = useRef(refetch)
+  refetchRowsRef.current = refetch
 
+  // Column reorder refetches GET_TABLE. Depending on that result would reload
+  // rows and visually duplicate them.
   useEffect(() => {
-    if (isGetTableCalled && getTableData?.getTable) {
-      // load rows after fetching table metadata
-      refetch()
+    if (loadedTableId) {
+      void refetchRowsRef.current()
     }
-  }, [isGetTableCalled, getTableError, getTableData, refetch])
+  }, [loadedTableId, viewToken, urlViewOnlyKey])
 
   // Refetch table data when view token changes (e.g. after password verification)
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Reordering columns in a Tile did not write extra rows to the database, but the grid showed existing rows a second time.

Column reorder calls `updateTable`, which refetches `GET_TABLE`. The tile page treated any new `GET_TABLE` result object as a reason to reload all rows. `useFetchAllRows` appends each page onto the current list. Two overlapping reloads therefore rendered the same rows twice.

The same path could fire for other metadata-only updates (rename, resize, collaborators).

## Fix

- Load rows when the tile id or view auth changes, not on every `GET_TABLE` payload.
- Ignore stale in-flight row pages so a second fetch cannot append onto the first.

Explicit reloads (CSV import, throughput retry) still call `refetch()`.

## How to verify

1. Open a Tile with several rows.
2. Drag a column to a new position.
3. Confirm the row count in the footer is unchanged and no rows are duplicated.
4. Add a row, reorder columns again, and confirm the new row is still there once.

Could not exercise this in the cloud agent environment (frontend deps/Node 22 were not available).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12be0048-21df-43f5-adce-75f7da756846?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12be0048-21df-43f5-adce-75f7da756846&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents metadata-only table updates from visually duplicating Tile rows and discards pages returned by superseded row fetches.
- Reloads rows when the loaded Tile or view credentials change rather than whenever table metadata is refetched.
- Uses fetch generations to prevent stale asynchronous pages from appending to current row state.
- Resets row-fetch state when switching tables.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx | Adds generation-based stale-response suppression and resets row-fetch state when the table changes. |
| packages/frontend/src/pages/Tile/index.tsx | Restricts automatic row reloads to table and view-authorization identity changes. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Tile UI
    participant Meta as GET_TABLE
    participant Rows as Row Fetch Hook
    UI->>Meta: Reorder column / metadata update
    Meta-->>UI: Updated table metadata
    Note over UI,Rows: Same table and credentials: no row reload
    UI->>Rows: Reload after table or credential change
    Rows->>Rows: Increment fetch generation
    Rows-->>UI: Append pages from current generation
    Rows--xUI: Discard stale-generation pages
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tiles): clear isFetching when invali..."](https://github.com/opengovsg/plumber/commit/fc4bab61d2f1a991db875739a3b90d2c59b8f8a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59787973)</sub>

<!-- /greptile_comment -->