### PR TITLE
feat: snapshot create_pipe topology next to traceId

### DIFF
--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -84,6 +84,17 @@ describe('createFlowWithStepsService', () => {
     expect(secondActionStep.appKey).toBe('slack')
     expect(secondActionStep.key).toBe('sendMessageToChannel')
     expect(secondActionStep.position).toBe(3)
+
+    expect(result.config).toEqual({
+      aiBuilderConfig: {
+        traceId: 'trace-id-123',
+        suggested: [
+          { position: 1, appKey: 'formsg', key: 'newSubmission' },
+          { position: 2, appKey: 'postman', key: 'sendTransactionalEmail' },
+          { position: 3, appKey: 'slack', key: 'sendMessageToChannel' },
+        ],
+      },
+    })
   })
 
   it('auto-initialises branchName and depth for toolbox/ifThen steps', async () => {
@@ -200,5 +211,52 @@ describe('createFlowWithStepsService', () => {
     expect(result.steps).toHaveLength(2)
     expect(result.steps[0].key).toBeNull()
     expect(result.steps[1].key).toBeNull()
+    expect(result.config?.aiBuilderConfig?.suggested).toEqual([
+      { position: 1, appKey: 'webhook', key: null },
+      { position: 2, appKey: 'slack', key: null },
+    ])
+  })
+
+  it('snapshots topology without storing step parameters', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-snapshot-params-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: 'Params Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'toolbox',
+          key: 'ifThen',
+          type: 'action',
+          position: 2,
+          parameters: { branchName: 'High Priority', depth: 0 },
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 3,
+        },
+      ],
+      traceId: 'trace-snapshot-params',
+    })
+
+    expect(result.config?.aiBuilderConfig).toEqual({
+      traceId: 'trace-snapshot-params',
+      suggested: [
+        { position: 1, appKey: 'formsg', key: 'newSubmission' },
+        { position: 2, appKey: 'toolbox', key: 'ifThen' },
+        { position: 3, appKey: 'postman', key: 'sendTransactionalEmail' },
+      ],
+    })
   })
 })

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -87,7 +87,16 @@ export async function createFlowWithStepsService({
       userId: user.id,
       name: trimmedName,
       active: false,
-      config: { aiBuilderConfig: { traceId } },
+      config: {
+        aiBuilderConfig: {
+          traceId,
+          suggested: steps.map((step) => ({
+            position: step.position,
+            appKey: step.appKey,
+            key: step.key ?? null,
+          })),
+        },
+      },
     })
 
     let ifThenCount = 0

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -224,6 +224,11 @@ export interface IFlowConfig {
   // AI Builder config
   aiBuilderConfig?: {
     traceId: string // trace id on Rome (Langfuse)
+    suggested?: Array<{
+      position: number
+      appKey: string | null
+      key: string | null
+    }>
   }
   isForceClogged?: boolean
 }


### PR DESCRIPTION
## Stack Context

This stack starts capturing what the AI Builder actually proposed when it calls `create_pipe`, so we can later compare that topology to the published pipe.

This PR is the first slice: persist the snapshot. Scoring in Langfuse / Datadog is not in this change.

## Why?

`create_pipe` immediately writes a real Flow and then mutates it in place (MCP tools, then the editor). Without a snapshot, Postgres only has the latest steps — we cannot tell whether the user rewrote the AI's suggested apps/actions.

## What?

- On the existing `createFlowWithStepsService` INSERT, store `suggested` next to `traceId` on `flow.config.aiBuilderConfig`.
- Snapshot is topology only: `{ position, appKey, key }[]` derived from the tool input. No parameter values, connections, or pipe name.
- Integration tests cover the snapshot, null keys, and that If-Then parameters are not stored on `suggested`.

## Test plan

- [ ] Create a pipe via AI Builder `create_pipe` and confirm `flows.config.aiBuilderConfig` has `traceId` plus `suggested` matching the created steps' position/appKey/key.
- [ ] Confirm step `parameters` are still on the step rows and are **not** copied into `suggested`.
- [ ] Confirm notification/attachment `updateFlowConfig` still preserves `aiBuilderConfig` (spreads existing `config`).
