### PR TITLE
feat(ai-builder): keep loader visible while tools run mid-stream

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -13,6 +13,7 @@ import { MAX_MESSAGES } from '@/pages/AiBuilder/constants'
 import {
   deduplicateMessages,
   extractTextContent,
+  isSilentStreamPhase,
   transformMessages,
 } from '@/pages/AiBuilder/helpers'
 
@@ -444,6 +445,21 @@ export function useChatStream(options: UseChatStreamOptions) {
     return ''
   }, [aiMessages, status])
 
+  // True while the turn is still running but no text is coming through, so the
+  // UI can keep a loading indicator up. Tool calls run server-side inside the
+  // same open stream, so without this any text streamed before the tool just
+  // freezes on screen and the chat looks stalled.
+  const isWorking = useMemo(() => {
+    if (status !== 'streaming' && status !== 'submitted') {
+      return false
+    }
+
+    const lastMessage = aiMessages[aiMessages.length - 1]
+    return isSilentStreamPhase(
+      lastMessage?.role === 'assistant' ? lastMessage : undefined,
+    )
+  }, [aiMessages, status])
+
   const {
     stepParametersByStepId,
     parameterLabelsByStepId,
@@ -540,6 +556,7 @@ export function useChatStream(options: UseChatStreamOptions) {
   return {
     messages,
     currentResponse,
+    isWorking,
     isStreaming: status === 'submitted' || status === 'streaming',
     isReady,
     error: aiError?.message || null,

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -18,6 +18,7 @@ import SideDrawer from './SideDrawer'
 interface ChatInterfaceProps {
   messages: Message[]
   currentResponse: string
+  isWorking: boolean
   isStreaming: boolean
   isReadyForPreview: boolean
   sendMessage: (message: string) => void
@@ -37,6 +38,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   const {
     messages,
     currentResponse,
+    isWorking,
     isStreaming,
     isReadyForPreview,
     sendMessage,
@@ -180,6 +182,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
           <ChatMessages
             messages={messages}
             currentResponse={currentResponse}
+            isWorking={isWorking}
             isStreaming={isStreaming}
           />
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -7,9 +7,21 @@ import Loader from './Loader'
 
 interface StreamingMessageProps {
   currentResponse: string
+  /** Stream is open but no text is arriving, e.g. a tool is running server-side. */
+  showWorkingIndicator: boolean
 }
 
-const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
+const WorkingIndicator = ({ label }: { label: string }) => (
+  <Flex gap={3} w="full" alignItems="center">
+    {label}
+    <Loader />
+  </Flex>
+)
+
+const StreamingMessage = ({
+  currentResponse,
+  showWorkingIndicator,
+}: StreamingMessageProps) => {
   if (currentResponse) {
     return (
       <Flex gap={3} w="full" align="start">
@@ -17,17 +29,17 @@ const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
           <ChakraStreamdown isAnimating={true}>
             {prepareAiText(currentResponse)}
           </ChakraStreamdown>
+          {showWorkingIndicator && (
+            <Box mt={2}>
+              <WorkingIndicator label="Working" />
+            </Box>
+          )}
         </Box>
       </Flex>
     )
   }
 
-  return (
-    <Flex gap={3} w="full" alignItems="center">
-      Thinking
-      <Loader />
-    </Flex>
-  )
+  return <WorkingIndicator label="Thinking" />
 }
 
 export default StreamingMessage

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -11,12 +11,14 @@ import StreamingMessage from './StreamingMessage'
 interface ChatMessagesProps {
   messages: Message[]
   currentResponse: string
+  isWorking: boolean
   isStreaming: boolean
 }
 
 export default function ChatMessages({
   messages,
   currentResponse,
+  isWorking,
   isStreaming,
 }: ChatMessagesProps) {
   const isMobile = useIsMobile()
@@ -49,7 +51,10 @@ export default function ChatMessages({
 
           {/* Streaming response */}
           {isStreaming && (
-            <StreamingMessage currentResponse={currentResponse} />
+            <StreamingMessage
+              currentResponse={currentResponse}
+              showWorkingIndicator={isWorking}
+            />
           )}
         </VStack>
       </Box>

--- a/packages/frontend/src/pages/AiBuilder/helpers.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { CustomUIMessage } from '@/hooks/useChatStream'
 
-import { extractTextContent } from './helpers'
+import { extractTextContent, isSilentStreamPhase } from './helpers'
 
 const buildMessage = (parts: CustomUIMessage['parts']): CustomUIMessage =>
   ({
@@ -39,5 +39,96 @@ describe('extractTextContent', () => {
     ] as unknown as CustomUIMessage['parts'])
 
     expect(extractTextContent(message)).toBe('A\n\nB')
+  })
+})
+
+describe('isSilentStreamPhase', () => {
+  it('is silent before the assistant message exists', () => {
+    expect(isSilentStreamPhase(undefined)).toBe(true)
+  })
+
+  it('is silent when the assistant message has no parts yet', () => {
+    expect(isSilentStreamPhase(buildMessage([]))).toBe(true)
+  })
+
+  it('is not silent while text tokens are arriving', () => {
+    const message = buildMessage([
+      { type: 'text', text: 'Setting up your pipe' },
+    ] as unknown as CustomUIMessage['parts'])
+
+    expect(isSilentStreamPhase(message)).toBe(false)
+  })
+
+  it('is silent on the empty text part that opens a tool step', () => {
+    const message = buildMessage([
+      { type: 'text', text: '' },
+    ] as unknown as CustomUIMessage['parts'])
+
+    expect(isSilentStreamPhase(message)).toBe(true)
+  })
+
+  it('is silent while a tool runs after earlier text', () => {
+    const message = buildMessage([
+      { type: 'text', text: 'One moment' },
+      {
+        type: 'tool-execute_step',
+        toolCallId: 'call-1',
+        state: 'input-available',
+      },
+    ] as unknown as CustomUIMessage['parts'])
+
+    expect(isSilentStreamPhase(message)).toBe(true)
+  })
+
+  it('is silent after a tool returns but before the next tokens', () => {
+    const message = buildMessage([
+      { type: 'text', text: 'One moment' },
+      {
+        type: 'tool-execute_step',
+        toolCallId: 'call-1',
+        state: 'output-available',
+      },
+    ] as unknown as CustomUIMessage['parts'])
+
+    expect(isSilentStreamPhase(message)).toBe(true)
+  })
+
+  it('is silent on step boundaries, dynamic tools and data annotations', () => {
+    const lastParts = [
+      { type: 'step-start' },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-1',
+        toolName: 'gitbook_search',
+        state: 'input-available',
+      },
+      {
+        type: 'data-stepUpdate',
+        data: { stepId: 'step-1', parameters: {} },
+      },
+    ]
+
+    for (const lastPart of lastParts) {
+      const message = buildMessage([
+        { type: 'text', text: 'One moment' },
+        lastPart,
+      ] as unknown as CustomUIMessage['parts'])
+
+      expect(isSilentStreamPhase(message)).toBe(true)
+    }
+  })
+
+  it('is not silent once text resumes after a tool call', () => {
+    const message = buildMessage([
+      { type: 'text', text: 'One moment' },
+      {
+        type: 'tool-execute_step',
+        toolCallId: 'call-1',
+        state: 'output-available',
+      },
+      { type: 'text', text: 'All done' },
+    ] as unknown as CustomUIMessage['parts'])
+
+    expect(isSilentStreamPhase(message)).toBe(false)
   })
 })

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -272,6 +272,21 @@ export const extractTextContent = (msg: CustomUIMessage): string => {
     .join('\n\n')
 }
 
+// Whether the assistant is mid-turn without producing visible text right now:
+// the stream is still open but the newest part is a tool call, a step boundary,
+// a data annotation, or the empty text part the AI SDK opens each generation
+// step with. Callers use this to keep a loading indicator on screen during
+// silent stretches — otherwise already-streamed markdown just freezes while a
+// tool runs server-side.
+export const isSilentStreamPhase = (msg: CustomUIMessage | undefined) => {
+  const parts = msg?.parts
+  if (!parts?.length) {
+    return true
+  }
+  const lastPart = parts[parts.length - 1]
+  return lastPart.type !== 'text' || lastPart.text.trim().length === 0
+}
+
 export const transformMessages = (messages: CustomUIMessage[]): Message[] => {
   let lastReadyIndex = -1
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -50,6 +50,7 @@ function AiBuilderContent() {
   const {
     messages,
     currentResponse,
+    isWorking,
     isStreaming,
     isReady: isReadyForPreview,
     sendMessage,
@@ -353,6 +354,7 @@ function AiBuilderContent() {
             <ChatInterface
               messages={messages}
               currentResponse={currentResponse}
+              isWorking={isWorking}
               isStreaming={isStreaming}
               isReadyForPreview={isReadyForPreview}
               sendMessage={sendMessage}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The AI Builder chat only shows a loading state when the stream is open **and** no assistant text exists yet. Since tool calls were introduced, that leaves a silent gap: once the model emits text and then calls a tool, the streamed markdown freezes with no indicator, even though the SSE connection is still open and the model is working server-side.

## Change

Frontend only. No new backend stream event — the AI SDK already delivers `tool-*`, `dynamic-tool`, `step-start` and `data-*` parts on the in-flight assistant message.

- `isSilentStreamPhase()` in `pages/AiBuilder/helpers.ts` reports whether the newest part on the streaming assistant message is anything other than non-empty text.
- `useChatStream` derives `isWorking` from that plus the stream status, and returns it alongside `currentResponse` / `isStreaming`.
- `StreamingMessage` keeps the existing dot `Loader` on screen during silent stretches: "Thinking" before any text arrives (unchanged), "Working" underneath already-streamed markdown while a tool runs.

Raw tool names (`execute_step`, `list_apps`) are deliberately not surfaced.

## Verification

`npm run -w frontend lint` (ESLint + `tsc --noEmit`) clean. `npx vitest run` in `packages/frontend`: 202 tests pass, including 10 new cases for `isSilentStreamPhase` (no message, empty parts, empty tool-preamble text, tool `input-available` / `output-available`, `step-start`, `dynamic-tool`, `data-stepUpdate`, and text resuming after a tool).

The rendered states were exercised in a real browser through a throwaway preview harness that mounts `ChatMessages` with each stream phase. The harness was deleted afterwards and is not part of this branch. No console errors in any state.

Recording of the phase transitions, showing the dots animating and the indicator appearing below the frozen text rather than replacing it:

[ai-builder-in-stream-loading-states.mp4](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai-builder-in-stream-loading-states.mp4)

Each screenshot below includes the props that produced the state.

**1. Submitted, no text yet** — unchanged "Thinking" plus loader.

[Thinking state with no text yet](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-thinking-no-text-yet.png)

**2. Text streaming** — no indicator, the animated markdown carries the feedback.

[Text streaming with no indicator](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F02-text-streaming.png)

**3. Tool running after text** — the case this PR fixes. The streamed text stays put and "Working" plus the loader appear below it.

[Working indicator below streamed text while a tool runs](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F03-tool-running-after-text.png)

**4. Text resumed after the tool** — indicator gone once tokens flow again.

[Text resumed after tool with no indicator](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F04-text-resumed-after-tool.png)

**5. Stream finished** — nothing left behind.

[Stream finished, empty streaming slot](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F05-stream-finished.png)

**6. Tool running, 390x844 mobile viewport** — layout holds, nothing clipped.

[Working indicator on a 390px mobile viewport](https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F06-tool-running-mobile-390px.png)

The full AI Builder page could not be loaded end to end here: the backend cannot be installed in this environment because `@taskforcesh/bullmq-pro` needs a private-registry token (`NPM_TASKFORCESH_TOKEN`), so a live `/api/chat` stream with real tool calls was not exercised.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f45705aa-7daa-4471-92bd-f5b81ff75f9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

