### PR TITLE
feat(ai-builder): extend list_columns to LetterSG and Databricks

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -78,7 +78,7 @@ export function createMcpBridgeTools(
 
     list_columns: tool<{ step_id: string }, ListColumnsResult>({
       description:
-        'List the columns of a step\'s multirow-multicol field (e.g. Tiles "Create row" rowData, M365 Excel "Create table row" columnValues) that are not yet configured. Returns at most 50 not-yet-configured columns; if truncated is true, tell the user this table has more columns than can be proposed at once and that they can add the rest manually in the pipe editor after the step is created. Use the returned column id and name exactly as given — never guess or recall column names from memory, and never call this for a field that isn\'t multirow-multicol.',
+        'List the columns/fields of a step\'s multirow-multicol field (Tiles "Create row" rowData, M365 Excel "Create table row" columnValues, LetterSG "Create letter" letterParams, Databricks "Create row" rowData) that are not yet configured. Returns at most 50 not-yet-configured columns; if truncated is true, tell the user this table has more columns than can be proposed at once and that they can add the rest manually in the pipe editor after the step is created. If valueRequired is true, every returned column must end up with a real value in the eventual update_step_parameters call — never leave one unset or let the user skip it. Use the returned column id and name exactly as given — never guess or recall column names from memory, and never call this for a field that isn\'t multirow-multicol on one of the four supported steps.',
       inputSchema: z.object({
         step_id: z
           .uuid()

--- a/packages/backend/src/services/mcp/__tests__/list-columns.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-columns.itest.ts
@@ -1,9 +1,10 @@
 // packages/backend/src/services/mcp/__tests__/list-columns.itest.ts
-import type { IJSONObject } from '@plumber/types'
+import type { IApp, IJSONObject } from '@plumber/types'
 
 import { randomUUID } from 'crypto'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import TableColumnMetadata from '@/models/table-column-metadata'
@@ -12,6 +13,40 @@ import { createTable } from '@/models/tiles/pg/table-functions'
 import User from '@/models/user'
 
 import { listColumnsService } from '../list-columns'
+
+// LetterSG's getTemplateFields and Databricks' databricks-list-table-columns
+// both call live external APIs — stub just their `run` functions so the test
+// still exercises the real, unmodified action/field schemas (subFields,
+// required flags, dependency params) for createLetter/createDatabricksTableRow.
+const mocks = vi.hoisted(() => ({
+  getTemplateFieldsRun: vi.fn(),
+  listTableColumnsRun: vi.fn(),
+}))
+
+vi.mock('@/apps', async (importOriginal) => {
+  const real = await importOriginal<{ default: Record<string, IApp> }>()
+  const replaceRun = (app: IApp, key: string, run: typeof vi.fn) => ({
+    ...app,
+    dynamicData: app.dynamicData?.map((d) =>
+      d.key === key ? { ...d, run } : d,
+    ),
+  })
+  return {
+    default: {
+      ...real.default,
+      lettersg: replaceRun(
+        real.default.lettersg,
+        'getTemplateFields',
+        mocks.getTemplateFieldsRun,
+      ),
+      databricks: replaceRun(
+        real.default.databricks,
+        'databricks-list-table-columns',
+        mocks.listTableColumnsRun,
+      ),
+    },
+  }
+})
 
 // Exercises the real Tiles app: `createTileRow`'s `rowData` multirow-multicol
 // field has `columnId` (dropdown, sourced from the `listColumns` dynamic-data
@@ -48,6 +83,7 @@ async function setupFlowAndStep(
   appKey: string,
   key: string,
   parameters: IJSONObject = {},
+  connectionId?: string,
 ) {
   const flow = await Flow.query().insertAndFetch({
     id: randomUUID(),
@@ -70,6 +106,7 @@ async function setupFlowAndStep(
     flowId: flow.id,
     appKey,
     key,
+    connectionId,
     type: 'action',
     position: 2,
     parameters,
@@ -82,6 +119,7 @@ describe('listColumnsService', () => {
   let user: User
 
   beforeEach(async () => {
+    vi.clearAllMocks()
     user = await User.query().insertAndFetch({
       id: randomUUID(),
       email: `list-columns-${randomUUID()}@example.com`,
@@ -105,7 +143,76 @@ describe('listColumnsService', () => {
       columns: columns.map((c) => ({ id: c.id, name: c.name })),
       alreadyConfigured: [],
       truncated: false,
+      valueRequired: false,
     })
+  })
+
+  it("supports LetterSG's createLetter action, and flags its value as required", async () => {
+    mocks.getTemplateFieldsRun.mockResolvedValue({
+      data: [
+        { name: 'Recipient Name', value: 'Recipient Name' },
+        { name: 'Amount', value: 'Amount' },
+      ],
+    })
+    const connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'lettersg',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      formattedData: {},
+    })
+    const { step } = await setupFlowAndStep(
+      user.id,
+      'lettersg',
+      'createLetter',
+      { templateId: 'template-1', letterParams: [] },
+      connection.id,
+    )
+
+    const result = await listColumnsService({ user, stepId: step.id })
+
+    expect(result).toEqual({
+      columns: [
+        { id: 'Recipient Name', name: 'Recipient Name' },
+        { id: 'Amount', name: 'Amount' },
+      ],
+      alreadyConfigured: [],
+      truncated: false,
+      valueRequired: true,
+    })
+    expect(mocks.getTemplateFieldsRun).toHaveBeenCalledOnce()
+  })
+
+  it("supports Databricks' createDatabricksTableRow action, and its value is not required", async () => {
+    mocks.listTableColumnsRun.mockResolvedValue({
+      data: [{ name: 'col1', value: 'col1' }],
+    })
+    const connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'databricks',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      formattedData: {},
+    })
+    const { step } = await setupFlowAndStep(
+      user.id,
+      'databricks',
+      'createDatabricksTableRow',
+      { tableName: 'my_table', rowData: [] },
+      connection.id,
+    )
+
+    const result = await listColumnsService({ user, stepId: step.id })
+
+    expect(result).toEqual({
+      columns: [{ id: 'col1', name: 'col1' }],
+      alreadyConfigured: [],
+      truncated: false,
+      valueRequired: false,
+    })
+    expect(mocks.listTableColumnsRun).toHaveBeenCalledOnce()
   })
 
   it('excludes columns already present in the saved rowData array', async () => {

--- a/packages/backend/src/services/mcp/list-columns.ts
+++ b/packages/backend/src/services/mcp/list-columns.ts
@@ -20,6 +20,7 @@ export interface ListColumnsResult {
   columns: Array<{ id: string; name: string }>
   alreadyConfigured: string[]
   truncated: boolean
+  valueRequired: boolean
 }
 
 const MAX_COLUMNS = 50
@@ -27,6 +28,8 @@ const MAX_COLUMNS = 50
 const SUPPORTED_STEPS: ReadonlyArray<{ appKey: string; key: string }> = [
   { appKey: 'tiles', key: 'createTileRow' },
   { appKey: 'm365-excel', key: 'createTableRow' },
+  { appKey: 'lettersg', key: 'createLetter' },
+  { appKey: 'databricks', key: 'createDatabricksTableRow' },
 ]
 
 function findMultiRowMultiColField(
@@ -55,7 +58,7 @@ export async function listColumnsService({
   )
   if (!isSupportedStep) {
     throw new UserFacingError(
-      'list_columns only supports Tiles "Create row" and M365 Excel "Create table row" steps',
+      'list_columns only supports Tiles "Create row", M365 Excel "Create table row", LetterSG "Create letter", and Databricks "Create row" steps',
     )
   }
 
@@ -70,6 +73,16 @@ export async function listColumnsService({
   if (!field) {
     throw new UserFacingError(
       'Step has no multirow-multicol field to list columns for',
+    )
+  }
+
+  // Guards against a future edit to one of the SUPPORTED_STEPS actions
+  // changing its shape (e.g. a third subField, like GatherSG's caseFields)
+  // without this service being updated to match — fail loudly rather than
+  // silently dropping a subField's value.
+  if (field.subFields.length !== 2) {
+    throw new UserFacingError(
+      'Step has an unsupported multirow-multicol shape (expected exactly a column selector and a value field)',
     )
   }
 
@@ -111,5 +124,9 @@ export async function listColumnsService({
       .map((column) => ({ id: column.value, name: column.name })),
     alreadyConfigured,
     truncated: notYetConfigured.length > MAX_COLUMNS,
+    // Derived from the schema, not hardcoded per app. LetterSG and M365 Excel
+    // both declare their value subField required, so the caller must fill
+    // every column it proposes. Tiles and Databricks leave it optional.
+    valueRequired: field.subFields[1].required === true,
   }
 }


### PR DESCRIPTION
## TL;DR

Extends `list_columns` (the batch column-proposal tool from the AI Builder column-setup feature) to LetterSG's "Create letter" and Databricks' "Create row" — both already use the same 2-subfield multirow-multicol shape as Tiles/Excel, so this is mostly an allowlist extension plus one new schema-derived signal for always-required fields.

## What changed?

- `SUPPORTED_STEPS` in `list-columns.ts` now includes `lettersg/createLetter` and `databricks/createDatabricksTableRow` alongside Tiles and M365 Excel.
- New `valueRequired: boolean` on `ListColumnsResult`, derived from the value subfield's own `required` declaration in the action schema — not hardcoded per app. This is `true` for LetterSG (its `letterParams` subfields are both `required: true`) and `false` for the other three, so callers know when a column can't be left unset.
- New defensive guard: rejects any multirow-multicol field that doesn't have exactly 2 subfields, so a future shape change (e.g. a third subfield, like GatherSG's `caseFields`) fails loudly instead of silently dropping a value if it's ever added to the allowlist without updating this service.
- Updated the `list_columns` tool description in `mcp-bridge-tools.ts` to name all four supported steps and explain `valueRequired`.
- Test coverage: two new integration tests exercising the *real* LetterSG and Databricks action schemas (only their external-API-calling dynamic-data `run` functions are stubbed, not the schemas), including the connection fixtures both apps require (unlike Tiles, which has no `auth`).

## Tests

- [ ] `npm run -w backend test:unit` passes locally
- [ ] `list-columns.itest.ts` (9 cases, including the new LetterSG/Databricks ones) passes locally
- [ ] Manual: in AI Builder chat, configure a LetterSG "Create letter" step and confirm `list_columns`/the column table surfaces the template's fields, with every field forced checked (since `valueRequired: true`)
- [ ] Manual: same for a Databricks "Create row" step, confirming columns are optional (unchecked rows allowed) as before

## Deploy notes

No migrations, env vars, or infra changes. Backend-only; no frontend changes needed since this only extends which steps `list_columns` accepts and adds one new field to its response shape.