### PR TITLE
fix(ai-builder): drop unused list_connections MCP tool

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,9 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
-vi.mock('@/services/mcp/list-connections', () => ({
-  listConnectionsService: vi.fn().mockResolvedValue([]),
-}))
 vi.mock('@/services/mcp/list-columns', () => ({
   listColumnsService: vi.fn().mockResolvedValue({
     columns: [],
@@ -65,7 +62,6 @@ describe('createMcpBridgeTools', () => {
     const tools = createMcpBridgeTools(mockUser, mockTraceId)
     expect(Object.keys(tools)).toEqual([
       'list_apps',
-      'list_connections',
       'list_columns',
       'create_pipe',
       'update_step_parameters',

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -26,10 +26,6 @@ import {
   listColumnsService,
 } from '@/services/mcp/list-columns'
 import {
-  listConnectionsService,
-  type McpConnection,
-} from '@/services/mcp/list-connections'
-import {
   type RegisterConnectionResult,
   registerConnectionService,
 } from '@/services/mcp/register-connection'
@@ -57,22 +53,6 @@ export function createMcpBridgeTools(
       inputSchema: z.object({}),
       execute: async (): Promise<IMcpApp[]> => {
         return listAppsService(user)
-      },
-    }),
-
-    list_connections: tool<{ app_key?: string }, McpConnection[]>({
-      description:
-        "List connections the user has set up, optionally filtered to a specific app. Returns each connection's ID, app key, verified status, and label. Use the returned id as connection_id when calling update_step_parameters.",
-      inputSchema: z.object({
-        app_key: z
-          .string()
-          .optional()
-          .describe(
-            'App key to filter by (e.g. "slack"). Omit to list all connections.',
-          ),
-      }),
-      execute: async ({ app_key }): Promise<McpConnection[]> => {
-        return listConnectionsService(user, app_key)
       },
     }),
 
@@ -145,7 +125,7 @@ export function createMcpBridgeTools(
 
     update_step_parameters: tool({
       description:
-        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Optionally assign a connection by passing connection_id (obtain from list_connections; must match the step's app). Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.\n\nWhen connection_id is provided for a step whose app uses per-step or global connection registration, registration runs automatically. Inspect the result before proceeding:\n- connectionRegistered: true — registration succeeded; step is fully connected.\n- connectionConflict: true + connectionConflictMessage — webhook already claimed; relay connectionConflictMessage to the user verbatim and call register_connection with the same step_id and connection_id only after explicit confirmation.\n- connectionError — permission or technical error; surface to user. Do not retry.\n- formFields (FormSG only, present on conflict or error) — trimmed field list for wiring downstream steps even when trigger is unconnected.",
+        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Optionally assign a connection by passing connection_id from the user's picker reply (A: Name (id: …)) or an established conversation connection id; the connection's app must match the step's app. Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.\n\nWhen connection_id is provided for a step whose app uses per-step or global connection registration, registration runs automatically. Inspect the result before proceeding:\n- connectionRegistered: true — registration succeeded; step is fully connected.\n- connectionConflict: true + connectionConflictMessage — webhook already claimed; relay connectionConflictMessage to the user verbatim and call register_connection with the same step_id and connection_id only after explicit confirmation.\n- connectionError — permission or technical error; surface to user. Do not retry.\n- formFields (FormSG only, present on conflict or error) — trimmed field list for wiring downstream steps even when trigger is unconnected.",
       inputSchema: z.object({
         pipe_id: z.uuid().describe('ID of the pipe that contains the step'),
         step_id: z.uuid().describe('ID of the step to update'),
@@ -158,7 +138,7 @@ export function createMcpBridgeTools(
           .uuid()
           .optional()
           .describe(
-            "Connection ID to assign to this step. Obtain from list_connections. The connection's app must match the step's app.",
+            "Connection ID to assign to this step. From the user's connection picker reply (A: Name (id: …)) or an established conversation connection id. The connection's app must match the step's app.",
           ),
         parameter_labels: z
           .record(z.string(), z.string())

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -163,7 +163,6 @@ const messagePartSchema = z.discriminatedUnion('type', [
   }),
   // One entry per MCP bridge tool — keeps discriminatedUnion error quality intact.
   toolPart('tool-list_apps'),
-  toolPart('tool-list_connections'),
   toolPart('tool-list_columns'),
   toolPart('tool-create_pipe'),
   toolPart('tool-update_step_parameters'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`list_connections` should not be a model-facing AI builder tool. The v174 prompt already forbids calling it: connection IDs come from `DYNAMIC_PICKER_DATA` picker replies (`A: Name (id: …)`) or an established FormSG / conversation id. The frontend already loads connections via `GET /api/connections` (`listConnectionsService`).

Error recovery for `update_step_parameters` / `execute_step` also does not need this tool:

- `connectionConflict` → same `connection_id` + `register_connection`
- `connectionError` → surface, do not retry
- invalid / missing connection → re-emit the picker
- field errors → re-check `list_apps` and retry `update_step_parameters`

Leaving the tool registered (and describing `connection_id` as “obtain from list_connections”) fought the prompt and invited skipping the picker.

### Code

- Removed `list_connections` from `createMcpBridgeTools`
- Removed `tool-list_connections` from the chat message schema (these tools have not landed in production)
- Pointed `update_step_parameters` `connection_id` docs at the picker / established conversation id
- Left `listConnectionsService`, `GET /api/connections`, and `resolveEstablishedFormConnection` in place

### Prompt (Langfuse, not in this PR)

Paste-ready **v175** is in the agent workspace as untracked `v175.md` (do not commit). Diff vs v174:

- Title `v174` → `v175`
- Connect-first: drop “Do not call `list_connections`”
- `requiresConnection: false`: drop “never call `list_connections`”
- Picker path: drop “do **not** call `list_connections`”
- Phase 2b checklist: drop “and never `list_connections`”
- Tool Reference: delete the `list_connections` row

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c33e46ce-2cbf-4621-8661-471ed2234803?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c33e46ce-2cbf-4621-8661-471ed2234803&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

