### PR TITLE
fix(ai-builder) add minor ui changes

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -376,8 +376,26 @@ export default function PromptInput({
               e.currentTarget.style.fontSize = '16px'
             }}
           />
+        </Flex>
 
-          <Flex justify="end" align="flex-end" p={3}>
+        <Flex px={2} pb={1} pt={1} align="center" gap={2}>
+          {showChipsRow &&
+            (attachedForm?.isConnected ? (
+              <FormChip form={attachedForm} />
+            ) : onConnectForm && onSelectExistingForm ? (
+              <ConnectFormPopover
+                isStreaming={isStreaming}
+                onSelectExisting={onSelectExistingForm}
+                onAddNewForm={onConnectForm}
+              />
+            ) : attachedForm ? (
+              // Dead-end fallback: a URL is known but not connected, and
+              // there's no trigger left to retry through (e.g. post-pipe,
+              // before the LLM's connection picker has fired).
+              <FormChip form={attachedForm} />
+            ) : null)}
+
+          <Flex ml="auto" pr={1} align="center" flexShrink={0}>
             {isStreaming ? (
               <Icon
                 as={FaCircleStop}
@@ -402,25 +420,6 @@ export default function PromptInput({
             )}
           </Flex>
         </Flex>
-
-        {showChipsRow && (
-          <Flex px={2} pb={1} pt={1} align="center" gap={2}>
-            {attachedForm?.isConnected ? (
-              <FormChip form={attachedForm} />
-            ) : onConnectForm && onSelectExistingForm ? (
-              <ConnectFormPopover
-                isStreaming={isStreaming}
-                onSelectExisting={onSelectExistingForm}
-                onAddNewForm={onConnectForm}
-              />
-            ) : attachedForm ? (
-              // Dead-end fallback: a URL is known but not connected, and
-              // there's no trigger left to retry through (e.g. post-pipe,
-              // before the LLM's connection picker has fired).
-              <FormChip form={attachedForm} />
-            ) : null}
-          </Flex>
-        )}
       </Flex>
 
       {showIdeas && (

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -194,7 +194,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             <Box
               maxW="3xl"
               mx="auto"
-              px={4}
+              px={8}
               py={4}
               gap={4}
               display="flex"

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -29,7 +29,7 @@ export default function ChatMessages({
         minHeight: 0,
       }}
     >
-      <Box w="full" maxW="3xl" mx="auto" px={4} py={6}>
+      <Box w="full" maxW="3xl" mx="auto" px={8} py={6}>
         <VStack align="stretch" spacing={4}>
           {messages.map((message, index) => {
             const shouldShowPreview = isMobile && message.isChatReady

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/RichTextPreview.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/RichTextPreview.tsx
@@ -46,8 +46,10 @@ export default function RichTextPreview({
   return (
     <Box
       w="full"
-      maxH="300px"
-      overflowY="auto"
+      // No height cap: the body renders in full and the preview panel scrolls.
+      // A capped box clipped long bodies with no cue that they scrolled.
+      // overflowX still scrolls, so a wide line can't spill out of the step card.
+      overflowX="auto"
       // Strip the editable-textarea chrome (border, focus ring, min-height)
       // and match the plain-text rows' font so this reads as display text.
       sx={{
@@ -60,8 +62,8 @@ export default function RichTextPreview({
           border: 'none',
           boxShadow: 'none',
         },
-        // isDisplayOnly forces a fixed 60vh height + its own scrollbar
-        // inline — override both so only our maxH Box scrolls.
+        // isDisplayOnly forces a fixed 60vh height + its own scrollbar inline.
+        // Override both so the body grows to its full height instead.
         '.editor__content': {
           height: 'auto !important',
           overflow: 'visible !important',


### PR DESCRIPTION
## Problem

Four UI nits from the AI builder bug bash:

1. The composer's send/stop button sat at the top right of the textarea row. The "Connect your form" chip rendered below it, so the button floated mid-card instead of anchoring the bottom right corner.
2. The chat column had 16px left and right padding, which read as too tight.
3. The clarification picker sat in the same tight gutters.
4. The email body preview in the step preview clipped at a 300px height with no visual cue. A long body looked cut off rather than scrollable.

## Solution

**Improvements**:

- `PromptInput`: moved the send/stop icon out of the textarea row and into the bottom row, pushed right with `ml="auto"`. The bottom row now always renders, so the icon holds the bottom right corner whether or not a form chip is present. The chip stays bottom left.
- `ChatMessages` and `ChatInterface`: raised the chat column horizontal padding from 16px to 32px (`px={4}` to `px={8}`). This covers the message list and the composer area, so the clarification picker gets the wider gutters too.
- `RichTextPreview`: removed the 300px height cap from the email body preview. The body now renders in full and the step preview panel scrolls, so nothing is clipped. `overflowX="auto"` stays, so an unusually wide line scrolls in place instead of spilling out of the step card.

## Tests

Frontend only, no automated test changes. `npm run -w frontend lint` (eslint + `tsc --noEmit`) passes.

Manual QA in the AI builder:

- Landing composer with idea buttons: arrow sits bottom right, level with the form chip.
- Mid conversation while streaming: stop button sits bottom right, and cancelling still works.
- Message list and clarification picker: 32px gutters on both sides.
- Step preview for a Send email step with a long body: the whole body renders with no inner scrollbar, and the preview panel scrolls to reach the end.

## Deploy Notes

None. No new environment variables, scripts, or dependencies.
