### PR TITLE
Restore credential editing from Connections page

### DIFF
--- a/packages/backend/src/apps/custom-api/auth/index.ts
+++ b/packages/backend/src/apps/custom-api/auth/index.ts
@@ -4,6 +4,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/gathersg/auth/index.ts
+++ b/packages/backend/src/apps/gathersg/auth/index.ts
@@ -6,6 +6,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/lettersg/__tests__/auth/verify-credentials.test.ts
+++ b/packages/backend/src/apps/lettersg/__tests__/auth/verify-credentials.test.ts
@@ -1,0 +1,67 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import verifyCredentials from '../../auth/verify-credentials'
+import { LetterSgEnvironment } from '../../common/api'
+
+const mocks = vi.hoisted(() => ({
+  authSet: vi.fn(),
+  httpGet: vi.fn(),
+}))
+
+describe('LetterSG verifyCredentials', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.httpGet.mockResolvedValue({ data: {} })
+
+    $ = {
+      auth: {
+        data: {
+          screenName: 'My Letter',
+          apiKey: 'test_v1_123',
+        },
+        set: mocks.authSet,
+      },
+      http: {
+        get: mocks.httpGet,
+      },
+    } as unknown as IGlobalVariable
+  })
+
+  it('appends a staging suffix for staging API keys', async () => {
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter [STAGING]',
+      env: LetterSgEnvironment.Staging,
+    })
+  })
+
+  it('does not append a second staging suffix', async () => {
+    $.auth.data.screenName = 'My Letter [STAGING]'
+
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter [STAGING]',
+      env: LetterSgEnvironment.Staging,
+    })
+  })
+
+  it('does not keep a leftover staging suffix for prod API keys', async () => {
+    $.auth.data = {
+      screenName: 'My Letter [STAGING]',
+      apiKey: 'live_v1_321',
+    }
+
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter',
+      env: LetterSgEnvironment.Prod,
+    })
+  })
+})

--- a/packages/backend/src/apps/lettersg/auth/index.ts
+++ b/packages/backend/src/apps/lettersg/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/lettersg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/lettersg/auth/verify-credentials.ts
@@ -3,7 +3,11 @@ import type { IGlobalVariable } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
-import { getEnvironmentFromApiKey, LetterSgEnvironment } from '../common/api'
+import {
+  getEnvironmentFromApiKey,
+  LETTERSG_STAGING_LABEL_SUFFIX,
+  LetterSgEnvironment,
+} from '../common/api'
 
 import { AuthData, validateAuthData } from './auth-data'
 import { verifyApiKey } from './verify-api-key'
@@ -14,15 +18,20 @@ export default async function verifyCredentials(
   try {
     const authData: AuthData = validateAuthData($)
     const env = getEnvironmentFromApiKey(authData.apiKey)
+    const isStaging = env === LetterSgEnvironment.Staging
+    const baseScreenName = authData.screenName.endsWith(
+      LETTERSG_STAGING_LABEL_SUFFIX,
+    )
+      ? authData.screenName.slice(0, -LETTERSG_STAGING_LABEL_SUFFIX.length)
+      : authData.screenName
 
-    // after validation, can only be a prod or staging API key
-    const labelSuffix: string =
-      env === LetterSgEnvironment.Staging ? ' [STAGING]' : ''
     await verifyApiKey($)
 
     // update label
     await $.auth.set({
-      screenName: `${authData.screenName}${labelSuffix}`,
+      screenName: isStaging
+        ? `${baseScreenName}${LETTERSG_STAGING_LABEL_SUFFIX}`
+        : baseScreenName,
       env,
     })
   } catch (error) {

--- a/packages/backend/src/apps/lettersg/common/api.ts
+++ b/packages/backend/src/apps/lettersg/common/api.ts
@@ -1,7 +1,4 @@
-export enum LetterSgEnvironment {
-  Staging = 'test',
-  Prod = 'live',
-}
+export const LETTERSG_STAGING_LABEL_SUFFIX = ' [STAGING]'
 
 const STAGING_ENV_API_KEY_PREFIX = 'test_'
 const STAGING_ENV_BASE_URL = 'https://staging.letters.gov.sg/api'

--- a/packages/backend/src/apps/postman-sms/auth/index.ts
+++ b/packages/backend/src/apps/postman-sms/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/telegram-bot/auth/index.ts
+++ b/packages/backend/src/apps/telegram-bot/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -60,21 +60,47 @@ describe('updateConnection', () => {
   })
 
   describe('without a flow', () => {
-    it('should allow a user to update their own personal connection', async () => {
+    // telegram-bot opts into credential editing; slack does not.
+    let editableConnection: Connection
+
+    beforeEach(async () => {
+      editableConnection = await Connection.query().insertAndFetch({
+        userId: owner.id,
+        key: 'telegram-bot',
+        formattedData: { screenName: 'Owner Telegram' },
+        verified: false,
+      })
+    })
+
+    it('should allow a user to update their own editable connection', async () => {
       const result = await updateConnection(
         null,
         {
           input: {
-            id: ownerConnection.id,
-            formattedData: { screenName: 'Updated from connections page' },
+            id: editableConnection.id,
+            formattedData: { token: 'new-token' },
           },
         },
         context,
       )
 
-      expect(result.formattedData.screenName).toBe(
-        'Updated from connections page',
-      )
+      expect(result.formattedData.token).toBe('new-token')
+      expect(result.formattedData.screenName).toBe('Owner Telegram')
+    })
+
+    it('should not allow updating a connection whose app does not support editing', async () => {
+      await expect(
+        updateConnection(
+          null,
+          {
+            input: {
+              id: ownerConnection.id,
+              formattedData: { token: 'new-token' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('This connection cannot be edited')
     })
 
     it('should not allow a user to update another user personal connection', async () => {
@@ -85,8 +111,8 @@ describe('updateConnection', () => {
           null,
           {
             input: {
-              id: ownerConnection.id,
-              formattedData: { screenName: 'Unauthorized update' },
+              id: editableConnection.id,
+              formattedData: { token: 'new-token' },
             },
           },
           context,

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -59,6 +59,42 @@ describe('updateConnection', () => {
     })
   })
 
+  describe('without a flow', () => {
+    it('should allow a user to update their own personal connection', async () => {
+      const result = await updateConnection(
+        null,
+        {
+          input: {
+            id: ownerConnection.id,
+            formattedData: { screenName: 'Updated from connections page' },
+          },
+        },
+        context,
+      )
+
+      expect(result.formattedData.screenName).toBe(
+        'Updated from connections page',
+      )
+    })
+
+    it('should not allow a user to update another user personal connection', async () => {
+      context.currentUser = editor
+
+      await expect(
+        updateConnection(
+          null,
+          {
+            input: {
+              id: ownerConnection.id,
+              formattedData: { screenName: 'Unauthorized update' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('Connection not found')
+    })
+  })
+
   describe('ownership guard', () => {
     it('should not allow editor to update owner personal connection shared to flow', async () => {
       // Setup: Owner's personal connection (userId = owner.id)

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -78,14 +78,13 @@ describe('updateConnection', () => {
         {
           input: {
             id: editableConnection.id,
-            formattedData: { token: 'new-token' },
+            formattedData: { screenName: 'Updated Telegram' },
           },
         },
         context,
       )
 
-      expect(result.formattedData.token).toBe('new-token')
-      expect(result.formattedData.screenName).toBe('Owner Telegram')
+      expect(result.formattedData.screenName).toBe('Updated Telegram')
     })
 
     it('should not allow updating a connection whose app does not support editing', async () => {
@@ -95,7 +94,7 @@ describe('updateConnection', () => {
           {
             input: {
               id: ownerConnection.id,
-              formattedData: { token: 'new-token' },
+              formattedData: { screenName: 'Unauthorized update' },
             },
           },
           context,
@@ -112,7 +111,7 @@ describe('updateConnection', () => {
           {
             input: {
               id: editableConnection.id,
-              formattedData: { token: 'new-token' },
+              formattedData: { screenName: 'Unauthorized update' },
             },
           },
           context,

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -85,6 +85,32 @@ describe('verifyConnection', () => {
     })
   })
 
+  describe('without a flow', () => {
+    it('should allow a user to verify their own personal connection', async () => {
+      const result = await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id } },
+        context,
+      )
+
+      expect(result.id).toBe(ownerConnection.id)
+      expect(mocks.verifyCredentials).toHaveBeenCalledOnce()
+    })
+
+    it('should not allow a user to verify another user personal connection', async () => {
+      context.currentUser = editor
+
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id } },
+          context,
+        ),
+      ).rejects.toThrow('Connection not found')
+      expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+    })
+  })
+
   describe('access control', () => {
     it('should allow owner to verify their personal connection', async () => {
       const result = await verifyConnection(

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import verifyConnection from '@/graphql/mutations/verify-connection'
+import App from '@/models/app'
 import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 import FlowConnections from '@/models/flow-connections'
@@ -28,6 +29,8 @@ vi.mock('@/models/app', () => ({
     findOneByKey: vi.fn().mockResolvedValue({
       key: 'slack',
       auth: {
+        connectionType: 'user-added',
+        supportsConnectionEdit: true,
         verifyCredentials: mocks.verifyCredentials,
       },
     }),
@@ -101,12 +104,23 @@ describe('verifyConnection', () => {
       context.currentUser = editor
 
       await expect(
-        verifyConnection(
-          null,
-          { input: { id: ownerConnection.id } },
-          context,
-        ),
+        verifyConnection(null, { input: { id: ownerConnection.id } }, context),
       ).rejects.toThrow('Connection not found')
+      expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+    })
+
+    it('should not allow verifying a connection whose app does not support editing', async () => {
+      vi.mocked(App.findOneByKey).mockResolvedValueOnce({
+        key: 'slack',
+        auth: {
+          connectionType: 'user-added',
+          verifyCredentials: mocks.verifyCredentials,
+        },
+      } as unknown as Awaited<ReturnType<typeof App.findOneByKey>>)
+
+      await expect(
+        verifyConnection(null, { input: { id: ownerConnection.id } }, context),
+      ).rejects.toThrow('This connection cannot be edited')
       expect(mocks.verifyCredentials).not.toHaveBeenCalled()
     })
   })

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -1,5 +1,5 @@
 import { ForbiddenError } from '@/errors/graphql-errors'
-import { getConnection } from '@/services/connection'
+import { getConnection, getOwnEditableConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -26,10 +26,10 @@ const updateConnection: MutationResolvers['updateConnection'] = async (
       includeOwnConnections: flow.role === 'owner',
     })
   } else {
-    connection = await context.currentUser
-      .$relatedQuery('connections')
-      .findById(params.input.id)
-      .throwIfNotFound({ message: 'Connection not found' })
+    connection = await getOwnEditableConnection({
+      context,
+      connectionId: params.input.id,
+    })
   }
 
   // GUARD: Prevent updating personal connections owned by others

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -11,17 +11,26 @@ const updateConnection: MutationResolvers['updateConnection'] = async (
   params,
   context,
 ) => {
-  const flow = await context.currentUser
-    .withAccessibleFlows({ requiredRole: 'editor' })
-    .findById(params.input.flowId)
-    .throwIfNotFound({ message: 'You do not have access to this flow' })
+  let connection
 
-  let connection = await getConnection({
-    context,
-    connectionId: params.input.id,
-    flowId: params.input.flowId,
-    includeOwnConnections: flow.role === 'owner',
-  })
+  if (params.input.flowId) {
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findById(params.input.flowId)
+      .throwIfNotFound({ message: 'You do not have access to this flow' })
+
+    connection = await getConnection({
+      context,
+      connectionId: params.input.id,
+      flowId: params.input.flowId,
+      includeOwnConnections: flow.role === 'owner',
+    })
+  } else {
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findById(params.input.id)
+      .throwIfNotFound({ message: 'Connection not found' })
+  }
 
   // GUARD: Prevent updating personal connections owned by others
   if (

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -14,17 +14,26 @@ const verifyConnection: MutationResolvers['verifyConnection'] = async (
   params,
   context,
 ) => {
-  const flow = await context.currentUser
-    .withAccessibleFlows({ requiredRole: 'editor' })
-    .findById(params.input.flowId)
-    .throwIfNotFound()
+  let connection
 
-  let connection = await getConnection({
-    context,
-    connectionId: params.input.id,
-    flowId: params.input.flowId,
-    includeOwnConnections: flow.role === 'owner',
-  })
+  if (params.input.flowId) {
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findById(params.input.flowId)
+      .throwIfNotFound()
+
+    connection = await getConnection({
+      context,
+      connectionId: params.input.id,
+      flowId: params.input.flowId,
+      includeOwnConnections: flow.role === 'owner',
+    })
+  } else {
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findById(params.input.id)
+      .throwIfNotFound({ message: 'Connection not found' })
+  }
 
   // GUARD: Prevent updating personal connections owned by others
   if (

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -5,7 +5,7 @@
 import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
-import { getConnection } from '@/services/connection'
+import { getConnection, getOwnEditableConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -29,10 +29,10 @@ const verifyConnection: MutationResolvers['verifyConnection'] = async (
       includeOwnConnections: flow.role === 'owner',
     })
   } else {
-    connection = await context.currentUser
-      .$relatedQuery('connections')
-      .findById(params.input.id)
-      .throwIfNotFound({ message: 'Connection not found' })
+    connection = await getOwnEditableConnection({
+      context,
+      connectionId: params.input.id,
+    })
   }
 
   // GUARD: Prevent updating personal connections owned by others

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -371,6 +371,7 @@ type AppAuth {
   reconnectionSteps: [ReconnectionStep]
   connectionModalLabel: ConnectionModalLabel
   autoCheckStep: Boolean
+  supportsConnectionEdit: Boolean
 }
 
 enum ArgumentEnumType {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -587,7 +587,7 @@ input GenerateAuthUrlInput {
 input UpdateConnectionInput {
   id: String!
   formattedData: JSONObject!
-  flowId: String!
+  flowId: String
 }
 
 input ResetConnectionInput {
@@ -596,7 +596,7 @@ input ResetConnectionInput {
 
 input VerifyConnectionInput {
   id: String!
-  flowId: String!
+  flowId: String
 }
 
 input DeleteConnectionInput {

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,5 +1,7 @@
 import { Transaction } from 'objection'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
+import App from '@/models/app'
 import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Context from '@/types/express/context'
@@ -53,4 +55,37 @@ export const getConnection = async (params: GetConnectionParams) => {
     .throwIfNotFound({ message: 'Connection not found' })
 
   return flowConnection?.connection
+}
+
+type GetOwnEditableConnectionParams = {
+  context: Context
+  connectionId: string
+  trx?: Transaction
+}
+
+/**
+ * Fetches a connection outside of any pipe, for the connections page's credential
+ * editing. Only the user's own connections are reachable, and only for apps that
+ * opted into editing via their auth's supportsConnectionEdit.
+ */
+export const getOwnEditableConnection = async (
+  params: GetOwnEditableConnectionParams,
+) => {
+  const { context, connectionId, trx } = params
+
+  const connection = await context.currentUser
+    .$relatedQuery('connections', trx)
+    .findById(connectionId)
+    .throwIfNotFound({ message: 'Connection not found' })
+
+  const app = await App.findOneByKey(connection.key)
+
+  if (
+    app.auth?.connectionType !== 'user-added' ||
+    !app.auth.supportsConnectionEdit
+  ) {
+    throw new ForbiddenError('This connection cannot be edited')
+  }
+
+  return connection
 }

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -186,7 +186,7 @@ export default function AddAppConnection(
                 data-test="create-connection-button"
                 isFullWidth
               >
-                Connect
+                {hasConnection ? 'Update connection' : 'Connect'}
               </Button>
             </VStack>
           </Form>

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -2,6 +2,7 @@ import type { IApp, IField, IJSONObject } from '@plumber/types'
 
 import * as React from 'react'
 import { FieldValues, SubmitHandler } from 'react-hook-form'
+import { useQuery } from '@apollo/client'
 import {
   Alert,
   AlertIcon,
@@ -11,13 +12,19 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  Text,
   VStack,
 } from '@chakra-ui/react'
 import { Button, Infobox, Link } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
+import { GET_APP_CONNECTIONS } from '@/graphql/queries/get-app-connections'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
+import {
+  getConnectionEnvLabel,
+  getEditableConnectionLabel,
+} from '@/helpers/connection-label'
 import { getOpenerOrigin } from '@/helpers/window'
 
 import Form from '../Form'
@@ -31,6 +38,8 @@ type AddAppConnectionProps = {
 type Response = {
   [key: string]: any
 }
+
+const LABEL_FIELD_KEYS = new Set(['screenName', 'label'])
 
 /**
  * TODO: deprecate this component, we only need to support the callback route
@@ -47,6 +56,37 @@ export default function AddAppConnection(
   const steps = hasConnection
     ? auth?.reconnectionSteps
     : auth?.authenticationSteps
+
+  const { data: connectionsData, loading: connectionLoading } = useQuery(
+    GET_APP_CONNECTIONS,
+    {
+      variables: { key },
+      skip: !connectionId,
+    },
+  )
+
+  const editingConnection = connectionsData?.getApp?.connections?.find(
+    (connection: { id?: string }) => connection.id === connectionId,
+  )
+  const storedScreenName = editingConnection?.formattedData?.screenName
+  const labelDefault = getEditableConnectionLabel(
+    key,
+    storedScreenName?.toString(),
+  )
+  const envLabel = getConnectionEnvLabel(
+    editingConnection?.formattedData?.env?.toString(),
+  )
+
+  const defaultValues = React.useMemo(() => {
+    if (!hasConnection || !labelDefault) {
+      return undefined
+    }
+
+    return {
+      screenName: labelDefault,
+      label: labelDefault,
+    }
+  }, [hasConnection, labelDefault])
 
   React.useEffect(() => {
     if (
@@ -172,24 +212,45 @@ export default function AddAppConnection(
         )}
 
         <ModalBody>
-          <Form onSubmit={submitHandler}>
-            <VStack gap={4} pt={4} pb={8} alignItems="stretch">
-              {auth?.fields?.map((field: IField) => (
-                <InputCreator key={field.key} schema={field} />
-              ))}
+          {hasConnection && connectionLoading ? null : (
+            <Form defaultValues={defaultValues} onSubmit={submitHandler}>
+              <VStack gap={4} pt={4} pb={8} alignItems="stretch">
+                {hasConnection && key === 'telegram-bot' ? (
+                  <Infobox>
+                    The connection name is taken from the bot after you save.
+                  </Infobox>
+                ) : null}
 
-              <Button
-                type="submit"
-                variant="solid"
-                colorScheme="primary"
-                isLoading={inProgress}
-                data-test="create-connection-button"
-                isFullWidth
-              >
-                {hasConnection ? 'Update connection' : 'Connect'}
-              </Button>
-            </VStack>
-          </Form>
+                {hasConnection && envLabel ? (
+                  <Text textStyle="body-2" color="base.content.medium">
+                    Environment: {envLabel}
+                  </Text>
+                ) : null}
+
+                {auth?.fields?.map((field: IField) => (
+                  <InputCreator
+                    key={field.key}
+                    schema={
+                      LABEL_FIELD_KEYS.has(field.key) && labelDefault
+                        ? { ...field, value: labelDefault }
+                        : field
+                    }
+                  />
+                ))}
+
+                <Button
+                  type="submit"
+                  variant="solid"
+                  colorScheme="primary"
+                  isLoading={inProgress}
+                  data-test="create-connection-button"
+                  isFullWidth
+                >
+                  {hasConnection ? 'Update connection' : 'Connect'}
+                </Button>
+              </VStack>
+            </Form>
+          )}
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
+++ b/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
@@ -7,8 +7,16 @@ import { IconButton } from '@opengovsg/design-system-react'
 import * as URLS from '@/config/urls'
 
 type Action = {
-  type: 'test' | 'delete' | 'viewFlows'
+  type: 'test' | 'edit' | 'delete' | 'viewFlows'
 }
+
+const EDITABLE_CONNECTION_APP_KEYS = new Set([
+  'custom-api',
+  'gathersg',
+  'lettersg',
+  'postman-sms',
+  'telegram-bot',
+])
 
 type ContextMenuProps = {
   appKey: string
@@ -56,6 +64,16 @@ export default function ContextMenu(
           <MenuItem onClick={createActionHandler({ type: 'test' })}>
             Test connection
           </MenuItem>
+
+          {EDITABLE_CONNECTION_APP_KEYS.has(appKey) ? (
+            <MenuItem
+              as={Link}
+              to={URLS.APP_EDIT_CONNECTION(appKey, connectionId)}
+              onClick={createActionHandler({ type: 'edit' })}
+            >
+              Edit connection
+            </MenuItem>
+          ) : null}
 
           <MenuItem
             onClick={createActionHandler({ type: 'delete' })}

--- a/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
+++ b/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
@@ -10,24 +10,19 @@ type Action = {
   type: 'test' | 'edit' | 'delete' | 'viewFlows'
 }
 
-const EDITABLE_CONNECTION_APP_KEYS = new Set([
-  'custom-api',
-  'gathersg',
-  'lettersg',
-  'postman-sms',
-  'telegram-bot',
-])
-
 type ContextMenuProps = {
   appKey: string
   connectionId: string
+  // Whether the app's auth opted into credential editing; comes from the backend
+  // via GetAppConnections.
+  supportsConnectionEdit?: boolean
   onMenuItemClick: (event: React.MouseEvent, action: Action) => void
 }
 
 export default function ContextMenu(
   props: ContextMenuProps,
 ): React.ReactElement {
-  const { appKey, connectionId, onMenuItemClick } = props
+  const { appKey, connectionId, supportsConnectionEdit, onMenuItemClick } = props
 
   const createActionHandler = React.useCallback(
     (action: Action) => {
@@ -65,7 +60,7 @@ export default function ContextMenu(
             Test connection
           </MenuItem>
 
-          {EDITABLE_CONNECTION_APP_KEYS.has(appKey) ? (
+          {supportsConnectionEdit ? (
             <MenuItem
               as={Link}
               to={URLS.APP_EDIT_CONNECTION(appKey, connectionId)}

--- a/packages/frontend/src/components/AppConnectionRow/index.tsx
+++ b/packages/frontend/src/components/AppConnectionRow/index.tsx
@@ -23,6 +23,7 @@ import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 
 type AppConnectionRowProps = {
   connection: IConnection
+  supportsConnectionEdit?: boolean
 }
 
 function AppConnectionRow(props: AppConnectionRowProps): React.ReactElement {
@@ -177,6 +178,7 @@ function AppConnectionRow(props: AppConnectionRowProps): React.ReactElement {
             <ConnectionContextMenu
               appKey={key}
               connectionId={id}
+              supportsConnectionEdit={props.supportsConnectionEdit}
               onMenuItemClick={onContextMenuAction}
             />
           </Box>

--- a/packages/frontend/src/components/AppConnections/index.tsx
+++ b/packages/frontend/src/components/AppConnections/index.tsx
@@ -19,6 +19,9 @@ export default function AppConnections(
     variables: { key: appKey },
   })
   const appConnections: IConnection[] = data?.getApp?.connections || []
+  const supportsConnectionEdit: boolean = Boolean(
+    data?.getApp?.auth?.supportsConnectionEdit,
+  )
 
   const hasConnections = appConnections?.length
 
@@ -34,7 +37,11 @@ export default function AppConnections(
   return (
     <>
       {appConnections.map((appConnection: IConnection) => (
-        <AppConnectionRow key={appConnection.id} connection={appConnection} />
+        <AppConnectionRow
+          key={appConnection.id}
+          connection={appConnection}
+          supportsConnectionEdit={supportsConnectionEdit}
+        />
       ))}
     </>
   )

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -29,6 +29,10 @@ export const APP_FLOWS_FOR_CONNECTION = (
   appKey: string,
   connectionId: string,
 ): string => `/app/${appKey}/flows?connectionId=${connectionId}`
+export const APP_EDIT_CONNECTION = (
+  appKey: string,
+  connectionId: string,
+): string => `/app/${appKey}/connections/${connectionId}/edit`
 export const APP_FLOWS_PATTERN = '/app/:appKey/flows'
 
 export const EDITOR = '/editor'

--- a/packages/frontend/src/graphql/queries/get-app-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-app-connections.ts
@@ -4,6 +4,9 @@ export const GET_APP_CONNECTIONS = gql`
   query GetAppConnections($key: String!, $flowId: String) {
     getApp(key: $key, flowId: $flowId) {
       key
+      auth {
+        supportsConnectionEdit
+      }
       connections {
         id
         key

--- a/packages/frontend/src/graphql/queries/get-app.ts
+++ b/packages/frontend/src/graphql/queries/get-app.ts
@@ -12,6 +12,7 @@ export const GET_APP = gql`
       auth {
         connectionType
         connectionRegistrationType
+        supportsConnectionEdit
         fields {
           key
           label

--- a/packages/frontend/src/helpers/__tests__/connection-label.test.ts
+++ b/packages/frontend/src/helpers/__tests__/connection-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getConnectionEnvLabel,
+  getEditableConnectionLabel,
+} from '../connection-label'
+
+describe('getEditableConnectionLabel', () => {
+  it('returns an empty string when there is no stored name', () => {
+    expect(getEditableConnectionLabel('lettersg')).toBe('')
+  })
+
+  it('strips the Postman test prefix', () => {
+    expect(
+      getEditableConnectionLabel('postman-sms', '[TEST] My Campaign'),
+    ).toBe('My Campaign')
+  })
+
+  it('strips a single LetterSG staging suffix', () => {
+    expect(getEditableConnectionLabel('lettersg', 'My Letter [STAGING]')).toBe(
+      'My Letter',
+    )
+  })
+
+  it('leaves other apps unchanged', () => {
+    expect(getEditableConnectionLabel('gathersg', 'My Gather [STAGING]')).toBe(
+      'My Gather [STAGING]',
+    )
+  })
+})
+
+describe('getConnectionEnvLabel', () => {
+  it('maps LetterSG stored env values', () => {
+    expect(getConnectionEnvLabel('test')).toBe('Staging')
+    expect(getConnectionEnvLabel('live')).toBe('Production')
+    expect(getConnectionEnvLabel('prod')).toBeNull()
+  })
+})

--- a/packages/frontend/src/helpers/connection-label.ts
+++ b/packages/frontend/src/helpers/connection-label.ts
@@ -1,0 +1,39 @@
+const POSTMAN_TEST_LABEL_PREFIX = '[TEST] '
+const LETTERSG_STAGING_LABEL_SUFFIX = ' [STAGING]'
+
+export function getEditableConnectionLabel(
+  appKey: string,
+  screenName?: string | null,
+): string {
+  if (!screenName) {
+    return ''
+  }
+
+  if (
+    appKey === 'postman-sms' &&
+    screenName.startsWith(POSTMAN_TEST_LABEL_PREFIX)
+  ) {
+    return screenName.slice(POSTMAN_TEST_LABEL_PREFIX.length)
+  }
+
+  if (
+    appKey === 'lettersg' &&
+    screenName.endsWith(LETTERSG_STAGING_LABEL_SUFFIX)
+  ) {
+    return screenName.slice(0, -LETTERSG_STAGING_LABEL_SUFFIX.length)
+  }
+
+  return screenName
+}
+
+export function getConnectionEnvLabel(env?: string | null): string | null {
+  if (env === 'test') {
+    return 'Staging'
+  }
+
+  if (env === 'live') {
+    return 'Production'
+  }
+
+  return null
+}

--- a/packages/frontend/src/pages/Application/index.tsx
+++ b/packages/frontend/src/pages/Application/index.tsx
@@ -24,6 +24,24 @@ type ApplicationParams = {
   connectionId?: string
 }
 
+function EditConnection({
+  application,
+  onClose,
+}: {
+  application: Parameters<typeof AddAppConnection>[0]['application']
+  onClose: () => void
+}): React.ReactElement {
+  const { connectionId } = useParams() as ApplicationParams
+
+  return (
+    <AddAppConnection
+      onClose={onClose}
+      application={application}
+      connectionId={connectionId}
+    />
+  )
+}
+
 export default function Application(): React.ReactElement | null {
   const connectionsPathMatch = useMatch({
     path: URLS.APP_CONNECTIONS_PATTERN,
@@ -34,7 +52,7 @@ export default function Application(): React.ReactElement | null {
   const navigate = useNavigate()
   const { data, loading } = useQuery(GET_APP, { variables: { key: appKey } })
 
-  const goToApplicationPage = () => navigate('connections')
+  const goToApplicationPage = () => navigate(URLS.APP_CONNECTIONS(appKey))
   const app = data?.getApp || {}
 
   if (loading) {
@@ -124,6 +142,15 @@ export default function Application(): React.ReactElement | null {
           path="/connections/add"
           element={
             <AddAppConnection onClose={goToApplicationPage} application={app} />
+          }
+        />
+        <Route
+          path="/connections/:connectionId/edit"
+          element={
+            <EditConnection
+              application={app}
+              onClose={goToApplicationPage}
+            />
           }
         />
       </Routes>

--- a/packages/frontend/src/pages/Application/index.tsx
+++ b/packages/frontend/src/pages/Application/index.tsx
@@ -144,15 +144,14 @@ export default function Application(): React.ReactElement | null {
             <AddAppConnection onClose={goToApplicationPage} application={app} />
           }
         />
-        <Route
-          path="/connections/:connectionId/edit"
-          element={
-            <EditConnection
-              application={app}
-              onClose={goToApplicationPage}
-            />
-          }
-        />
+        {app.auth?.supportsConnectionEdit ? (
+          <Route
+            path="/connections/:connectionId/edit"
+            element={
+              <EditConnection application={app} onClose={goToApplicationPage} />
+            }
+          />
+        ) : null}
       </Routes>
     </>
   )

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -901,6 +901,11 @@ interface IBaseAuth {
 interface IUserAddedConnectionAuth extends IBaseAuth {
   connectionType: 'user-added'
   fields?: IField[]
+
+  // Whether users may overwrite this app's stored credentials from the
+  // connections page. Editing only submits new credentials; existing ones are
+  // never returned to the client.
+  supportsConnectionEdit?: boolean
 }
 
 interface ISystemAddedConnectionAuth extends IBaseAuth {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- restore the Edit connection action and credential modal on the Connections page
- the editable-app allow-list lives in the backend: each app's auth opts in with `supportsConnectionEdit`, currently GatherSG, Telegram, Postman SMS, LetterSG, and Custom API
- `updateConnection` and `verifyConnection` enforce that flag server-side on the no-pipe path via `getOwnEditableConnection`
- credential secret fields stay blank so submitted values overwrite stored credentials
- labels are prefilled from stored `screenName` (Custom API uses the `label` field). Postman `[TEST]` and LetterSG `[STAGING]` tags are stripped in the form and re-applied on verify without doubling. Telegram explains that the name comes from the bot after save. LetterSG env is shown as read-only text when present.

## Follow-up
- Failed-edit wipe (`resetConnection` before verify) is still open; we are not implementing the in-memory verify / persist-once change until that plan is agreed.

## Tests
- LetterSG `verifyCredentials` unit tests for suffix handling
- Frontend `getEditableConnectionLabel` unit tests
- Integration coverage for the no-pipe update/verify path
- Automated tests could not run locally because the private `@taskforcesh/bullmq-pro` package returned HTTP 401 during dependency installation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

