### PR TITLE
feat(connection-edit): persist credentials after verification

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/replace-connection-credentials.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/replace-connection-credentials.itest.ts
@@ -1,0 +1,173 @@
+import type { IGlobalVariable, IJSONObject } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import replaceConnectionCredentials from '@/graphql/mutations/replace-connection-credentials'
+import Connection from '@/models/connection'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+
+const mocks = vi.hoisted(() => ({
+  verifyCredentials: vi.fn(),
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: vi.fn(
+    async ({
+      authData,
+    }: {
+      authData: IJSONObject
+    }): Promise<IGlobalVariable> => {
+      const $ = {
+        auth: {
+          data: authData,
+          set: async (updates: IJSONObject) => {
+            $.auth.data = {
+              ...$.auth.data,
+              ...updates,
+            }
+            return null
+          },
+        },
+      }
+
+      return $ as unknown as IGlobalVariable
+    },
+  ),
+}))
+
+vi.mock('@/models/app', () => ({
+  default: {
+    findOneByKey: vi.fn().mockResolvedValue({
+      key: 'telegram-bot',
+      auth: {
+        connectionType: 'user-added',
+        supportsConnectionEdit: true,
+        fields: [
+          {
+            key: 'token',
+            label: 'Bot token',
+            type: 'string',
+            required: true,
+          },
+        ],
+        verifyCredentials: mocks.verifyCredentials,
+      },
+    }),
+  },
+}))
+
+describe('replaceConnectionCredentials', () => {
+  let context: Context
+  let owner: User
+  let otherUser: User
+  let connection: Connection
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await Connection.query().delete()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+    otherUser = await generateMockUser('connection-editor')
+    connection = await Connection.query().insertAndFetch({
+      userId: owner.id,
+      key: 'telegram-bot',
+      formattedData: {
+        token: 'old-token',
+        screenName: 'Old bot',
+        legacyField: 'remove-me',
+      },
+      verified: true,
+      draft: false,
+    })
+  })
+
+  it('replaces credentials only after verification succeeds', async () => {
+    mocks.verifyCredentials.mockImplementationOnce(
+      async ($: IGlobalVariable) => {
+        expect($.auth.data).toEqual({ token: 'new-token' })
+        await $.auth.set({ screenName: 'New bot' })
+      },
+    )
+
+    await replaceConnectionCredentials(
+      null,
+      {
+        input: {
+          id: connection.id,
+          formattedData: { token: 'new-token' },
+        },
+      },
+      context,
+    )
+
+    const updated = await Connection.query().findById(connection.id)
+    expect(updated.formattedData).toEqual({
+      token: 'new-token',
+      screenName: 'New bot',
+    })
+    expect(updated.verified).toBe(true)
+  })
+
+  it('leaves the stored connection unchanged when verification fails', async () => {
+    mocks.verifyCredentials.mockRejectedValueOnce(new Error('Invalid token'))
+    const before = await Connection.query().findById(connection.id)
+
+    await expect(
+      replaceConnectionCredentials(
+        null,
+        {
+          input: {
+            id: connection.id,
+            formattedData: { token: 'invalid-token' },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('Invalid token')
+
+    const after = await Connection.query().findById(connection.id)
+    expect(after.formattedData).toEqual(before.formattedData)
+    expect(after.verified).toBe(before.verified)
+    expect(after.updatedAt).toEqual(before.updatedAt)
+  })
+
+  it('rejects blank required credentials before verification', async () => {
+    await expect(
+      replaceConnectionCredentials(
+        null,
+        {
+          input: {
+            id: connection.id,
+            formattedData: { token: '' },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('Bot token is required')
+
+    expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+  })
+
+  it('does not allow a user to edit another user connection', async () => {
+    context.currentUser = otherUser
+
+    await expect(
+      replaceConnectionCredentials(
+        null,
+        {
+          input: {
+            id: connection.id,
+            formattedData: { token: 'new-token' },
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('Connection not found')
+    expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+  })
+})

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -108,5 +108,5 @@ export default {
   // This is a special stub that enables us to group all our admin-related
   // mutations into a special AdminMutation object; each "mutation" is handled by field
   // resolvers defined in @/graphql/admin/mutations.
-  admin: () => ({} as AdminMutation),
+  admin: () => ({}) as AdminMutation,
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -28,6 +28,7 @@ import loginWithSgid from './mutations/login-with-sgid'
 import loginWithSso from './mutations/login-with-sso'
 import logout from './mutations/logout'
 import registerConnection from './mutations/register-connection'
+import replaceConnectionCredentials from './mutations/replace-connection-credentials'
 import requestOtp from './mutations/request-otp'
 import resetConnection from './mutations/reset-connection'
 import retryExecutionStep from './mutations/retry-execution-step'
@@ -66,6 +67,7 @@ export default {
   createConnection,
   generateAuthUrl,
   updateConnection,
+  replaceConnectionCredentials,
   resetConnection,
   verifyConnection,
   deleteConnection,

--- a/packages/backend/src/graphql/mutations/replace-connection-credentials.ts
+++ b/packages/backend/src/graphql/mutations/replace-connection-credentials.ts
@@ -1,0 +1,51 @@
+import { ForbiddenError } from '@/errors/graphql-errors'
+import buildConnectionEditCandidate from '@/helpers/build-connection-edit-candidate'
+import globalVariable from '@/helpers/global-variable'
+import App from '@/models/app'
+import { getOwnEditableConnection } from '@/services/connection'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const replaceConnectionCredentials: MutationResolvers['replaceConnectionCredentials'] =
+  async (_parent, params, context) => {
+    const connection = await getOwnEditableConnection({
+      context,
+      connectionId: params.input.id,
+    })
+    const app = await App.findOneByKey(connection.key)
+
+    if (
+      app.auth?.connectionType !== 'user-added' ||
+      !app.auth.supportsConnectionEdit
+    ) {
+      throw new ForbiddenError('This connection cannot be edited')
+    }
+
+    const candidate = buildConnectionEditCandidate({
+      app,
+      storedData: connection.formattedData,
+      submittedData: params.input.formattedData,
+    })
+    const $ = await globalVariable({
+      connection,
+      app,
+      user: context.currentUser,
+      authData: candidate,
+      persistAuthData: false,
+    })
+
+    await app.auth.verifyCredentials($)
+
+    const updatedConnection = await connection.$query().patchAndFetch({
+      formattedData: $.auth.data,
+      verified: true,
+      draft: false,
+    })
+
+    return {
+      ...updatedConnection,
+      app,
+    }
+  }
+
+export default replaceConnectionCredentials

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -68,6 +68,9 @@ type Mutation {
   createConnection(input: CreateConnectionInput): Connection
   generateAuthUrl(input: GenerateAuthUrlInput): AuthLink
   updateConnection(input: UpdateConnectionInput): Connection
+  replaceConnectionCredentials(
+    input: ReplaceConnectionCredentialsInput
+  ): Connection
   resetConnection(input: ResetConnectionInput): Connection
   verifyConnection(input: VerifyConnectionInput): Connection
   deleteConnection(input: DeleteConnectionInput): Boolean
@@ -589,6 +592,11 @@ input UpdateConnectionInput {
   id: String!
   formattedData: JSONObject!
   flowId: String
+}
+
+input ReplaceConnectionCredentialsInput {
+  id: String!
+  formattedData: JSONObject!
 }
 
 input ResetConnectionInput {

--- a/packages/backend/src/helpers/__tests__/build-connection-edit-candidate.test.ts
+++ b/packages/backend/src/helpers/__tests__/build-connection-edit-candidate.test.ts
@@ -1,0 +1,120 @@
+import type { IApp, IField, IJSONObject } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import buildConnectionEditCandidate from '@/helpers/build-connection-edit-candidate'
+
+function createApp(
+  key: string,
+  fields: IField[],
+): IApp {
+  return {
+    key,
+    auth: {
+      connectionType: 'user-added',
+      fields,
+    },
+  } as IApp
+}
+
+describe('buildConnectionEditCandidate', () => {
+  it('only includes declared auth fields', () => {
+    const app = createApp('telegram-bot', [
+      {
+        key: 'token',
+        label: 'Bot token',
+        type: 'string',
+        required: true,
+      },
+    ])
+
+    expect(
+      buildConnectionEditCandidate({
+        app,
+        submittedData: {
+          token: 'new-token',
+          unexpected: 'value',
+        },
+      }),
+    ).toEqual({ token: 'new-token' })
+  })
+
+  it('rejects a blank required field', () => {
+    const app = createApp('gathersg', [
+      {
+        key: 'apiKey',
+        label: 'API key',
+        type: 'string',
+        required: true,
+      },
+    ])
+
+    expect(() =>
+      buildConnectionEditCandidate({
+        app,
+        submittedData: { apiKey: ' ' },
+      }),
+    ).toThrow('API key is required')
+  })
+
+  it('keeps stored Custom API headers when submitted headers are blank', () => {
+    const app = createApp('custom-api', [
+      {
+        key: 'label',
+        label: 'Label',
+        type: 'string',
+        required: true,
+      },
+      {
+        key: 'headers',
+        label: 'Headers',
+        type: 'multiline',
+        required: false,
+      },
+    ])
+    const storedData: IJSONObject = {
+      screenName: 'Existing API',
+      headers: {
+        Authorization: 'Bearer old-token',
+        'X-Custom': 'value',
+      },
+    }
+
+    expect(
+      buildConnectionEditCandidate({
+        app,
+        storedData,
+        submittedData: {
+          label: 'Updated API',
+          headers: '',
+        },
+      }),
+    ).toEqual({
+      label: 'Updated API',
+      headers: 'Authorization=Bearer old-token\nX-Custom=value',
+    })
+  })
+
+  it('uses new Custom API headers when provided', () => {
+    const app = createApp('custom-api', [
+      {
+        key: 'headers',
+        label: 'Headers',
+        type: 'multiline',
+        required: false,
+      },
+    ])
+
+    expect(
+      buildConnectionEditCandidate({
+        app,
+        storedData: {
+          headers: { Authorization: 'Bearer old-token' },
+        },
+        submittedData: {
+          headers: 'Authorization=Bearer new-token',
+        },
+      }),
+    ).toEqual({ headers: 'Authorization=Bearer new-token' })
+  })
+})

--- a/packages/backend/src/helpers/__tests__/build-connection-edit-candidate.test.ts
+++ b/packages/backend/src/helpers/__tests__/build-connection-edit-candidate.test.ts
@@ -1,4 +1,9 @@
-import type { IApp, IField, IJSONObject } from '@plumber/types'
+import type {
+  IApp,
+  IField,
+  IJSONObject,
+  IUserAddedConnectionAuth,
+} from '@plumber/types'
 
 import { describe, expect, it } from 'vitest'
 
@@ -7,14 +12,14 @@ import buildConnectionEditCandidate from '@/helpers/build-connection-edit-candid
 function createApp(
   key: string,
   fields: IField[],
-): IApp {
+): IApp & { auth: IUserAddedConnectionAuth } {
   return {
     key,
     auth: {
       connectionType: 'user-added',
       fields,
     },
-  } as IApp
+  } as IApp & { auth: IUserAddedConnectionAuth }
 }
 
 describe('buildConnectionEditCandidate', () => {

--- a/packages/backend/src/helpers/__tests__/global-variable.test.ts
+++ b/packages/backend/src/helpers/__tests__/global-variable.test.ts
@@ -1,0 +1,58 @@
+import type { IApp, IJSONObject } from '@plumber/types'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import globalVariable from '@/helpers/global-variable'
+import Connection from '@/models/connection'
+
+describe('globalVariable auth persistence', () => {
+  const app = {
+    apiBaseUrl: '',
+    beforeRequest: [],
+  } as unknown as IApp
+
+  it('updates auth data in memory without updating the connection', async () => {
+    const patchAndFetch = vi.fn()
+    const connection = {
+      id: 'connection-id',
+      formattedData: { token: 'stored-token' },
+      $query: () => ({ patchAndFetch }),
+    } as unknown as Connection
+    const candidate: IJSONObject = { token: 'candidate-token' }
+
+    const $ = await globalVariable({
+      app,
+      connection,
+      authData: candidate,
+      persistAuthData: false,
+    })
+
+    await $.auth.set({ screenName: 'Candidate bot' })
+
+    expect($.auth.data).toEqual({
+      token: 'candidate-token',
+      screenName: 'Candidate bot',
+    })
+    expect(patchAndFetch).not.toHaveBeenCalled()
+    expect(connection.formattedData).toEqual({ token: 'stored-token' })
+  })
+
+  it('continues to persist auth updates by default', async () => {
+    const patchAndFetch = vi.fn()
+    const connection = {
+      id: 'connection-id',
+      formattedData: { token: 'stored-token' },
+      $query: () => ({ patchAndFetch }),
+    } as unknown as Connection
+
+    const $ = await globalVariable({ app, connection })
+    await $.auth.set({ screenName: 'Stored bot' })
+
+    expect(patchAndFetch).toHaveBeenCalledWith({
+      formattedData: {
+        token: 'stored-token',
+        screenName: 'Stored bot',
+      },
+    })
+  })
+})

--- a/packages/backend/src/helpers/build-connection-edit-candidate.ts
+++ b/packages/backend/src/helpers/build-connection-edit-candidate.ts
@@ -1,0 +1,67 @@
+import type {
+  IApp,
+  IJSONObject,
+  IUserAddedConnectionAuth,
+} from '@plumber/types'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+
+const CUSTOM_API_KEY = 'custom-api'
+const CUSTOM_API_HEADERS_KEY = 'headers'
+
+function isBlank(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    (typeof value === 'string' && value.trim() === '')
+  )
+}
+
+function serializeHeaders(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return ''
+  }
+
+  return Object.entries(value)
+    .map(([key, headerValue]) => `${key}=${String(headerValue)}`)
+    .join('\n')
+}
+
+export default function buildConnectionEditCandidate({
+  app,
+  storedData,
+  submittedData,
+}: {
+  app: IApp & { auth: IUserAddedConnectionAuth }
+  storedData?: IJSONObject
+  submittedData: IJSONObject
+}): IJSONObject {
+  const candidate: IJSONObject = {}
+
+  for (const field of app.auth.fields ?? []) {
+    const submittedValue = submittedData[field.key]
+
+    if (field.required && isBlank(submittedValue)) {
+      throw new BadUserInputError(`${field.label} is required`)
+    }
+
+    if (
+      app.key === CUSTOM_API_KEY &&
+      field.key === CUSTOM_API_HEADERS_KEY &&
+      isBlank(submittedValue)
+    ) {
+      candidate[field.key] = serializeHeaders(storedData?.[field.key])
+      continue
+    }
+
+    if (submittedValue !== undefined) {
+      candidate[field.key] = submittedValue
+    }
+  }
+
+  return candidate
+}

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -27,6 +27,8 @@ type GlobalVariableOptions = {
   request?: IRequest
   user?: User // only required in GraphQL context
   metadata?: IJSONObject
+  authData?: IJSONObject
+  persistAuthData?: boolean
 }
 
 const globalVariable = async (
@@ -42,6 +44,8 @@ const globalVariable = async (
     testRun = false,
     user,
     metadata,
+    authData,
+    persistAuthData = true,
   } = options
 
   const isTrigger = step?.isTrigger
@@ -50,20 +54,21 @@ const globalVariable = async (
   const $: IGlobalVariable = {
     auth: {
       set: async (args: IJSONObject) => {
-        if (connection) {
-          await connection.$query().patchAndFetch({
-            formattedData: {
-              ...connection.formattedData,
-              ...args,
-            },
-          })
-
-          $.auth.data = connection.formattedData
+        const updatedAuthData = {
+          ...$.auth.data,
+          ...args,
         }
 
+        if (connection && persistAuthData) {
+          await connection.$query().patchAndFetch({
+            formattedData: updatedAuthData,
+          })
+        }
+
+        $.auth.data = updatedAuthData
         return null
       },
-      data: connection?.formattedData,
+      data: authData ?? connection?.formattedData,
       connectionId: connection?.id,
     },
     app: app,

--- a/packages/backend/src/helpers/morgan.ts
+++ b/packages/backend/src/helpers/morgan.ts
@@ -36,6 +36,7 @@ morgan.token('graphql-query', (req: Request) => {
 
 const SENSITIVE_MUTATIONS = [
   'createConnection',
+  'replaceConnectionCredentials',
   'updateConnection',
   'verifyTableViewPassword',
   'setTableViewPassword',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack context

This is PR 3 of 5. It provides the safe backend operation used by the Connections page UI above it.

## What

- add `replaceConnectionCredentials`
- build candidates only from declared auth fields
- verify candidates with in-memory auth state
- persist once only after verification succeeds
- replace old credentials instead of merging them
- preserve stored Custom API headers when the optional field is blank
- redact mutation variables from request logs

## Why

The previous reset-update-verify sequence could wipe a working connection when verification failed. This mutation performs zero writes before successful verification.

## Testing

Unit tests cover candidate validation and in-memory auth updates. Integration tests cover success, verification failure, blank credentials, and ownership. Local execution is blocked because the private npm package registry returns HTTP 401 during dependency installation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

