### PR TITLE
fix(connection-edit): prefill labels and stabilize environment tags

### DIFF
--- a/packages/backend/src/apps/lettersg/__tests__/auth/verify-credentials.test.ts
+++ b/packages/backend/src/apps/lettersg/__tests__/auth/verify-credentials.test.ts
@@ -1,0 +1,67 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import verifyCredentials from '../../auth/verify-credentials'
+import { LetterSgEnvironment } from '../../common/api'
+
+const mocks = vi.hoisted(() => ({
+  authSet: vi.fn(),
+  httpGet: vi.fn(),
+}))
+
+describe('LetterSG verifyCredentials', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.httpGet.mockResolvedValue({ data: {} })
+
+    $ = {
+      auth: {
+        data: {
+          screenName: 'My Letter',
+          apiKey: 'test_v1_123',
+        },
+        set: mocks.authSet,
+      },
+      http: {
+        get: mocks.httpGet,
+      },
+    } as unknown as IGlobalVariable
+  })
+
+  it('appends a staging suffix for staging API keys', async () => {
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter [STAGING]',
+      env: LetterSgEnvironment.Staging,
+    })
+  })
+
+  it('does not append a second staging suffix', async () => {
+    $.auth.data.screenName = 'My Letter [STAGING]'
+
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter [STAGING]',
+      env: LetterSgEnvironment.Staging,
+    })
+  })
+
+  it('does not keep a leftover staging suffix for prod API keys', async () => {
+    $.auth.data = {
+      screenName: 'My Letter [STAGING]',
+      apiKey: 'live_v1_321',
+    }
+
+    await verifyCredentials($)
+
+    expect(mocks.authSet).toHaveBeenCalledWith({
+      screenName: 'My Letter',
+      env: LetterSgEnvironment.Prod,
+    })
+  })
+})

--- a/packages/backend/src/apps/lettersg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/lettersg/auth/verify-credentials.ts
@@ -3,7 +3,11 @@ import type { IGlobalVariable } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
-import { getEnvironmentFromApiKey, LetterSgEnvironment } from '../common/api'
+import {
+  getEnvironmentFromApiKey,
+  LETTERSG_STAGING_LABEL_SUFFIX,
+  LetterSgEnvironment,
+} from '../common/api'
 
 import { AuthData, validateAuthData } from './auth-data'
 import { verifyApiKey } from './verify-api-key'
@@ -14,15 +18,20 @@ export default async function verifyCredentials(
   try {
     const authData: AuthData = validateAuthData($)
     const env = getEnvironmentFromApiKey(authData.apiKey)
+    const isStaging = env === LetterSgEnvironment.Staging
+    const baseScreenName = authData.screenName.endsWith(
+      LETTERSG_STAGING_LABEL_SUFFIX,
+    )
+      ? authData.screenName.slice(0, -LETTERSG_STAGING_LABEL_SUFFIX.length)
+      : authData.screenName
 
-    // after validation, can only be a prod or staging API key
-    const labelSuffix: string =
-      env === LetterSgEnvironment.Staging ? ' [STAGING]' : ''
     await verifyApiKey($)
 
     // update label
     await $.auth.set({
-      screenName: `${authData.screenName}${labelSuffix}`,
+      screenName: isStaging
+        ? `${baseScreenName}${LETTERSG_STAGING_LABEL_SUFFIX}`
+        : baseScreenName,
       env,
     })
   } catch (error) {

--- a/packages/backend/src/apps/lettersg/common/api.ts
+++ b/packages/backend/src/apps/lettersg/common/api.ts
@@ -1,3 +1,8 @@
+export enum LetterSgEnvironment {
+  Staging = 'test',
+  Prod = 'live',
+}
+
 export const LETTERSG_STAGING_LABEL_SUFFIX = ' [STAGING]'
 
 const STAGING_ENV_API_KEY_PREFIX = 'test_'

--- a/packages/backend/src/apps/lettersg/common/api.ts
+++ b/packages/backend/src/apps/lettersg/common/api.ts
@@ -1,7 +1,4 @@
-export enum LetterSgEnvironment {
-  Staging = 'test',
-  Prod = 'live',
-}
+export const LETTERSG_STAGING_LABEL_SUFFIX = ' [STAGING]'
 
 const STAGING_ENV_API_KEY_PREFIX = 'test_'
 const STAGING_ENV_BASE_URL = 'https://staging.letters.gov.sg/api'

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -2,7 +2,7 @@ import type { IApp, IField, IJSONObject } from '@plumber/types'
 
 import * as React from 'react'
 import { FieldValues, SubmitHandler } from 'react-hook-form'
-import { useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client'
 import {
   Alert,
   AlertIcon,
@@ -12,14 +12,20 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  Text,
   VStack,
 } from '@chakra-ui/react'
 import { Button, Infobox, Link } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
 import { REPLACE_CONNECTION_CREDENTIALS } from '@/graphql/mutations/replace-connection-credentials'
+import { GET_APP_CONNECTIONS } from '@/graphql/queries/get-app-connections'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
+import {
+  getConnectionEnvLabel,
+  getEditableConnectionLabel,
+} from '@/helpers/connection-label'
 import { getOpenerOrigin } from '@/helpers/window'
 
 import Form from '../Form'
@@ -33,6 +39,8 @@ type AddAppConnectionProps = {
 type Response = {
   [key: string]: any
 }
+
+const LABEL_FIELD_KEYS = new Set(['screenName', 'label'])
 
 /**
  * TODO: deprecate this component, we only need to support the callback route
@@ -50,6 +58,37 @@ export default function AddAppConnection(
   )
   const hasConnection = Boolean(connectionId)
   const steps = auth?.authenticationSteps
+
+  const { data: connectionsData, loading: connectionLoading } = useQuery(
+    GET_APP_CONNECTIONS,
+    {
+      variables: { key },
+      skip: !connectionId,
+    },
+  )
+
+  const editingConnection = connectionsData?.getApp?.connections?.find(
+    (connection: { id?: string }) => connection.id === connectionId,
+  )
+  const storedScreenName = editingConnection?.formattedData?.screenName
+  const labelDefault = getEditableConnectionLabel(
+    key,
+    storedScreenName?.toString(),
+  )
+  const envLabel = getConnectionEnvLabel(
+    editingConnection?.formattedData?.env?.toString(),
+  )
+
+  const defaultValues = React.useMemo(() => {
+    if (!hasConnection || !labelDefault) {
+      return undefined
+    }
+
+    return {
+      screenName: labelDefault,
+      label: labelDefault,
+    }
+  }, [hasConnection, labelDefault])
 
   React.useEffect(() => {
     if (
@@ -213,24 +252,45 @@ export default function AddAppConnection(
         )}
 
         <ModalBody>
-          <Form onSubmit={submitHandler}>
-            <VStack gap={4} pt={4} pb={8} alignItems="stretch">
-              {auth?.fields?.map((field: IField) => (
-                <InputCreator key={field.key} schema={field} />
-              ))}
+          {hasConnection && connectionLoading ? null : (
+            <Form defaultValues={defaultValues} onSubmit={submitHandler}>
+              <VStack gap={4} pt={4} pb={8} alignItems="stretch">
+                {hasConnection && key === 'telegram-bot' ? (
+                  <Infobox>
+                    The connection name is taken from the bot after you save.
+                  </Infobox>
+                ) : null}
 
-              <Button
-                type="submit"
-                variant="solid"
-                colorScheme="primary"
-                isLoading={inProgress}
-                data-test="create-connection-button"
-                isFullWidth
-              >
-                {hasConnection ? 'Update connection' : 'Connect'}
-              </Button>
-            </VStack>
-          </Form>
+                {hasConnection && envLabel ? (
+                  <Text textStyle="body-2" color="base.content.medium">
+                    Environment: {envLabel}
+                  </Text>
+                ) : null}
+
+                {auth?.fields?.map((field: IField) => (
+                  <InputCreator
+                    key={field.key}
+                    schema={
+                      LABEL_FIELD_KEYS.has(field.key) && labelDefault
+                        ? { ...field, value: labelDefault }
+                        : field
+                    }
+                  />
+                ))}
+
+                <Button
+                  type="submit"
+                  variant="solid"
+                  colorScheme="primary"
+                  isLoading={inProgress}
+                  data-test="create-connection-button"
+                  isFullWidth
+                >
+                  {hasConnection ? 'Update connection' : 'Connect'}
+                </Button>
+              </VStack>
+            </Form>
+          )}
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/packages/frontend/src/helpers/__tests__/connection-label.test.ts
+++ b/packages/frontend/src/helpers/__tests__/connection-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getConnectionEnvLabel,
+  getEditableConnectionLabel,
+} from '../connection-label'
+
+describe('getEditableConnectionLabel', () => {
+  it('returns an empty string when there is no stored name', () => {
+    expect(getEditableConnectionLabel('lettersg')).toBe('')
+  })
+
+  it('strips the Postman test prefix', () => {
+    expect(
+      getEditableConnectionLabel('postman-sms', '[TEST] My Campaign'),
+    ).toBe('My Campaign')
+  })
+
+  it('strips a single LetterSG staging suffix', () => {
+    expect(getEditableConnectionLabel('lettersg', 'My Letter [STAGING]')).toBe(
+      'My Letter',
+    )
+  })
+
+  it('leaves other apps unchanged', () => {
+    expect(getEditableConnectionLabel('gathersg', 'My Gather [STAGING]')).toBe(
+      'My Gather [STAGING]',
+    )
+  })
+})
+
+describe('getConnectionEnvLabel', () => {
+  it('maps LetterSG stored env values', () => {
+    expect(getConnectionEnvLabel('test')).toBe('Staging')
+    expect(getConnectionEnvLabel('live')).toBe('Production')
+    expect(getConnectionEnvLabel('prod')).toBeNull()
+  })
+})

--- a/packages/frontend/src/helpers/connection-label.ts
+++ b/packages/frontend/src/helpers/connection-label.ts
@@ -1,0 +1,39 @@
+const POSTMAN_TEST_LABEL_PREFIX = '[TEST] '
+const LETTERSG_STAGING_LABEL_SUFFIX = ' [STAGING]'
+
+export function getEditableConnectionLabel(
+  appKey: string,
+  screenName?: string | null,
+): string {
+  if (!screenName) {
+    return ''
+  }
+
+  if (
+    appKey === 'postman-sms' &&
+    screenName.startsWith(POSTMAN_TEST_LABEL_PREFIX)
+  ) {
+    return screenName.slice(POSTMAN_TEST_LABEL_PREFIX.length)
+  }
+
+  if (
+    appKey === 'lettersg' &&
+    screenName.endsWith(LETTERSG_STAGING_LABEL_SUFFIX)
+  ) {
+    return screenName.slice(0, -LETTERSG_STAGING_LABEL_SUFFIX.length)
+  }
+
+  return screenName
+}
+
+export function getConnectionEnvLabel(env?: string | null): string | null {
+  if (env === 'test') {
+    return 'Staging'
+  }
+
+  if (env === 'live') {
+    return 'Production'
+  }
+
+  return null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack context

This is PR 5 of 5. It adds label behavior to the Connections page edit UI below it.

## What

- prefill non-secret connection labels
- map Custom API `screenName` into its `label` field
- strip Postman `[TEST]` and LetterSG `[STAGING]` from editable labels
- show the stored LetterSG environment as read-only text
- explain Telegram's API-derived connection name
- prevent duplicate LetterSG staging suffixes

## Why

Users should edit the label they originally entered without derived environment text accumulating after each save.

## Testing

Unit tests cover frontend label normalization and LetterSG suffix behavior. Local execution is blocked because the private npm package registry returns HTTP 401 during dependency installation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

