### PR TITLE
feat(connection-edit): restrict editing to opted-in apps

### DIFF
--- a/packages/backend/src/apps/custom-api/auth/index.ts
+++ b/packages/backend/src/apps/custom-api/auth/index.ts
@@ -4,6 +4,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/gathersg/auth/index.ts
+++ b/packages/backend/src/apps/gathersg/auth/index.ts
@@ -6,6 +6,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/lettersg/auth/index.ts
+++ b/packages/backend/src/apps/lettersg/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/postman-sms/auth/index.ts
+++ b/packages/backend/src/apps/postman-sms/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/apps/telegram-bot/auth/index.ts
+++ b/packages/backend/src/apps/telegram-bot/auth/index.ts
@@ -5,6 +5,7 @@ import verifyCredentials from './verify-credentials'
 
 const auth: IUserAddedConnectionAuth = {
   connectionType: 'user-added' as const,
+  supportsConnectionEdit: true,
 
   fields: [
     {

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -60,21 +60,46 @@ describe('updateConnection', () => {
   })
 
   describe('without a flow', () => {
-    it('should allow a user to update their own personal connection', async () => {
+    // telegram-bot opts into credential editing; slack does not.
+    let editableConnection: Connection
+
+    beforeEach(async () => {
+      editableConnection = await Connection.query().insertAndFetch({
+        userId: owner.id,
+        key: 'telegram-bot',
+        formattedData: { screenName: 'Owner Telegram' },
+        verified: false,
+      })
+    })
+
+    it('should allow a user to update their own editable connection', async () => {
       const result = await updateConnection(
         null,
         {
           input: {
-            id: ownerConnection.id,
-            formattedData: { screenName: 'Updated from connections page' },
+            id: editableConnection.id,
+            formattedData: { screenName: 'Updated Telegram' },
           },
         },
         context,
       )
 
-      expect(result.formattedData.screenName).toBe(
-        'Updated from connections page',
-      )
+      expect(result.formattedData.screenName).toBe('Updated Telegram')
+    })
+
+    it('should not allow updating a connection whose app does not support editing', async () => {
+      await expect(
+        updateConnection(
+          null,
+          {
+            input: {
+              id: ownerConnection.id,
+              formattedData: { screenName: 'Unauthorized update' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('This connection cannot be edited')
     })
 
     it('should not allow a user to update another user personal connection', async () => {
@@ -85,7 +110,7 @@ describe('updateConnection', () => {
           null,
           {
             input: {
-              id: ownerConnection.id,
+              id: editableConnection.id,
               formattedData: { screenName: 'Unauthorized update' },
             },
           },

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import verifyConnection from '@/graphql/mutations/verify-connection'
+import App from '@/models/app'
 import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 import FlowConnections from '@/models/flow-connections'
@@ -28,6 +29,8 @@ vi.mock('@/models/app', () => ({
     findOneByKey: vi.fn().mockResolvedValue({
       key: 'slack',
       auth: {
+        connectionType: 'user-added',
+        supportsConnectionEdit: true,
         verifyCredentials: mocks.verifyCredentials,
       },
     }),
@@ -101,12 +104,23 @@ describe('verifyConnection', () => {
       context.currentUser = editor
 
       await expect(
-        verifyConnection(
-          null,
-          { input: { id: ownerConnection.id } },
-          context,
-        ),
+        verifyConnection(null, { input: { id: ownerConnection.id } }, context),
       ).rejects.toThrow('Connection not found')
+      expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+    })
+
+    it('should not allow verifying a connection whose app does not support editing', async () => {
+      vi.mocked(App.findOneByKey).mockResolvedValueOnce({
+        key: 'slack',
+        auth: {
+          connectionType: 'user-added',
+          verifyCredentials: mocks.verifyCredentials,
+        },
+      } as unknown as Awaited<ReturnType<typeof App.findOneByKey>>)
+
+      await expect(
+        verifyConnection(null, { input: { id: ownerConnection.id } }, context),
+      ).rejects.toThrow('This connection cannot be edited')
       expect(mocks.verifyCredentials).not.toHaveBeenCalled()
     })
   })

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -1,5 +1,5 @@
 import { ForbiddenError } from '@/errors/graphql-errors'
-import { getConnection } from '@/services/connection'
+import { getConnection, getOwnEditableConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -26,10 +26,10 @@ const updateConnection: MutationResolvers['updateConnection'] = async (
       includeOwnConnections: flow.role === 'owner',
     })
   } else {
-    connection = await context.currentUser
-      .$relatedQuery('connections')
-      .findById(params.input.id)
-      .throwIfNotFound({ message: 'Connection not found' })
+    connection = await getOwnEditableConnection({
+      context,
+      connectionId: params.input.id,
+    })
   }
 
   // GUARD: Prevent updating personal connections owned by others

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -5,7 +5,7 @@
 import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
-import { getConnection } from '@/services/connection'
+import { getConnection, getOwnEditableConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -29,10 +29,10 @@ const verifyConnection: MutationResolvers['verifyConnection'] = async (
       includeOwnConnections: flow.role === 'owner',
     })
   } else {
-    connection = await context.currentUser
-      .$relatedQuery('connections')
-      .findById(params.input.id)
-      .throwIfNotFound({ message: 'Connection not found' })
+    connection = await getOwnEditableConnection({
+      context,
+      connectionId: params.input.id,
+    })
   }
 
   // GUARD: Prevent updating personal connections owned by others

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -371,6 +371,7 @@ type AppAuth {
   reconnectionSteps: [ReconnectionStep]
   connectionModalLabel: ConnectionModalLabel
   autoCheckStep: Boolean
+  supportsConnectionEdit: Boolean
 }
 
 enum ArgumentEnumType {

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,5 +1,7 @@
 import { Transaction } from 'objection'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
+import App from '@/models/app'
 import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Context from '@/types/express/context'
@@ -53,4 +55,37 @@ export const getConnection = async (params: GetConnectionParams) => {
     .throwIfNotFound({ message: 'Connection not found' })
 
   return flowConnection?.connection
+}
+
+type GetOwnEditableConnectionParams = {
+  context: Context
+  connectionId: string
+  trx?: Transaction
+}
+
+/**
+ * Fetches a connection outside of any pipe, for the connections page's credential
+ * editing. Only the user's own connections are reachable, and only for apps that
+ * opted into editing via their auth's supportsConnectionEdit.
+ */
+export const getOwnEditableConnection = async (
+  params: GetOwnEditableConnectionParams,
+) => {
+  const { context, connectionId, trx } = params
+
+  const connection = await context.currentUser
+    .$relatedQuery('connections', trx)
+    .findById(connectionId)
+    .throwIfNotFound({ message: 'Connection not found' })
+
+  const app = await App.findOneByKey(connection.key)
+
+  if (
+    app.auth?.connectionType !== 'user-added' ||
+    !app.auth.supportsConnectionEdit
+  ) {
+    throw new ForbiddenError('This connection cannot be edited')
+  }
+
+  return connection
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -901,6 +901,11 @@ interface IBaseAuth {
 interface IUserAddedConnectionAuth extends IBaseAuth {
   connectionType: 'user-added'
   fields?: IField[]
+
+  // Whether users may overwrite this app's stored credentials from the
+  // connections page. Editing only submits new credentials; existing ones are
+  // never returned to the client.
+  supportsConnectionEdit?: boolean
 }
 
 interface ISystemAddedConnectionAuth extends IBaseAuth {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack context

This is PR 2 of 5. It depends on the no-flow mutation support in the PR below.

## What

- add `supportsConnectionEdit` to backend app auth
- opt in GatherSG, Telegram, Postman SMS, LetterSG, and Custom API
- enforce the policy and ownership through `getOwnEditableConnection`
- expose the policy through GraphQL
- test allowed, disallowed, and wrong-owner cases

## Why

The backend must own and enforce the editable-app policy. Frontend visibility alone is not an authorization boundary.

## Testing

Integration coverage added. Local execution is blocked because the private npm package registry returns HTTP 401 during dependency installation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

