### PR TITLE
feat(connection-edit): allow updating own connections without flowId

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -59,6 +59,42 @@ describe('updateConnection', () => {
     })
   })
 
+  describe('without a flow', () => {
+    it('should allow a user to update their own personal connection', async () => {
+      const result = await updateConnection(
+        null,
+        {
+          input: {
+            id: ownerConnection.id,
+            formattedData: { screenName: 'Updated from connections page' },
+          },
+        },
+        context,
+      )
+
+      expect(result.formattedData.screenName).toBe(
+        'Updated from connections page',
+      )
+    })
+
+    it('should not allow a user to update another user personal connection', async () => {
+      context.currentUser = editor
+
+      await expect(
+        updateConnection(
+          null,
+          {
+            input: {
+              id: ownerConnection.id,
+              formattedData: { screenName: 'Unauthorized update' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('Connection not found')
+    })
+  })
+
   describe('ownership guard', () => {
     it('should not allow editor to update owner personal connection shared to flow', async () => {
       // Setup: Owner's personal connection (userId = owner.id)

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -85,6 +85,32 @@ describe('verifyConnection', () => {
     })
   })
 
+  describe('without a flow', () => {
+    it('should allow a user to verify their own personal connection', async () => {
+      const result = await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id } },
+        context,
+      )
+
+      expect(result.id).toBe(ownerConnection.id)
+      expect(mocks.verifyCredentials).toHaveBeenCalledOnce()
+    })
+
+    it('should not allow a user to verify another user personal connection', async () => {
+      context.currentUser = editor
+
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id } },
+          context,
+        ),
+      ).rejects.toThrow('Connection not found')
+      expect(mocks.verifyCredentials).not.toHaveBeenCalled()
+    })
+  })
+
   describe('access control', () => {
     it('should allow owner to verify their personal connection', async () => {
       const result = await verifyConnection(

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -11,17 +11,26 @@ const updateConnection: MutationResolvers['updateConnection'] = async (
   params,
   context,
 ) => {
-  const flow = await context.currentUser
-    .withAccessibleFlows({ requiredRole: 'editor' })
-    .findById(params.input.flowId)
-    .throwIfNotFound({ message: 'You do not have access to this flow' })
+  let connection
 
-  let connection = await getConnection({
-    context,
-    connectionId: params.input.id,
-    flowId: params.input.flowId,
-    includeOwnConnections: flow.role === 'owner',
-  })
+  if (params.input.flowId) {
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findById(params.input.flowId)
+      .throwIfNotFound({ message: 'You do not have access to this flow' })
+
+    connection = await getConnection({
+      context,
+      connectionId: params.input.id,
+      flowId: params.input.flowId,
+      includeOwnConnections: flow.role === 'owner',
+    })
+  } else {
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findById(params.input.id)
+      .throwIfNotFound({ message: 'Connection not found' })
+  }
 
   // GUARD: Prevent updating personal connections owned by others
   if (

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -14,17 +14,26 @@ const verifyConnection: MutationResolvers['verifyConnection'] = async (
   params,
   context,
 ) => {
-  const flow = await context.currentUser
-    .withAccessibleFlows({ requiredRole: 'editor' })
-    .findById(params.input.flowId)
-    .throwIfNotFound()
+  let connection
 
-  let connection = await getConnection({
-    context,
-    connectionId: params.input.id,
-    flowId: params.input.flowId,
-    includeOwnConnections: flow.role === 'owner',
-  })
+  if (params.input.flowId) {
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findById(params.input.flowId)
+      .throwIfNotFound()
+
+    connection = await getConnection({
+      context,
+      connectionId: params.input.id,
+      flowId: params.input.flowId,
+      includeOwnConnections: flow.role === 'owner',
+    })
+  } else {
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findById(params.input.id)
+      .throwIfNotFound({ message: 'Connection not found' })
+  }
 
   // GUARD: Prevent updating personal connections owned by others
   if (

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -587,7 +587,7 @@ input GenerateAuthUrlInput {
 input UpdateConnectionInput {
   id: String!
   formattedData: JSONObject!
-  flowId: String!
+  flowId: String
 }
 
 input ResetConnectionInput {
@@ -596,7 +596,7 @@ input ResetConnectionInput {
 
 input VerifyConnectionInput {
   id: String!
-  flowId: String!
+  flowId: String
 }
 
 input DeleteConnectionInput {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack context

This is PR 1 of 5. The stack restores credential editing from the Connections page without exposing stored secrets.

## What

- make `flowId` optional for update and verify connection mutations
- scope no-flow operations to the current user's personal connections
- preserve the existing pipe-scoped access path
- add integration coverage for no-flow ownership

## Why

The Connections page has no pipe context. Backend support must exist before the app policy and safe replacement mutation can be added.

## Testing

Integration tests added. Local execution is blocked because the private npm package registry returns HTTP 401 during dependency installation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

