### PR TITLE
feat(connection-edit): add safe Connections page edit UI

### DIFF
--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -2,6 +2,7 @@ import type { IApp, IField, IJSONObject } from '@plumber/types'
 
 import * as React from 'react'
 import { FieldValues, SubmitHandler } from 'react-hook-form'
+import { useMutation } from '@apollo/client'
 import {
   Alert,
   AlertIcon,
@@ -16,6 +17,7 @@ import {
 import { Button, Infobox, Link } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
+import { REPLACE_CONNECTION_CREDENTIALS } from '@/graphql/mutations/replace-connection-credentials'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
 import { getOpenerOrigin } from '@/helpers/window'
@@ -43,10 +45,11 @@ export default function AddAppConnection(
   const { name, authDocUrl, key, auth } = application
   const [error, setError] = React.useState<IJSONObject | null>(null)
   const [inProgress, setInProgress] = React.useState(false)
+  const [replaceConnectionCredentials] = useMutation(
+    REPLACE_CONNECTION_CREDENTIALS,
+  )
   const hasConnection = Boolean(connectionId)
-  const steps = hasConnection
-    ? auth?.reconnectionSteps
-    : auth?.authenticationSteps
+  const steps = auth?.authenticationSteps
 
   React.useEffect(() => {
     if (
@@ -66,6 +69,37 @@ export default function AddAppConnection(
 
   const submitHandler: SubmitHandler<FieldValues> = React.useCallback(
     async (data) => {
+      if (hasConnection && connectionId) {
+        setInProgress(true)
+        setError(null)
+
+        try {
+          const result = await replaceConnectionCredentials({
+            variables: {
+              input: {
+                id: connectionId,
+                formattedData: data,
+              },
+            },
+            context: {
+              autoSnackbar: false,
+            },
+          })
+
+          onClose({
+            replaceConnectionCredentials:
+              result.data?.replaceConnectionCredentials,
+          })
+        } catch (err) {
+          const mutationError = err as IJSONObject
+          setError((mutationError.graphQLErrors as IJSONObject[])?.[0])
+        } finally {
+          setInProgress(false)
+        }
+
+        return
+      }
+
       if (!steps) {
         return
       }
@@ -107,7 +141,14 @@ export default function AddAppConnection(
 
       setInProgress(false)
     },
-    [connectionId, key, steps, onClose],
+    [
+      connectionId,
+      hasConnection,
+      key,
+      onClose,
+      replaceConnectionCredentials,
+      steps,
+    ],
   )
 
   if (auth?.connectionType !== 'user-added') {
@@ -186,7 +227,7 @@ export default function AddAppConnection(
                 data-test="create-connection-button"
                 isFullWidth
               >
-                Connect
+                {hasConnection ? 'Update connection' : 'Connect'}
               </Button>
             </VStack>
           </Form>

--- a/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
+++ b/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
@@ -22,7 +22,8 @@ type ContextMenuProps = {
 export default function ContextMenu(
   props: ContextMenuProps,
 ): React.ReactElement {
-  const { appKey, connectionId, supportsConnectionEdit, onMenuItemClick } = props
+  const { appKey, connectionId, supportsConnectionEdit, onMenuItemClick } =
+    props
 
   const createActionHandler = React.useCallback(
     (action: Action) => {

--- a/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
+++ b/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
@@ -7,19 +7,22 @@ import { IconButton } from '@opengovsg/design-system-react'
 import * as URLS from '@/config/urls'
 
 type Action = {
-  type: 'test' | 'delete' | 'viewFlows'
+  type: 'test' | 'edit' | 'delete' | 'viewFlows'
 }
 
 type ContextMenuProps = {
   appKey: string
   connectionId: string
+  // Whether the app's auth opted into credential editing; comes from the backend
+  // via GetAppConnections.
+  supportsConnectionEdit?: boolean
   onMenuItemClick: (event: React.MouseEvent, action: Action) => void
 }
 
 export default function ContextMenu(
   props: ContextMenuProps,
 ): React.ReactElement {
-  const { appKey, connectionId, onMenuItemClick } = props
+  const { appKey, connectionId, supportsConnectionEdit, onMenuItemClick } = props
 
   const createActionHandler = React.useCallback(
     (action: Action) => {
@@ -56,6 +59,16 @@ export default function ContextMenu(
           <MenuItem onClick={createActionHandler({ type: 'test' })}>
             Test connection
           </MenuItem>
+
+          {supportsConnectionEdit ? (
+            <MenuItem
+              as={Link}
+              to={URLS.APP_EDIT_CONNECTION(appKey, connectionId)}
+              onClick={createActionHandler({ type: 'edit' })}
+            >
+              Edit connection
+            </MenuItem>
+          ) : null}
 
           <MenuItem
             onClick={createActionHandler({ type: 'delete' })}

--- a/packages/frontend/src/components/AppConnectionRow/index.tsx
+++ b/packages/frontend/src/components/AppConnectionRow/index.tsx
@@ -23,6 +23,7 @@ import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 
 type AppConnectionRowProps = {
   connection: IConnection
+  supportsConnectionEdit?: boolean
 }
 
 function AppConnectionRow(props: AppConnectionRowProps): React.ReactElement {
@@ -177,6 +178,7 @@ function AppConnectionRow(props: AppConnectionRowProps): React.ReactElement {
             <ConnectionContextMenu
               appKey={key}
               connectionId={id}
+              supportsConnectionEdit={props.supportsConnectionEdit}
               onMenuItemClick={onContextMenuAction}
             />
           </Box>

--- a/packages/frontend/src/components/AppConnections/index.tsx
+++ b/packages/frontend/src/components/AppConnections/index.tsx
@@ -19,6 +19,9 @@ export default function AppConnections(
     variables: { key: appKey },
   })
   const appConnections: IConnection[] = data?.getApp?.connections || []
+  const supportsConnectionEdit: boolean = Boolean(
+    data?.getApp?.auth?.supportsConnectionEdit,
+  )
 
   const hasConnections = appConnections?.length
 
@@ -34,7 +37,11 @@ export default function AppConnections(
   return (
     <>
       {appConnections.map((appConnection: IConnection) => (
-        <AppConnectionRow key={appConnection.id} connection={appConnection} />
+        <AppConnectionRow
+          key={appConnection.id}
+          connection={appConnection}
+          supportsConnectionEdit={supportsConnectionEdit}
+        />
       ))}
     </>
   )

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -29,6 +29,10 @@ export const APP_FLOWS_FOR_CONNECTION = (
   appKey: string,
   connectionId: string,
 ): string => `/app/${appKey}/flows?connectionId=${connectionId}`
+export const APP_EDIT_CONNECTION = (
+  appKey: string,
+  connectionId: string,
+): string => `/app/${appKey}/connections/${connectionId}/edit`
 export const APP_FLOWS_PATTERN = '/app/:appKey/flows'
 
 export const EDITOR = '/editor'

--- a/packages/frontend/src/graphql/mutations/replace-connection-credentials.ts
+++ b/packages/frontend/src/graphql/mutations/replace-connection-credentials.ts
@@ -1,0 +1,17 @@
+import { graphql } from '../__generated__/gql'
+
+export const REPLACE_CONNECTION_CREDENTIALS = graphql(`
+  mutation ReplaceConnectionCredentials(
+    $input: ReplaceConnectionCredentialsInput
+  ) {
+    replaceConnectionCredentials(input: $input) {
+      id
+      key
+      verified
+      formattedData {
+        screenName
+        env
+      }
+    }
+  }
+`)

--- a/packages/frontend/src/graphql/queries/get-app-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-app-connections.ts
@@ -4,6 +4,9 @@ export const GET_APP_CONNECTIONS = gql`
   query GetAppConnections($key: String!, $flowId: String) {
     getApp(key: $key, flowId: $flowId) {
       key
+      auth {
+        supportsConnectionEdit
+      }
       connections {
         id
         key

--- a/packages/frontend/src/graphql/queries/get-app.ts
+++ b/packages/frontend/src/graphql/queries/get-app.ts
@@ -12,6 +12,7 @@ export const GET_APP = gql`
       auth {
         connectionType
         connectionRegistrationType
+        supportsConnectionEdit
         fields {
           key
           label

--- a/packages/frontend/src/pages/Application/index.tsx
+++ b/packages/frontend/src/pages/Application/index.tsx
@@ -24,6 +24,24 @@ type ApplicationParams = {
   connectionId?: string
 }
 
+function EditConnection({
+  application,
+  onClose,
+}: {
+  application: Parameters<typeof AddAppConnection>[0]['application']
+  onClose: () => void
+}): React.ReactElement {
+  const { connectionId } = useParams() as ApplicationParams
+
+  return (
+    <AddAppConnection
+      onClose={onClose}
+      application={application}
+      connectionId={connectionId}
+    />
+  )
+}
+
 export default function Application(): React.ReactElement | null {
   const connectionsPathMatch = useMatch({
     path: URLS.APP_CONNECTIONS_PATTERN,
@@ -34,7 +52,7 @@ export default function Application(): React.ReactElement | null {
   const navigate = useNavigate()
   const { data, loading } = useQuery(GET_APP, { variables: { key: appKey } })
 
-  const goToApplicationPage = () => navigate('connections')
+  const goToApplicationPage = () => navigate(URLS.APP_CONNECTIONS(appKey))
   const app = data?.getApp || {}
 
   if (loading) {
@@ -126,6 +144,14 @@ export default function Application(): React.ReactElement | null {
             <AddAppConnection onClose={goToApplicationPage} application={app} />
           }
         />
+        {app.auth?.supportsConnectionEdit ? (
+          <Route
+            path="/connections/:connectionId/edit"
+            element={
+              <EditConnection application={app} onClose={goToApplicationPage} />
+            }
+          />
+        ) : null}
       </Routes>
     </>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack context

This is PR 4 of 5. It depends on the safe persist-once mutation in the PR below.

## What

- show Edit connection only when backend app auth allows it
- add the Connections page edit route
- submit edits through `replaceConnectionCredentials`
- keep the existing add-connection flow unchanged
- keep secret inputs blank

## Why

Users need to replace credentials from the Connections page. The UI must use the safe mutation instead of the destructive reconnection steps.

## Testing

Local execution is blocked because the private npm package registry returns HTTP 401 during dependency installation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12db8616-920e-415a-a82a-65b046b1c0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12db8616-920e-415a-a82a-65b046b1c0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

