### PR TITLE
fix(ai-builder): show the session-expired toast when the chat session expires

### DIFF
--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -4,8 +4,8 @@ import { Flex, Link, Text } from '@chakra-ui/react'
 import { Button, Infobox, useToast } from '@opengovsg/design-system-react'
 
 import { NOT_AUTHORISED } from '@/config/errors'
-import * as URLS from '@/config/urls'
 import { createClient } from '@/graphql/client'
+import { redirectToLogin } from '@/helpers/redirectToLogin'
 
 type ApolloProviderProps = {
   children: React.ReactNode
@@ -32,13 +32,7 @@ const SessionExpiredToast = () => {
           colorScheme="yellow"
           variant="outline"
           size="sm"
-          onClick={() => {
-            const redirectQueryParam =
-              window.location.pathname + window.location.search
-            window.location.href = URLS.ADD_REDIRECT_TO_LOGIN(
-              encodeURIComponent(redirectQueryParam),
-            )
-          }}
+          onClick={redirectToLogin}
         >
           Login
         </Button>

--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -1,72 +1,31 @@
 import { useCallback, useMemo } from 'react'
 import { ApolloProvider as BaseApolloProvider } from '@apollo/client'
-import { Flex, Link, Text } from '@chakra-ui/react'
-import { Button, Infobox, useToast } from '@opengovsg/design-system-react'
+import { Link } from '@chakra-ui/react'
+import { useToast } from '@opengovsg/design-system-react'
 
 import { NOT_AUTHORISED } from '@/config/errors'
 import { createClient } from '@/graphql/client'
-import { redirectToLogin } from '@/helpers/redirectToLogin'
+import { useSessionExpiredToast } from '@/hooks/useSessionExpiredToast'
 
 type ApolloProviderProps = {
   children: React.ReactNode
 }
 
-const SessionExpiredToast = () => {
-  return (
-    <Infobox
-      alignItems="center"
-      variant="warning"
-      justifyContent="space-between"
-      borderRadius="md"
-      border="1px solid"
-      w="500px"
-      maxW="90vw"
-      borderColor="interaction.warning.default"
-      style={{
-        padding: '0.5rem 1rem',
-      }}
-    >
-      <Flex w="100%" justifyContent="space-between" alignItems="center">
-        <Text>Session expired. Please login again.</Text>
-        <Button
-          colorScheme="yellow"
-          variant="outline"
-          size="sm"
-          onClick={redirectToLogin}
-        >
-          Login
-        </Button>
-      </Flex>
-    </Infobox>
-  )
-}
-
 const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
   const toast = useToast()
-
-  const showSessionExpiredToast = useCallback(
-    (id: string) => {
-      toast({
-        id,
-        duration: null,
-        isClosable: false,
-        position: 'top',
-        render: SessionExpiredToast,
-      })
-    },
-    [toast],
-  )
+  const showSessionExpiredToast = useSessionExpiredToast()
 
   const onError = useCallback(
     (message: string) => {
+      if (message === NOT_AUTHORISED) {
+        showSessionExpiredToast()
+        return
+      }
+
       // HACKFIX: we use this toast.isActive to prevent duplicate toasts from being shown.
       // there should be a better way to handle this from the ApolloClient.
       const id = `graphql-error-${message.slice(0, 15)}`
       if (!toast.isActive(id)) {
-        if (message === NOT_AUTHORISED) {
-          showSessionExpiredToast(id)
-          return
-        }
         toast({
           id,
           title: message,

--- a/packages/frontend/src/components/RedirectToLogin/index.tsx
+++ b/packages/frontend/src/components/RedirectToLogin/index.tsx
@@ -1,12 +1,7 @@
 import { Navigate } from 'react-router-dom'
 
-import * as URLS from '../../config/urls'
+import { getLoginRedirectHref } from '@/helpers/redirectToLogin'
 
 export default function RedirectToLogin(): React.ReactElement {
-  const redirectQueryParam = window.location.pathname + window.location.search
-  return (
-    <Navigate
-      to={URLS.ADD_REDIRECT_TO_LOGIN(encodeURIComponent(redirectQueryParam))}
-    />
-  )
+  return <Navigate to={getLoginRedirectHref()} />
 }

--- a/packages/frontend/src/components/SessionExpiredToast/index.tsx
+++ b/packages/frontend/src/components/SessionExpiredToast/index.tsx
@@ -1,0 +1,40 @@
+import { Flex, Text } from '@chakra-ui/react'
+import { Button, Infobox } from '@opengovsg/design-system-react'
+
+import { redirectToLogin } from '@/helpers/redirectToLogin'
+
+/**
+ * Shared by every source that can detect an expired session (GraphQL and the
+ * REST chat API), so a single expiry can't stack duplicate toasts.
+ */
+export const SESSION_EXPIRED_TOAST_ID = 'session-expired'
+
+export default function SessionExpiredToast(): React.ReactElement {
+  return (
+    <Infobox
+      alignItems="center"
+      variant="warning"
+      justifyContent="space-between"
+      borderRadius="md"
+      border="1px solid"
+      w="500px"
+      maxW="90vw"
+      borderColor="interaction.warning.default"
+      style={{
+        padding: '0.5rem 1rem',
+      }}
+    >
+      <Flex w="100%" justifyContent="space-between" alignItems="center">
+        <Text>Session expired. Please login again.</Text>
+        <Button
+          colorScheme="yellow"
+          variant="outline"
+          size="sm"
+          onClick={redirectToLogin}
+        >
+          Login
+        </Button>
+      </Flex>
+    </Infobox>
+  )
+}

--- a/packages/frontend/src/helpers/__tests__/redirectToLogin.test.ts
+++ b/packages/frontend/src/helpers/__tests__/redirectToLogin.test.ts
@@ -1,23 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { NOT_AUTHORISED } from '@/config/errors'
+import { getLoginRedirectHref } from '../redirectToLogin'
 
-import { getLoginRedirectHref, isNotAuthorisedError } from '../redirectToLogin'
-
-describe('redirectToLogin helpers', () => {
+describe('getLoginRedirectHref', () => {
   it('encodes the current path as a login redirect query param', () => {
     expect(getLoginRedirectHref('/editor/ai')).toBe(
       '/login/?redirect=%2Feditor%2Fai',
     )
-  })
-
-  it('detects the backend not-authorised message and JSON error bodies', () => {
-    expect(isNotAuthorisedError({ message: NOT_AUTHORISED })).toBe(true)
-    expect(
-      isNotAuthorisedError({
-        message: JSON.stringify({ error: NOT_AUTHORISED }),
-      }),
-    ).toBe(true)
-    expect(isNotAuthorisedError({ message: 'Failed to fetch' })).toBe(false)
   })
 })

--- a/packages/frontend/src/helpers/__tests__/redirectToLogin.test.ts
+++ b/packages/frontend/src/helpers/__tests__/redirectToLogin.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { NOT_AUTHORISED } from '@/config/errors'
+
+import { getLoginRedirectHref, isNotAuthorisedError } from '../redirectToLogin'
+
+describe('redirectToLogin helpers', () => {
+  it('encodes the current path as a login redirect query param', () => {
+    expect(getLoginRedirectHref('/editor/ai')).toBe(
+      '/login/?redirect=%2Feditor%2Fai',
+    )
+  })
+
+  it('detects the backend not-authorised message and JSON error bodies', () => {
+    expect(isNotAuthorisedError({ message: NOT_AUTHORISED })).toBe(true)
+    expect(
+      isNotAuthorisedError({
+        message: JSON.stringify({ error: NOT_AUTHORISED }),
+      }),
+    ).toBe(true)
+    expect(isNotAuthorisedError({ message: 'Failed to fetch' })).toBe(false)
+  })
+})

--- a/packages/frontend/src/helpers/redirectToLogin.ts
+++ b/packages/frontend/src/helpers/redirectToLogin.ts
@@ -1,4 +1,3 @@
-import { NOT_AUTHORISED } from '@/config/errors'
 import * as URLS from '@/config/urls'
 
 export function getLoginRedirectHref(
@@ -9,9 +8,4 @@ export function getLoginRedirectHref(
 
 export function redirectToLogin(): void {
   window.location.href = getLoginRedirectHref()
-}
-
-export function isNotAuthorisedError(error: { message?: string }): boolean {
-  const message = error.message ?? ''
-  return message === NOT_AUTHORISED || message.includes(NOT_AUTHORISED)
 }

--- a/packages/frontend/src/helpers/redirectToLogin.ts
+++ b/packages/frontend/src/helpers/redirectToLogin.ts
@@ -1,0 +1,17 @@
+import { NOT_AUTHORISED } from '@/config/errors'
+import * as URLS from '@/config/urls'
+
+export function getLoginRedirectHref(
+  pathnameAndSearch: string = window.location.pathname + window.location.search,
+): string {
+  return URLS.ADD_REDIRECT_TO_LOGIN(encodeURIComponent(pathnameAndSearch))
+}
+
+export function redirectToLogin(): void {
+  window.location.href = getLoginRedirectHref()
+}
+
+export function isNotAuthorisedError(error: { message?: string }): boolean {
+  const message = error.message ?? ''
+  return message === NOT_AUTHORISED || message.includes(NOT_AUTHORISED)
+}

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -8,6 +8,10 @@ import { useToast } from '@opengovsg/design-system-react'
 import { DefaultChatTransport } from 'ai'
 
 import * as URLS from '@/config/urls'
+import {
+  isNotAuthorisedError,
+  redirectToLogin,
+} from '@/helpers/redirectToLogin'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import { MAX_MESSAGES } from '@/pages/AiBuilder/constants'
 import {
@@ -187,6 +191,15 @@ export function useChatStream(options: UseChatStreamOptions) {
     transport: new DefaultChatTransport({
       api: '/api/chat',
       credentials: 'include',
+      fetch: async (input, init) => {
+        const response = await fetch(input, init)
+        // REST chat bypasses Apollo, so expired sessions would otherwise toast
+        // the raw 401 body instead of sending the user back to login.
+        if (response.status === 401) {
+          redirectToLogin()
+        }
+        return response
+      },
       prepareSendMessagesRequest: ({ messages }) => {
         // Filter out any initialMessages already tracked by the AI SDK to avoid
         // duplicates (the SDK accumulates messages across exchanges in its own state)
@@ -269,6 +282,10 @@ export function useChatStream(options: UseChatStreamOptions) {
       },
     }),
     onError: (error: Error) => {
+      if (isNotAuthorisedError(error)) {
+        redirectToLogin()
+        return
+      }
       toast({
         title: 'Error: ' + error.message,
         status: 'error',

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -7,11 +7,9 @@ import { useChat } from '@ai-sdk/react'
 import { useToast } from '@opengovsg/design-system-react'
 import { DefaultChatTransport } from 'ai'
 
+import { NOT_AUTHORISED } from '@/config/errors'
 import * as URLS from '@/config/urls'
-import {
-  isNotAuthorisedError,
-  redirectToLogin,
-} from '@/helpers/redirectToLogin'
+import { redirectToLogin } from '@/helpers/redirectToLogin'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import { MAX_MESSAGES } from '@/pages/AiBuilder/constants'
 import {
@@ -197,6 +195,7 @@ export function useChatStream(options: UseChatStreamOptions) {
         // the raw 401 body instead of sending the user back to login.
         if (response.status === 401) {
           redirectToLogin()
+          throw new Error(NOT_AUTHORISED)
         }
         return response
       },
@@ -282,8 +281,7 @@ export function useChatStream(options: UseChatStreamOptions) {
       },
     }),
     onError: (error: Error) => {
-      if (isNotAuthorisedError(error)) {
-        redirectToLogin()
+      if (error.message === NOT_AUTHORISED) {
         return
       }
       toast({

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -9,7 +9,7 @@ import { DefaultChatTransport } from 'ai'
 
 import { NOT_AUTHORISED } from '@/config/errors'
 import * as URLS from '@/config/urls'
-import { redirectToLogin } from '@/helpers/redirectToLogin'
+import { useSessionExpiredToast } from '@/hooks/useSessionExpiredToast'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import { MAX_MESSAGES } from '@/pages/AiBuilder/constants'
 import {
@@ -130,6 +130,7 @@ export interface UseChatStreamOptions {
 
 export function useChatStream(options: UseChatStreamOptions) {
   const toast = useToast()
+  const showSessionExpiredToast = useSessionExpiredToast()
   const navigate = useNavigate()
   const location = useLocation()
   const { ddSessionId, output, chatId, refetchTestExecutionSteps } =
@@ -191,10 +192,10 @@ export function useChatStream(options: UseChatStreamOptions) {
       credentials: 'include',
       fetch: async (input, init) => {
         const response = await fetch(input, init)
-        // REST chat bypasses Apollo, so expired sessions would otherwise toast
-        // the raw 401 body instead of sending the user back to login.
+        // REST chat bypasses Apollo's error link, so an expired session would
+        // otherwise surface as a raw "Not Authorised!" error toast.
         if (response.status === 401) {
-          redirectToLogin()
+          showSessionExpiredToast()
           throw new Error(NOT_AUTHORISED)
         }
         return response
@@ -281,6 +282,7 @@ export function useChatStream(options: UseChatStreamOptions) {
       },
     }),
     onError: (error: Error) => {
+      // The fetch wrapper above already showed the session-expired toast.
       if (error.message === NOT_AUTHORISED) {
         return
       }

--- a/packages/frontend/src/hooks/useSessionExpiredToast.ts
+++ b/packages/frontend/src/hooks/useSessionExpiredToast.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react'
+import { useToast } from '@opengovsg/design-system-react'
+
+import SessionExpiredToast, {
+  SESSION_EXPIRED_TOAST_ID,
+} from '@/components/SessionExpiredToast'
+
+/**
+ * Returns a callback that shows the session-expired toast, letting the user
+ * choose when to log in rather than navigating away from unsaved work.
+ */
+export function useSessionExpiredToast(): () => void {
+  const toast = useToast()
+
+  return useCallback(() => {
+    if (toast.isActive(SESSION_EXPIRED_TOAST_ID)) {
+      return
+    }
+    toast({
+      id: SESSION_EXPIRED_TOAST_ID,
+      duration: null,
+      isClosable: false,
+      position: 'top',
+      render: SessionExpiredToast,
+    })
+  }, [toast])
+}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -6,7 +6,9 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { CloseButton, Container, Flex, HStack, Text } from '@chakra-ui/react'
 
 import AddAppConnection from '@/components/AddAppConnection'
+import RedirectToLogin from '@/components/RedirectToLogin'
 import * as URLS from '@/config/urls'
+import useAuthentication from '@/hooks/useAuthentication'
 import { useChatStream } from '@/hooks/useChatStream'
 import { useNavigationGuard } from '@/hooks/useNavigationGuard'
 import { usePersistedState } from '@/hooks/usePersistedState'
@@ -404,7 +406,7 @@ function AiBuilderContent() {
   )
 }
 
-export default function AiBuilder() {
+function AiBuilderDraft() {
   const locationState = useLocation()?.state
 
   // Persist state to sessionStorage so it survives refresh.
@@ -457,4 +459,13 @@ export default function AiBuilder() {
       <AiBuilderContent />
     </AiBuilderContextProvider>
   )
+}
+
+export default function AiBuilder(): React.ReactElement {
+  const { currentUser } = useAuthentication()
+
+  if (!currentUser) {
+    return <RedirectToLogin />
+  }
+  return <AiBuilderDraft />
 }

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -406,7 +406,7 @@ function AiBuilderContent() {
   )
 }
 
-function AiBuilderDraft() {
+function AiBuilderDraftProvider() {
   const locationState = useLocation()?.state
 
   // Persist state to sessionStorage so it survives refresh.
@@ -467,5 +467,5 @@ export default function AiBuilder(): React.ReactElement {
   if (!currentUser) {
     return <RedirectToLogin />
   }
-  return <AiBuilderDraft />
+  return <AiBuilderDraftProvider />
 }

--- a/packages/frontend/src/pages/Editor/routes.tsx
+++ b/packages/frontend/src/pages/Editor/routes.tsx
@@ -6,15 +6,25 @@ import FlowCollaborators from '@/components/EditorSettings/FlowCollaborators'
 import FlowConnections from '@/components/EditorSettings/FlowConnections'
 import FlowTransfer from '@/components/EditorSettings/FlowTransfer'
 import Notifications from '@/components/EditorSettings/Notifications'
+import RedirectToLogin from '@/components/RedirectToLogin'
+import useAuthentication from '@/hooks/useAuthentication'
 
 import AiBuilder from '../AiBuilder'
 
 import EditorPage from './index'
 
+function AuthenticatedAiBuilder() {
+  const { currentUser } = useAuthentication()
+  if (!currentUser) {
+    return <RedirectToLogin />
+  }
+  return <AiBuilder />
+}
+
 export default function EditorRoutes(): React.ReactElement {
   return (
     <Routes>
-      <Route path="/ai" element={<AiBuilder />} />
+      <Route path="/ai" element={<AuthenticatedAiBuilder />} />
       <Route path="/:flowId" element={<EditorPage />} />
 
       <Route

--- a/packages/frontend/src/pages/Editor/routes.tsx
+++ b/packages/frontend/src/pages/Editor/routes.tsx
@@ -6,25 +6,15 @@ import FlowCollaborators from '@/components/EditorSettings/FlowCollaborators'
 import FlowConnections from '@/components/EditorSettings/FlowConnections'
 import FlowTransfer from '@/components/EditorSettings/FlowTransfer'
 import Notifications from '@/components/EditorSettings/Notifications'
-import RedirectToLogin from '@/components/RedirectToLogin'
-import useAuthentication from '@/hooks/useAuthentication'
 
 import AiBuilder from '../AiBuilder'
 
 import EditorPage from './index'
 
-function AuthenticatedAiBuilder() {
-  const { currentUser } = useAuthentication()
-  if (!currentUser) {
-    return <RedirectToLogin />
-  }
-  return <AiBuilder />
-}
-
 export default function EditorRoutes(): React.ReactElement {
   return (
     <Routes>
-      <Route path="/ai" element={<AuthenticatedAiBuilder />} />
+      <Route path="/ai" element={<AiBuilder />} />
       <Route path="/:flowId" element={<EditorPage />} />
 
       <Route


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

AI Builder talks to `/api/chat` (REST), not GraphQL. When the session expires, `requireAuthentication` returns 401 `{ error: 'Not Authorised!' }`. Apollo's error link never sees it, so instead of the familiar "Session expired. Please login again." toast the user gets a raw `Error: Not Authorised!` toast that auto-dismisses after 3s.

## Approach

Match what `/editor/<flow-id>` already does, rather than force-navigating away from an in-progress chat.

- Extracted `SessionExpiredToast` out of `ApolloProvider` into its own component, plus a `useSessionExpiredToast()` hook that owns the toast options and de-duplication.
- Chat `fetch` on HTTP 401 shows that toast and throws `NOT_AUTHORISED`, which `onError` swallows so the raw 401 body is never toasted.
- Both sources share one toast id, so a GraphQL 401 and a chat 401 arriving together produce one toast instead of two.
- Guarded the `AiBuilder` page against the logged-out case (open or refresh) the same way `pages/Editor/index.tsx` guards the flow editor: a thin page component calls `useAuthentication()` and returns `RedirectToLogin`, with the draft-persistence hooks moved into an inner `AiBuilderDraftProvider`. The route table is untouched. This does not fire mid-session, since `GET_CURRENT_USER` is fetched on mount and not polled.

The user keeps their chat on screen and clicks Login when ready. The Login button does a full page load to `/login/?redirect=…`, so Apollo and auth state reset cleanly, and login returns them to `/editor/ai`.

## Test plan

- [x] `npx vitest run --project frontend` (203 passed), `tsc --noEmit`, `eslint`
- [ ] Manual: on `/editor/ai`, expire the session, send a message. Expect the session-expired toast, chat still on screen, no auto-navigation.
- [ ] Manual: click Login on that toast. Expect `/login/?redirect=%2Feditor%2Fai`, and a return to the builder after login.
- [ ] Manual: open `/editor/ai` while logged out. Expect an immediate redirect to login.
- [ ] Manual: a GraphQL 401 elsewhere still shows one toast, and other GraphQL errors still show the generic error toast.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3c29f01-96bb-4310-b832-ac89a7be365e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3c29f01-96bb-4310-b832-ac89a7be365e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

Resolves PLU-779