### PR TITLE
chore: what's new for Pair actions

### DIFF
--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -11,6 +11,22 @@ const IF_THEN_EXTERNAL_LINK =
   'https://guide.plumber.gov.sg/user-guides/actions/toolbox'
 export const NEWS_ITEM_LIST: NewsItemProps[] = [
   {
+    date: '2026-08-31',
+    tag: NEW_FEATURE_TAG,
+    title: '🤖 Introducing Pair actions',
+    details: dedent`
+      Pair brings AI into your pipe with two new actions.
+
+      * **Process image** — Extract data from an image or PDF, like fields from a scanned form.
+      * **Process text** — Summarise, categorise, or write text based on your own prompt.
+
+      Read how to set it up [here](https://guide.plumber.gov.sg/user-guides/actions/pair).
+    `,
+    multimedia: {
+      url: 'https://file.go.gov.sg/plumber-x-pair.png',
+    },
+  },
+  {
     date: '2026-07-21',
     tag: NEW_ENHANCEMENT_TAG,
     title: 'OR conditions for If-then and Only continue if',


### PR DESCRIPTION
## TL;DR

Writes the "What's new" description for the Pair actions release.

## What changed?

The Pair news item had a copy-pasted MRF description instead of describing what Pair actually does. Updated it to describe both actions (Process image, Process text) and link the actions guide.

## Tests

- [ ] Open the What's new drawer and confirm the Pair entry renders correctly, including the bullet list and link.

## Deploy notes

None.
