### PR TITLE
fix: pair template if-then params

### DIFF
--- a/packages/backend/src/db/storage/attendance-taking-v2.ts
+++ b/packages/backend/src/db/storage/attendance-taking-v2.ts
@@ -54,10 +54,14 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
         branchName: 'New event attendance',
         conditions: [
           {
-            is: 'is',
-            text: '0',
-            field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: '0',
+                field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },
@@ -101,10 +105,14 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
         branchName: 'Update existing attendance',
         conditions: [
           {
-            is: 'not',
-            text: '0',
-            field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'not',
+                text: '0',
+                field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },

--- a/packages/backend/src/db/storage/route-support-enquiries-with-pair.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries-with-pair.ts
@@ -50,12 +50,16 @@ function createDivisionBranch(
       branchName: division,
       conditions: [
         {
-          is: 'is',
-          text: division,
-          field: CREATE_TEMPLATE_STEP_VARIABLE(
-            'Replace with department from step 2',
-          ),
-          condition: 'equals',
+          rows: [
+            {
+              is: 'is',
+              text: division,
+              field: CREATE_TEMPLATE_STEP_VARIABLE(
+                'Replace with department from step 2',
+              ),
+              condition: 'equals',
+            },
+          ],
         },
       ],
     },

--- a/packages/backend/src/db/storage/route-support-enquiries.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries.ts
@@ -31,12 +31,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
         branchName: 'Resetting device',
         conditions: [
           {
-            is: 'is',
-            text: 'Resetting device',
-            field: CREATE_TEMPLATE_STEP_VARIABLE(
-              'Replace with response 1 request',
-            ),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: 'Resetting device',
+                field: CREATE_TEMPLATE_STEP_VARIABLE(
+                  'Replace with response 1 request',
+                ),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },
@@ -67,12 +71,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
         branchName: 'Damaged device',
         conditions: [
           {
-            is: 'is',
-            text: 'Damaged device',
-            field: CREATE_TEMPLATE_STEP_VARIABLE(
-              'Replace with response 1 request',
-            ),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: 'Damaged device',
+                field: CREATE_TEMPLATE_STEP_VARIABLE(
+                  'Replace with response 1 request',
+                ),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },
@@ -103,12 +111,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
         branchName: 'Lost device',
         conditions: [
           {
-            is: 'is',
-            text: 'Lost device',
-            field: CREATE_TEMPLATE_STEP_VARIABLE(
-              'Replace with response 1 request',
-            ),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: 'Lost device',
+                field: CREATE_TEMPLATE_STEP_VARIABLE(
+                  'Replace with response 1 request',
+                ),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },
@@ -139,12 +151,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
         branchName: 'New device',
         conditions: [
           {
-            is: 'is',
-            text: 'New device',
-            field: CREATE_TEMPLATE_STEP_VARIABLE(
-              'Replace with response 1 request',
-            ),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: 'New device',
+                field: CREATE_TEMPLATE_STEP_VARIABLE(
+                  'Replace with response 1 request',
+                ),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },

--- a/packages/backend/src/db/storage/update-mailing-lists-v2.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists-v2.ts
@@ -53,10 +53,14 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
         branchName: 'Officer has not signed up for the mailing list',
         conditions: [
           {
-            is: 'is',
-            text: '0',
-            field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'is',
+                text: '0',
+                field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },
@@ -98,10 +102,14 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
         branchName: 'Officer has signed up for the mailing list',
         conditions: [
           {
-            is: 'not',
-            text: '0',
-            field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
-            condition: 'equals',
+            rows: [
+              {
+                is: 'not',
+                text: '0',
+                field: CREATE_TEMPLATE_STEP_VARIABLE('rowsFound', 2),
+                condition: 'equals',
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Problem
* If-then templates were not working because the format of parameters were wrong.

## Solution
* Update parameters to `v2` format across all templates using if-then (pair, route support enquiries, attendance taking, update mailing lists).