### PR TITLE
fix(frontend): lazy-load announcement modal Lottie JSON

### DIFF
--- a/packages/frontend/src/components/AnnouncementModal/AnnouncementItem.tsx
+++ b/packages/frontend/src/components/AnnouncementModal/AnnouncementItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { Components } from 'react-markdown'
 import {
   Box,
@@ -59,9 +59,7 @@ function LazyLottieAnimation({
   title: string
   loader: () => Promise<AnimationData>
 }) {
-  const [animationData, setAnimationData] = useState<AnimationData | null>(
-    null,
-  )
+  const [animationData, setAnimationData] = useState<AnimationData | null>(null)
 
   useEffect(() => {
     let cancelled = false

--- a/packages/frontend/src/components/AnnouncementModal/AnnouncementItem.tsx
+++ b/packages/frontend/src/components/AnnouncementModal/AnnouncementItem.tsx
@@ -1,18 +1,29 @@
-import { useMemo } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Components } from 'react-markdown'
-import { Box, Image, ModalBody, ModalHeader, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Image,
+  ModalBody,
+  ModalHeader,
+  Skeleton,
+  Text,
+} from '@chakra-ui/react'
 import { AnimationConfigWithData } from 'lottie-web'
 import { RequireExactlyOne } from 'type-fest'
 
 import MarkdownRenderer from '@/components/MarkdownRenderer'
 import LottieWebAnimation from '@/components/NewsDrawer/LottieWebAnimation'
 
+type AnimationData = AnimationConfigWithData['animationData']
+
 type AnnouncementItemMultimedia = RequireExactlyOne<
   {
     url: string
-    animationData: AnimationConfigWithData['animationData']
+    animationData: AnimationData
+    // Dynamic import keeps large Lottie JSON out of the main bundle.
+    animationDataLoader: () => Promise<AnimationData>
   },
-  'url' | 'animationData'
+  'url' | 'animationData' | 'animationDataLoader'
 >
 
 export interface AnnouncementItemProps {
@@ -41,21 +52,57 @@ const mdComponents: Components = {
   },
 }
 
+function LazyLottieAnimation({
+  title,
+  loader,
+}: {
+  title: string
+  loader: () => Promise<AnimationData>
+}) {
+  const [animationData, setAnimationData] = useState<AnimationData | null>(
+    null,
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    void loader().then((data) => {
+      if (!cancelled) {
+        setAnimationData(data)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [loader])
+
+  if (!animationData) {
+    // 16:9 placeholder matching the 1920×1080 Lottie canvases
+    return <Skeleton borderTopRadius="lg" w="100%" aspectRatio={16 / 9} />
+  }
+
+  return <LottieWebAnimation title={title} animationData={animationData} />
+}
+
 export default function AnnouncementItem(props: AnnouncementItemProps) {
   const { title, details, multimedia } = props
-  const displayedMultimedia = useMemo(() => {
-    if (!multimedia) {
-      return
-    }
-    if (multimedia.animationData) {
-      return (
-        <LottieWebAnimation
-          title={title}
-          animationData={multimedia.animationData}
-        />
-      )
-    }
-    return (
+
+  let displayedMultimedia: ReactNode
+  if (multimedia?.animationDataLoader) {
+    displayedMultimedia = (
+      <LazyLottieAnimation
+        title={title}
+        loader={multimedia.animationDataLoader}
+      />
+    )
+  } else if (multimedia?.animationData) {
+    displayedMultimedia = (
+      <LottieWebAnimation
+        title={title}
+        animationData={multimedia.animationData}
+      />
+    )
+  } else if (multimedia?.url) {
+    displayedMultimedia = (
       <Image
         borderTopRadius="lg"
         fit="fill"
@@ -64,7 +111,7 @@ export default function AnnouncementItem(props: AnnouncementItemProps) {
         alt={title}
       />
     )
-  }, [multimedia, title])
+  }
 
   return (
     <>

--- a/packages/frontend/src/components/AnnouncementModal/AnnouncementItemList.ts
+++ b/packages/frontend/src/components/AnnouncementModal/AnnouncementItemList.ts
@@ -1,17 +1,20 @@
-import aiBuilderV2Animation1 from './assets/ai_builder_v2_1.json'
-import aiBuilderV2Animation2 from './assets/ai_builder_v2_2.json'
-import aiBuilderV2Animation3 from './assets/ai_builder_v2_3.json'
 import { AnnouncementItemProps } from './AnnouncementItem'
 
-// TODO: add a `multimedia` image/animation to each item once the AI Builder
-// screenshots are hosted (see NewsItemList for the file.go.gov.sg convention).
+// Module-level loaders so LazyLottieAnimation gets stable function identities.
+const loadAiBuilderV2Animation1 = () =>
+  import('./assets/ai_builder_v2_1.json').then((m) => m.default)
+const loadAiBuilderV2Animation2 = () =>
+  import('./assets/ai_builder_v2_2.json').then((m) => m.default)
+const loadAiBuilderV2Animation3 = () =>
+  import('./assets/ai_builder_v2_3.json').then((m) => m.default)
+
 export const ANNOUNCEMENT_ITEM_LIST: AnnouncementItemProps[] = [
   {
     title: 'Describe your workflow and AI Builder builds it',
     details:
       'Say what you want to happen in plain English. It now fills in the step fields too, not just the outline, so you get a working pipe rather than a starting point.',
     multimedia: {
-      animationData: aiBuilderV2Animation1,
+      animationDataLoader: loadAiBuilderV2Animation1,
     },
   },
   {
@@ -19,7 +22,7 @@ export const ANNOUNCEMENT_ITEM_LIST: AnnouncementItemProps[] = [
     details:
       'Paste your form link and AI Builder suggests what you could automate with it. Pick one and it builds the pipe for you.',
     multimedia: {
-      animationData: aiBuilderV2Animation2,
+      animationDataLoader: loadAiBuilderV2Animation2,
     },
   },
   {
@@ -27,7 +30,7 @@ export const ANNOUNCEMENT_ITEM_LIST: AnnouncementItemProps[] = [
     details:
       'The preview is the real editor, so you can see exactly what AI Builder filled in, down to the variable pills and field labels. Nothing runs until you publish.',
     multimedia: {
-      animationData: aiBuilderV2Animation3,
+      animationDataLoader: loadAiBuilderV2Animation3,
     },
   },
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the review note on #2081: the three AI Builder v2 Lottie files (~16.9 MB raw / ~10.6 MB gzipped) were statically imported into `AnnouncementItemList`, so they shipped with the main frontend bundle via the eagerly loaded Flows route.

## Changes

- Replace static JSON imports with module-level `import()` loaders (`animationDataLoader`)
- `AnnouncementItem` loads animation data on demand and shows a 16:9 skeleton while fetching
- Remove the stale TODO about hosting screenshots (multimedia is already wired)

## Notes

`file.go.gov.sg` cannot host `.json` (not in GoGovSG’s allowed file types), and our CSP only allows that host under `imgSrc` anyway. Lazy dynamic imports keep the files local while still keeping them out of the main graph.

Further size reduction (these are `lfvideo2lottie` full-frame WebP sequences at 1920×1080) is still worth doing separately.

## Test plan

- [ ] With AI Builder flag on and no dismissal, open `/flows` — modal appears; first slide animation loads after a brief skeleton
- [ ] Click Next through slides 2 and 3 — each animation loads independently
- [ ] Confirm network/devtools: Lottie JSON chunks are not requested until the modal slide needs them
- [ ] Primary action / close still dismisses as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05ad4-e357-798c-9b8e-fddc34f42f5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05ad4-e357-798c-9b8e-fddc34f42f5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

