### PR TITLE
chore(ai-builder): generic empty-state copy, quieter unsaved notice, stacked step params

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -145,7 +145,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
       >
         <Flex flexDir="column" gap="1.5rem" w="full" maxW="2xl">
           <Text textStyle="h3" textAlign="left">
-            How can we help?
+            What do you want to automate?
           </Text>
           <PromptInput
             sendMessage={sendMessage}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -7,7 +7,7 @@ import * as URLS from '@/config/urls'
 import { Message } from '@/hooks/useChatStream'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import ChatMessages from '@/pages/AiBuilder/components/ChatMessages'
-import { PLACEHOLDER_MESSAGES } from '@/pages/AiBuilder/constants'
+import { PLACEHOLDER_MESSAGE } from '@/pages/AiBuilder/constants'
 import { buildSupportFormUrl } from '@/pages/AiBuilder/helpers'
 import { createNewChatDraft } from '@/pages/AiBuilder/new-chat'
 
@@ -145,7 +145,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
       >
         <Flex flexDir="column" gap="1.5rem" w="full" maxW="2xl">
           <Text textStyle="h3" textAlign="left">
-            What do you want to automate?
+            How can we help?
           </Text>
           <PromptInput
             sendMessage={sendMessage}
@@ -153,9 +153,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             cancelStream={cancelStream}
             showIdeas
             initialValue={chatInput}
-            placeholder={
-              PLACEHOLDER_MESSAGES[Date.now() % PLACEHOLDER_MESSAGES.length]
-            }
+            placeholder={PLACEHOLDER_MESSAGE}
             onConnectForm={onConnectForm}
             onSelectExistingForm={onSelectExistingForm}
             attachedForm={attachedForm}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -21,7 +21,7 @@ const AiMessage = memo(
   ({ message, shouldShowPreview, shouldShowToolbar }: ChatMessageProps) => {
     return (
       <Flex gap={3} w="full" align="start">
-        <Box flex={1} px={2} color="gray.900">
+        <Box flex={1} px={2} pt={5} pb={2} color="gray.900">
           <ChakraStreamdown isAnimating={false}>
             {prepareAiText(message.text || '')}
           </ChakraStreamdown>
@@ -87,27 +87,5 @@ const ChatMessage = memo(
 )
 
 ChatMessage.displayName = 'ChatMessage'
-
-export const WarningMessage = () => {
-  return (
-    <Flex justify="flex-start">
-      <Box
-        bg="utility.feedback.warning-subtle"
-        color="gray.900"
-        px={4}
-        py={3}
-        borderRadius="lg"
-        w="full"
-      >
-        <Text textStyle="subhead-1" whiteSpace="pre-wrap">
-          Your conversation won&apos;t be saved.
-        </Text>
-        <Text textStyle="body-1" whiteSpace="pre-wrap">
-          The only thing you can keep is the workflow you create here.
-        </Text>
-      </Box>
-    </Flex>
-  )
-}
 
 export default ChatMessage

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -12,7 +12,15 @@ interface StreamingMessageProps {
 }
 
 const WorkingIndicator = ({ label }: { label: string }) => (
-  <Flex gap={3} w="full" alignItems="center">
+  <Flex
+    gap={3}
+    w="full"
+    alignItems="center"
+    textStyle="subhead-2"
+    textTransform="uppercase"
+    fontWeight={500}
+    color="gray.500"
+  >
     {label}
     <Loader />
   </Flex>
@@ -25,7 +33,7 @@ const StreamingMessage = ({
   if (currentResponse) {
     return (
       <Flex gap={3} w="full" align="start">
-        <Box flex={1} px={2} color="gray.900">
+        <Box flex={1} px={2} py={2} color="gray.900">
           <ChakraStreamdown isAnimating={true}>
             {prepareAiText(currentResponse)}
           </ChakraStreamdown>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -1,11 +1,10 @@
-import { Fragment } from 'react'
 import { Box, VStack } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
 import { StickToBottom } from 'use-stick-to-bottom'
 
 import { Message } from '@/hooks/useChatStream'
 
-import ChatMessage, { WarningMessage } from './ChatMessage'
+import ChatMessage from './ChatMessage'
 import StreamingMessage from './StreamingMessage'
 
 interface ChatMessagesProps {
@@ -36,16 +35,13 @@ export default function ChatMessages({
           {messages.map((message, index) => {
             const shouldShowPreview = isMobile && message.isChatReady
             const isLast = index === messages.length - 1
-            const isFirst = index === 0
             return (
-              <Fragment key={message.id}>
-                <ChatMessage
-                  message={message}
-                  shouldShowPreview={shouldShowPreview}
-                  shouldShowToolbar={isLast}
-                />
-                {isFirst && <WarningMessage />}
-              </Fragment>
+              <ChatMessage
+                key={message.id}
+                message={message}
+                shouldShowPreview={shouldShowPreview}
+                shouldShowToolbar={isLast}
+              />
             )
           })}
 

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -196,20 +196,12 @@ interface ParameterRowProps {
   children: ReactNode
 }
 
-// Shared row layout for both the connection row and each parameter row —
-// keeps the label column (width, alignment, styling) in one place.
+// Shared layout for the connection row and each parameter row —
+// label stacked above content so long values (e.g. email body) get full width.
 function ParameterRow({ label, children }: ParameterRowProps) {
   return (
-    <Flex align="flex-start" gap={4} py={2}>
-      <Text
-        as="span"
-        display="inline-block"
-        fontSize="sm"
-        color="base.content.medium"
-        fontWeight={500}
-        w="80px"
-        flexShrink={0}
-      >
+    <Flex flexDir="column" align="stretch" gap={1} pt={4} pb={2}>
+      <Text as="span" textStyle="subhead-3" color="base.content.medium">
         {label}
       </Text>
       {children}
@@ -354,8 +346,7 @@ export default function StepParameterRows({
       <Box
         pt={1}
         pb={3}
-        pl="58px"
-        pr={4}
+        px={6}
         borderTop="1px solid"
         borderColor="base.divider.medium"
       >

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -32,11 +32,8 @@ export type AiChatIdea = {
   input: string
 }
 
-export const PLACEHOLDER_MESSAGES = [
-  'Think in order. What happens first, and what follows',
-  "Describe what you have in mind and we'll show you what's possible",
-  "Share what you're trying to do and we'll help you figure out the best way to automate it",
-]
+export const PLACEHOLDER_MESSAGE =
+  "Describe the task and we'll build it for you, or ask a question"
 
 // Maximum number of messages allowed in a conversation (hard limit).
 // Keep in sync with backend/src/routes/api/chat/{schema,index}.ts.

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -2,8 +2,10 @@ import type { IApp, IJSONObject } from '@plumber/types'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
+import { BiInfoCircle } from 'react-icons/bi'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CloseButton, Container, Flex, HStack, Text } from '@chakra-ui/react'
+import { Tag, TagLabel, TagLeftIcon } from '@opengovsg/design-system-react'
 
 import AddAppConnection from '@/components/AddAppConnection'
 import RedirectToLogin from '@/components/RedirectToLogin'
@@ -340,8 +342,18 @@ function AiBuilderContent() {
               <Flex flex={1} alignItems="center" minWidth={0} gap={2}>
                 <CloseButton size="sm" onClick={handleClose} />
 
-                <Text>{flowName}</Text>
+                <Text noOfLines={1}>{flowName}</Text>
               </Flex>
+              <Tag
+                colorScheme="sub"
+                variant="subtle"
+                size="xs"
+                pointerEvents="none"
+                flexShrink={0}
+              >
+                <TagLeftIcon as={BiInfoCircle} />
+                <TagLabel>This conversation isn&apos;t saved</TagLabel>
+              </Tag>
             </HStack>
           )}
           <Container

--- a/packages/frontend/src/theme/components/Streamdown.tsx
+++ b/packages/frontend/src/theme/components/Streamdown.tsx
@@ -79,26 +79,34 @@ export function ChakraStreamdown({
   const components = useMemo(
     () => ({
       h1: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h1" {...props} />
+        <Text textStyle="h" fontWeight={600} my={2} {...props} />
       ),
       h2: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h2" mb={2} {...props} />
+        <Text textStyle="h5" mt={4} mb={2} {...props} />
       ),
       h3: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h3" mt={2} mb={2} {...props} />
+        <Text textStyle="h6" fontWeight={600} mt={4} mb={2} {...props} />
       ),
       h4: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h4" mt={2} mb={4} {...props} />
+        <Text textStyle="subhead-1" fontWeight={600} mt={4} mb={4} {...props} />
       ),
       h5: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h5" mt={2} mb={4} {...props} />
+        <Text textStyle="subhead-2" mt={4} mb={4} {...props} />
       ),
       h6: (props: React.ComponentProps<typeof Text>) => (
-        <Text textStyle="h6" mt={2} mb={2} {...props} />
+        <Text textStyle="caption-1" mt={4} mb={2} {...props} />
       ),
-      p: (props: React.ComponentProps<typeof Text>) => <Text {...props} />,
+      p: (props: React.ComponentProps<typeof Text>) => (
+        <Text mb={4} lineHeight={1.6} {...props} />
+      ),
       strong: (props: React.ComponentProps<'strong'>) => (
-        <Box as="strong" fontWeight="semibold" display="inline" {...props} />
+        <Box
+          as="strong"
+          fontWeight="semibold"
+          display="inline"
+          my={4}
+          {...props}
+        />
       ),
       code: (props: React.ComponentProps<typeof Code>) => (
         <Code colorScheme="gray" {...props} />

--- a/packages/frontend/src/theme/components/Streamdown.tsx
+++ b/packages/frontend/src/theme/components/Streamdown.tsx
@@ -100,13 +100,7 @@ export function ChakraStreamdown({
         <Text mb={4} lineHeight={1.6} {...props} />
       ),
       strong: (props: React.ComponentProps<'strong'>) => (
-        <Box
-          as="strong"
-          fontWeight="semibold"
-          display="inline"
-          my={4}
-          {...props}
-        />
+        <Box as="strong" fontWeight="semibold" display="inline" {...props} />
       ),
       code: (props: React.ComponentProps<typeof Code>) => (
         <Code colorScheme="gray" {...props} />


### PR DESCRIPTION
## Summary
- Empty-state heading stays "What do you want to automate?" The input placeholder now covers both building a workflow and asking a question.
- The yellow "Your conversation won't be saved" banner is gone. A quieter header tag says the conversation isn't saved.
- Step parameter preview stacks the label above the value so long content (e.g. email body) can use the full width.
- Chat markdown typography is tighter: smaller headings, paragraph spacing, and a quieter working/thinking indicator.

## Test plan
- [ ] Open AI Builder empty state and confirm the heading is unchanged and the placeholder mentions asking a question.
- [ ] Send a first message and confirm there is no yellow banner in the chat. The header tag "This conversation isn't saved" is visible.
- [ ] Build or load a pipe with a long rich-text/email body and check the step preview: label above value, value uses full width.
- [ ] Stream a reply with headings, lists, and bold text and check spacing/size looks readable rather than oversized.
- [ ] Check the working/thinking indicator while a tool is running.
