### PR TITLE
feat(flows): skip Next when creating a pipe from AI or a template

### DIFF
--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
@@ -11,7 +11,10 @@ import {
 } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
-import { useCreateFlowContext } from '@/pages/Flows/contexts/CreateFlowContext'
+import {
+  FLOW_CREATE_MODE,
+  useCreateFlowContext,
+} from '@/pages/Flows/contexts/CreateFlowContext'
 
 import FlowNameInput from '../FlowNameInput'
 import ModeSelector from '../ModeSelector'
@@ -23,6 +26,7 @@ export default function FlowNameAndModeContent({
   flowName,
   handleInputChange,
   handleSubmit,
+  onModeSelect,
 }: {
   isButtonDisabled: boolean
   loading: boolean
@@ -30,6 +34,7 @@ export default function FlowNameAndModeContent({
   flowName: string
   handleInputChange: () => void
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onModeSelect: (mode: FLOW_CREATE_MODE) => void
 }) {
   const { createMode } = useCreateFlowContext()
 
@@ -38,9 +43,9 @@ export default function FlowNameAndModeContent({
       <ModalHeader p="2.5rem 2rem 1.5rem">
         <Text textStyle="h4">How do you want to create your workflow?</Text>
       </ModalHeader>
-      <ModalBody>
+      <ModalBody pb={createMode === 'new' ? undefined : 8}>
         <Flex flexDir="column" rowGap={4}>
-          <ModeSelector />
+          <ModeSelector onModeSelect={onModeSelect} />
 
           {/* Specific form items */}
           {createMode === 'new' && (
@@ -52,8 +57,8 @@ export default function FlowNameAndModeContent({
           )}
         </Flex>
       </ModalBody>
-      <ModalFooter>
-        {createMode && (
+      {createMode === 'new' && (
+        <ModalFooter>
           <Button
             type="submit"
             isDisabled={isButtonDisabled}
@@ -61,8 +66,8 @@ export default function FlowNameAndModeContent({
           >
             Next <Icon boxSize={6} as={BiRightArrowAlt} />
           </Button>
-        )}
-      </ModalFooter>
+        </ModalFooter>
+      )}
     </Form>
   )
 }

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
@@ -6,6 +6,7 @@ import {
   ModalOverlay,
 } from '@chakra-ui/react'
 
+import { FLOW_CREATE_MODE } from '@/pages/Flows/contexts/CreateFlowContext'
 import { useFlowCreation } from '@/pages/Flows/hooks/useFlowCreation'
 
 import FlowNameAndModeContent from './FlowNameAndModeContent'
@@ -31,6 +32,10 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
     handleModeSubmit({ onClose })
   }
 
+  const handleModeSelect = (mode: FLOW_CREATE_MODE) => {
+    handleModeSubmit({ onClose, mode })
+  }
+
   return (
     <Modal
       isOpen={true}
@@ -48,6 +53,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
           flowName={flowName}
           handleInputChange={handleInputChange}
           handleSubmit={handleSubmit}
+          onModeSelect={handleModeSelect}
         />
         <ModalCloseButton mt={3} />
       </ModalContent>

--- a/packages/frontend/src/pages/Flows/components/EmptyFlows.tsx
+++ b/packages/frontend/src/pages/Flows/components/EmptyFlows.tsx
@@ -32,24 +32,23 @@ export default function EmptyFlows() {
         <Text textStyle="h3">How do you want to create your workflow?</Text>
       </Flex>
 
-      <ModeSelector />
+      <ModeSelector onModeSelect={(mode) => handleModeSubmit({ mode })} />
 
       {createMode === 'new' && (
-        <FlowNameInput
-          inputRef={inputRef}
-          flowName={flowName}
-          handleInputChange={handleInputChange}
-        />
-      )}
-
-      {createMode && (
-        <Button
-          onClick={() => handleModeSubmit()}
-          isDisabled={isButtonDisabled}
-          isLoading={loading}
-        >
-          Next <Icon boxSize={6} as={BiRightArrowAlt} />
-        </Button>
+        <>
+          <FlowNameInput
+            inputRef={inputRef}
+            flowName={flowName}
+            handleInputChange={handleInputChange}
+          />
+          <Button
+            onClick={() => handleModeSubmit()}
+            isDisabled={isButtonDisabled}
+            isLoading={loading}
+          >
+            Next <Icon boxSize={6} as={BiRightArrowAlt} />
+          </Button>
+        </>
       )}
     </Flex>
   )

--- a/packages/frontend/src/pages/Flows/components/ModeSelector.tsx
+++ b/packages/frontend/src/pages/Flows/components/ModeSelector.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { Flex, FormControl } from '@chakra-ui/react'
 
 import {
@@ -7,12 +8,40 @@ import {
 
 import ModeTile from './ModeTile'
 
-export default function ModeSelector() {
+const CARD_ADVANCE_DELAY_MS = 180
+
+interface ModeSelectorProps {
+  onModeSelect: (mode: FLOW_CREATE_MODE) => void
+}
+
+export default function ModeSelector({ onModeSelect }: ModeSelectorProps) {
   const { canUseAiBuilder, createMode, skipModeSelection, setCreateMode } =
     useCreateFlowContext()
+  const isAdvancingRef = useRef(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
 
   const handleModeClick = (mode: FLOW_CREATE_MODE) => {
+    if (isAdvancingRef.current) {
+      return
+    }
+
     setCreateMode(mode)
+
+    // Hold the selected card long enough to register, then advance.
+    if (mode !== 'new') {
+      isAdvancingRef.current = true
+      timeoutRef.current = setTimeout(() => {
+        onModeSelect(mode)
+      }, CARD_ADVANCE_DELAY_MS)
+    }
   }
 
   return (

--- a/packages/frontend/src/pages/Flows/hooks/useFlowCreation.ts
+++ b/packages/frontend/src/pages/Flows/hooks/useFlowCreation.ts
@@ -1,10 +1,13 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 
 import * as URLS from '@/config/urls'
 import { CREATE_FLOW } from '@/graphql/mutations/create-flow'
-import { useCreateFlowContext } from '@/pages/Flows/contexts/CreateFlowContext'
+import {
+  FLOW_CREATE_MODE,
+  useCreateFlowContext,
+} from '@/pages/Flows/contexts/CreateFlowContext'
 
 export const useFlowCreation = () => {
   const navigate = useNavigate()
@@ -17,14 +20,7 @@ export const useFlowCreation = () => {
     setFlowName(inputRef.current?.value || '')
   }, [])
 
-  const isButtonDisabled = useMemo(() => {
-    // ai builder auto-suggests a name for the pipe
-    // template does not require a name
-    if (createMode === 'ai' || createMode === 'template') {
-      return false
-    }
-    return flowName.trim() === ''
-  }, [createMode, flowName])
+  const isButtonDisabled = flowName.trim() === ''
 
   const onCreateFlow = useCallback(
     async (flowName: string) => {
@@ -43,14 +39,16 @@ export const useFlowCreation = () => {
   )
 
   const handleModeSubmit = useCallback(
-    (options?: { onClose?: () => void }) => {
-      if (createMode === 'ai') {
+    (options?: { onClose?: () => void; mode?: FLOW_CREATE_MODE }) => {
+      const mode = options?.mode ?? createMode
+
+      if (mode === 'ai') {
         options?.onClose?.()
         navigate(`${URLS.EDITOR}/ai`, { replace: true })
         return
       }
 
-      if (createMode === 'template') {
+      if (mode === 'template') {
         options?.onClose?.()
         navigate(URLS.TEMPLATES)
         return


### PR DESCRIPTION
## Why

Creating a pipe from **Build with AI** or **Use a template** does not need a name. Those cards already have a destination (AI builder or the template gallery). Asking the user to select a card and then press **Next** was an extra step with no extra information.

**Start from scratch** still needs a workflow name, so that path keeps the name field and Next.

## What changed

- Clicking **Build with AI** or **Use a template** goes straight to that destination in both the Create Pipe modal and the empty pipes screen.
- Next only appears after **Start from scratch**.
- The selected card is held for 180ms so the choice is visible before the page changes. There is no modal close animation (`motionPreset="none"` stays).
- The modal body keeps bottom padding when the footer is hidden.

## Test plan

- [ ] Open Create Pipe with existing pipes. Click **Build with AI**. Confirm you land on the AI builder without pressing Next.
- [ ] Repeat with **Use a template**. Confirm you land on the template gallery.
- [ ] Click **Start from scratch**. Confirm the name field and Next appear, and Next stays disabled until a name is entered.
- [ ] Same three paths on the empty pipes screen (no existing pipes).
- [ ] Dismiss the modal with X while a card is selected during the 180ms hold. Confirm it does not navigate.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR streamlines flow creation by navigating directly from the AI and template cards while retaining the name-and-Next flow for workflows created from scratch.

- Adds a cancellable 180ms selection hold before direct navigation.
- Passes the selected mode explicitly to the creation hook to avoid stale context state.
- Hides the modal footer and inline Next button unless the scratch mode is selected.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The direct-navigation paths pass the clicked mode explicitly, modal dismissal cancels pending navigation through unmount cleanup, and the name-dependent action remains confined to scratch creation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/pages/Flows/components/ModeSelector.tsx | Adds guarded delayed advancement for AI and template selections, with unmount cleanup that cancels pending navigation. |
| packages/frontend/src/pages/Flows/hooks/useFlowCreation.ts | Accepts an explicit selected mode for direct navigation while preserving named workflow creation for scratch mode. |
| packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx | Connects card selection to mode submission while retaining modal closure semantics. |
| packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx | Restricts the name input and footer action to scratch mode and preserves body spacing without a footer. |
| packages/frontend/src/pages/Flows/components/EmptyFlows.tsx | Enables direct card navigation in the empty state and shows the name input and Next button only for scratch creation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Selector as ModeSelector
    participant Creation as useFlowCreation
    participant Router

    User->>Selector: Select AI or template
    Selector->>Selector: Set selected mode and wait 180ms
    alt Selector remains mounted
        Selector->>Creation: Submit explicit mode
        Creation->>Router: Navigate to destination
    else Modal is dismissed
        Selector->>Selector: Cleanup cancels timeout
    end

    User->>Selector: Select start from scratch
    Selector->>Selector: Set mode to new
    User->>Creation: Enter name and press Next
    Creation->>Creation: Create workflow
    Creation->>Router: Open workflow editor
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(flows): skip Next when creating a p..."](https://github.com/opengovsg/plumber/commit/e3f36fffc67a3378286c7f8599b35edd95640146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59466627)</sub>

<!-- /greptile_comment -->