### PR TITLE
PLU-741 fix: clarify live pipe status and confirm before unpublish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,9 +4415,9 @@
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
-      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.1.tgz",
+      "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17372,9 +17372,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
-      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17372,9 +17372,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,9 +4415,9 @@
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.1.tgz",
-      "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
+      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -3,7 +3,7 @@ import { BiCog, BiHistory, BiInfoCircle } from 'react-icons/bi'
 import { HiOutlineDotsVertical } from 'react-icons/hi'
 import { MdOutlineRemoveRedEye } from 'react-icons/md'
 import { Link } from 'react-router-dom'
-import { Hide, HStack, MenuButton, MenuList, Show } from '@chakra-ui/react'
+import { Box, Hide, HStack, MenuButton, MenuList, Show } from '@chakra-ui/react'
 import {
   Button,
   IconButton,
@@ -150,11 +150,50 @@ const ViewOnlyTag = () => {
   )
 }
 
+const LiveTag = () => {
+  return (
+    <TouchableTooltip
+      label="Your pipe is running. It will do the steps you set up."
+      aria-label="live tooltip"
+    >
+      <Tag
+        {...tagStyles}
+        colorScheme="success"
+        bgColor="transparent"
+        mr={4}
+        pointerEvents="auto"
+      >
+        <Box position="relative" boxSize={2} flexShrink={0}>
+          <Box
+            position="absolute"
+            inset={0}
+            borderRadius="full"
+            bg="currentColor"
+            sx={{
+              animation:
+                'live-dot-ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite',
+              '@keyframes live-dot-ping': {
+                '75%, 100%': {
+                  transform: 'scale(2.2)',
+                  opacity: 0,
+                },
+              },
+            }}
+          />
+          <Box boxSize={2} borderRadius="full" bg="currentColor" />
+        </Box>
+        <TagLabel>Live</TagLabel>
+      </Tag>
+    </TouchableTooltip>
+  )
+}
+
 interface EditorToolbarProps {
   loading: boolean
   shouldWarnOnLeave: boolean
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void
   onFlowStatusUpdate: (active: boolean) => void
+  onUnpublish: () => void
   setLeaveToUrl: (url: string) => void
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
 }
@@ -174,6 +213,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
           <ExecutionsItem type="icon" />
           <GuideItem type="icon" />
           <SettingsItem {...props} type="icon" settingsLink={settingsLink} />
+          {flow?.active && <LiveTag />}
           {flow?.role === 'viewer' ? (
             <ViewOnlyTag />
           ) : (
@@ -204,6 +244,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
               type="button"
               settingsLink={settingsLink}
             />
+            {flow?.active && <LiveTag />}
             {flow?.role === 'viewer' ? (
               <ViewOnlyTag />
             ) : (

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -6,17 +6,37 @@ import { hasEmptyIfThenV2Block } from '@/components/Editor/helpers/steps-utils'
 import { EditorContext } from '@/contexts/Editor'
 import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 
+const unpublishButtonStyles = {
+  bg: 'base.content.strong',
+  color: 'white',
+  borderColor: 'base.content.strong',
+  _hover: {
+    bg: 'base.content.default',
+    borderColor: 'base.content.default',
+    _disabled: {
+      bg: 'interaction.support.disabled',
+      borderColor: 'interaction.support.disabled',
+    },
+  },
+  _active: {
+    bg: 'grey.900',
+    borderColor: 'grey.900',
+  },
+}
+
 export default function PublishButton({
   loading,
   shouldWarnOnLeave,
   handleWarnOnLeave,
   onFlowStatusUpdate,
+  onUnpublish,
   setShouldWarnOnPublish,
 }: {
   loading: boolean
   shouldWarnOnLeave: boolean
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
   onFlowStatusUpdate: (active: boolean) => void
+  onUnpublish: () => void
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void
 }) {
   const {
@@ -70,12 +90,17 @@ export default function PublishButton({
         spinner={<Spinner fontSize={24} />}
         size="sm"
         minW="120px" // set this to avoid button width changing on publish/unpublish
+        {...(flow?.active ? unpublishButtonStyles : {})}
         onClick={(e) => {
+          if (flow.active) {
+            onUnpublish()
+            return
+          }
           if (shouldWarnOnLeave) {
             setShouldWarnOnPublish(true)
             handleWarnOnLeave(e)
           } else {
-            onFlowStatusUpdate(!flow.active)
+            onFlowStatusUpdate(true)
           }
         }}
       >

--- a/packages/frontend/src/components/EditorLayout/UnpublishConfirmationDialog.tsx
+++ b/packages/frontend/src/components/EditorLayout/UnpublishConfirmationDialog.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
-import { FORMSG_APP_KEY, MRF_ACTION_KEY } from '@/helpers/formsg'
+import { FORMSG_APP_KEY } from '@/helpers/formsg'
 
 const DELAY_APP_KEY = 'delay'
 
@@ -28,14 +28,6 @@ interface UnpublishConfirmationDialogProps {
   onClose: () => void
   onUnpublish: () => void | Promise<void>
   steps: IStep[]
-}
-
-function hasLongLivedRuns(steps: IStep[]): boolean {
-  return steps.some(
-    (step) =>
-      (step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY) ||
-      step.appKey === DELAY_APP_KEY,
-  )
 }
 
 function ConsequenceRow({
@@ -65,7 +57,11 @@ export default function UnpublishConfirmationDialog(
     onUnpublish,
     steps,
   } = props
-  const showOngoingRunsNote = hasLongLivedRuns(steps)
+
+  // Only delay steps count as long-lived: an MRF submission waits on an
+  // external approver, so it isn't a run "in progress" the way a delay is.
+  const isLongLivedRun = steps.some((step) => step.appKey === DELAY_APP_KEY)
+  const hasFormSteps = steps.some((step) => step.appKey === FORMSG_APP_KEY)
 
   const handleUnpublish = async () => {
     await onUnpublish()
@@ -88,14 +84,16 @@ export default function UnpublishConfirmationDialog(
                 It stops running until you publish it again.
               </Text>
               <VStack align="stretch" spacing={2}>
-                <ConsequenceRow icon={BiCheck}>
-                  Your form stays open and keeps collecting responses
-                </ConsequenceRow>
+                {hasFormSteps && (
+                  <ConsequenceRow icon={BiCheck}>
+                    Your form stays open and keeps collecting responses
+                  </ConsequenceRow>
+                )}
                 <ConsequenceRow icon={BiX}>
                   No steps run: no emails sent, no rows created in your tiles
                 </ConsequenceRow>
               </VStack>
-              {showOngoingRunsNote ? (
+              {isLongLivedRun ? (
                 <Text textStyle="body-1">
                   Runs that already started will still finish.
                 </Text>
@@ -104,8 +102,8 @@ export default function UnpublishConfirmationDialog(
           </AlertDialogBody>
           <AlertDialogFooter>
             <Button
-              colorScheme="neutral"
-              variant="outline"
+              variant="clear"
+              colorScheme="secondary"
               ref={cancelRef}
               onClick={onClose}
               isDisabled={isLoading}

--- a/packages/frontend/src/components/EditorLayout/UnpublishConfirmationDialog.tsx
+++ b/packages/frontend/src/components/EditorLayout/UnpublishConfirmationDialog.tsx
@@ -1,0 +1,128 @@
+import type { IStep } from '@plumber/types'
+
+import { RefObject } from 'react'
+import { BiCheck, BiX } from 'react-icons/bi'
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Flex,
+  Icon,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import { FORMSG_APP_KEY, MRF_ACTION_KEY } from '@/helpers/formsg'
+
+const DELAY_APP_KEY = 'delay'
+
+interface UnpublishConfirmationDialogProps {
+  cancelRef: RefObject<HTMLButtonElement>
+  flowName: string
+  isOpen: boolean
+  isLoading: boolean
+  onClose: () => void
+  onUnpublish: () => void | Promise<void>
+  steps: IStep[]
+}
+
+function hasLongLivedRuns(steps: IStep[]): boolean {
+  return steps.some(
+    (step) =>
+      (step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY) ||
+      step.appKey === DELAY_APP_KEY,
+  )
+}
+
+function ConsequenceRow({
+  icon,
+  children,
+}: {
+  icon: typeof BiCheck
+  children: string
+}) {
+  return (
+    <Flex alignItems="flex-start" gap={2}>
+      <Icon as={icon} boxSize={5} mt="2px" color="base.content.default" />
+      <Text textStyle="body-1">{children}</Text>
+    </Flex>
+  )
+}
+
+export default function UnpublishConfirmationDialog(
+  props: UnpublishConfirmationDialogProps,
+) {
+  const {
+    cancelRef,
+    flowName,
+    isOpen,
+    isLoading,
+    onClose,
+    onUnpublish,
+    steps,
+  } = props
+  const showOngoingRunsNote = hasLongLivedRuns(steps)
+
+  const handleUnpublish = async () => {
+    await onUnpublish()
+    onClose()
+  }
+
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+      closeOnOverlayClick={!isLoading}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader>Unpublish {flowName}?</AlertDialogHeader>
+          <AlertDialogBody>
+            <VStack align="stretch" spacing={4}>
+              <Text textStyle="body-1" color="base.content.medium">
+                It stops running until you publish it again.
+              </Text>
+              <VStack align="stretch" spacing={2}>
+                <ConsequenceRow icon={BiCheck}>
+                  Your form stays open and keeps collecting responses
+                </ConsequenceRow>
+                <ConsequenceRow icon={BiX}>
+                  No steps run: no emails sent, no rows created in your tiles
+                </ConsequenceRow>
+              </VStack>
+              {showOngoingRunsNote ? (
+                <Text textStyle="body-1">
+                  Runs that already started will still finish.
+                </Text>
+              ) : null}
+            </VStack>
+          </AlertDialogBody>
+          <AlertDialogFooter>
+            <Button
+              colorScheme="neutral"
+              variant="outline"
+              ref={cancelRef}
+              onClick={onClose}
+              isDisabled={isLoading}
+            >
+              Keep pipe published
+            </Button>
+            <Button
+              colorScheme="critical"
+              onClick={handleUnpublish}
+              ml={3}
+              isLoading={isLoading}
+            >
+              Unpublish
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  )
+}

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -24,6 +24,7 @@ import { EDITOR_MARGIN_TOP } from '../Editor/constants'
 import { ConfettiSurvey } from './ConfettiSurvey'
 import EditorSnackbar from './EditorSnackbar'
 import EditorToolbar from './EditorToolbar'
+import UnpublishConfirmationDialog from './UnpublishConfirmationDialog'
 
 export default function EditorLayout() {
   const cancelRef = useRef(null)
@@ -34,9 +35,12 @@ export default function EditorLayout() {
   const [updateFlow] = useMutation(UPDATE_FLOW, {
     refetchQueries: [GET_FLOW], // need to refetch flow to get the latest updatedAt
   })
-  const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS, {
-    refetchQueries: [GET_FLOW],
-  })
+  const [updateFlowStatus, { loading: isUpdatingFlowStatus }] = useMutation(
+    UPDATE_FLOW_STATUS,
+    {
+      refetchQueries: [GET_FLOW],
+    },
+  )
   const [shouldWarnOnPublish, setShouldWarnOnPublish] = useState(false)
   const [shouldWarnOnLeave, setShouldWarnOnLeave] = useState(false)
   const [leaveToUrl, setLeaveToUrl] = useState(URLS.FLOWS)
@@ -45,6 +49,12 @@ export default function EditorLayout() {
     onOpen: onWarningOpen,
     onClose: onWarningClose,
   } = useDisclosure()
+  const {
+    isOpen: isUnpublishOpen,
+    onOpen: onUnpublishOpen,
+    onClose: onUnpublishClose,
+  } = useDisclosure()
+  const unpublishCancelRef = useRef(null)
 
   const { data, loading, error } = useQuery(GET_FLOW, {
     variables: { id: flowId },
@@ -85,6 +95,10 @@ export default function EditorLayout() {
     },
     [flow?.updatedAt, flowId, updateFlowStatus],
   )
+
+  const handleUnpublish = useCallback(async () => {
+    await onFlowStatusUpdate(false)
+  }, [onFlowStatusUpdate])
 
   const handleWarningClose = useCallback(() => {
     setShouldWarnOnPublish(false)
@@ -224,6 +238,7 @@ export default function EditorLayout() {
             shouldWarnOnLeave={shouldWarnOnLeave}
             setShouldWarnOnPublish={setShouldWarnOnPublish}
             onFlowStatusUpdate={onFlowStatusUpdate}
+            onUnpublish={onUnpublishOpen}
             setLeaveToUrl={setLeaveToUrl}
             handleWarnOnLeave={handleWarnOnLeave}
           />
@@ -243,7 +258,7 @@ export default function EditorLayout() {
 
       <EditorSnackbar
         isOpen={!!flow?.active}
-        handleUnpublish={() => onFlowStatusUpdate(!flow.active)}
+        handleUnpublish={onUnpublishOpen}
       />
 
       {shouldOpenDemoModal && (
@@ -258,6 +273,16 @@ export default function EditorLayout() {
         isOpen={isWarningOpen}
         onClose={handleWarningClose}
         onLeave={onDiscardChanges}
+      />
+
+      <UnpublishConfirmationDialog
+        cancelRef={unpublishCancelRef}
+        flowName={flow.name}
+        isOpen={isUnpublishOpen}
+        isLoading={isUpdatingFlowStatus}
+        onClose={onUnpublishClose}
+        onUnpublish={handleUnpublish}
+        steps={flow.steps}
       />
     </EditorProvider>
   )

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -140,7 +140,7 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
                 colorScheme={flow?.active ? 'success' : 'grey'}
                 variant="subtle"
               >
-                <Text>{flow?.active ? 'Published' : 'Draft'}</Text>
+                <Text>{flow?.active ? 'Live' : 'Draft'}</Text>
               </Badge>
 
               {showMenu ? (


### PR DESCRIPTION
## Summary
- Show **Live** instead of Published on the pipe list and in the editor toolbar
- Confirm before unpublish, with an extra line on MRF and Delay pipes: runs that already started still finish

## Test plan
- [ ] Open a published pipe and check the editor shows a Live tag
- [ ] Confirm the pipes list badge says Live, not Published
- [ ] Unpublish a simple FormSG pipe and check the dialog has no extra line
- [ ] Unpublish a pipe with a Delay or MRF step and check the extra line appears
- [ ] Confirm cancel leaves the pipe live, and confirm unpublish actually unpublishes

Resolves PLU-741
