### PR TITLE
fix(ecs): keep Datadog profiling on glibc base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22-alpine as build
+FROM node:22-bookworm-slim as build
 
 ARG APP_ENV=prod
 ENV VITE_MODE=$APP_ENV
@@ -12,7 +12,7 @@ RUN --mount=type=secret,id=NPM_TASKFORCESH_TOKEN \
 RUN npm run build
 RUN npm prune --omit=dev --ignore-scripts
 
-FROM node:22-alpine as main
+FROM node:22-bookworm-slim as main
 
 WORKDIR /opt/plumber
 

--- a/ecs/env.json
+++ b/ecs/env.json
@@ -54,7 +54,11 @@
     },
     {
       "name": "DD_PROFILING_ENABLED",
-      "value": "true"
+      "value": "false"
+    },
+    {
+      "name": "DD_CRASHTRACKING_ENABLED",
+      "value": "false"
     },
     {
       "name": "SES_FROM_ADDRESS",

--- a/ecs/env.json
+++ b/ecs/env.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "DD_PROFILING_ENABLED",
-      "value": "false"
+      "value": "true"
     },
     {
       "name": "DD_CRASHTRACKING_ENABLED",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

ECS tasks crash at startup with `npm error signal SIGSEGV` after the collateral `dd-trace` bump from `4.55.0` to `5.102.0`. APM tracing and continuous profiling must stay enabled.

Root cause: dd-trace v5 ships heavier native addons (`@datadog/pprof`, `@datadog/libdatadog` crashtracker) that are unstable on **Alpine/musl** (`node:22-alpine`), especially with `DD_PROFILING_ENABLED=true`.

## Fix

1. **Switch production image to `node:22-bookworm-slim`** (glibc) in [`Dockerfile`](Dockerfile). Datadog's profiler prebuilds are reliable on glibc; this preserves continuous profiling without turning it off.

2. **Keep `DD_PROFILING_ENABLED=true`** in [`ecs/env.json`](ecs/env.json) — profiling stays on as before.

3. **Set `DD_CRASHTRACKING_ENABLED=false`** — crashtracking is a **new v5 default-on** feature (not part of the pre-v5 tracing/profiling stack). Disabling it removes one native init path that can SIGSEGV on startup, without affecting APM spans or profiler uploads.

## What stays the same

- `dd-trace@5.102.0` and `tracer.init()` (spans, `tracer.wrap`, log injection)
- Continuous profiling (`DD_PROFILING_ENABLED=true`)
- Datadog agent sidecar / APM on port 8126

## What changes

- Container OS: Alpine → Debian bookworm-slim (slightly larger image; required for stable native profiling on v5)
- Crashtracking off (new v5 feature only; was not explicitly enabled before the bump)

## Rollout / verification

1. Deploy to staging; confirm server and worker containers stay up.
2. Confirm APM traces for GraphQL + worker jobs.
3. Confirm CPU/heap profiles appear in Datadog Profiler (same as before #1805).
4. If SIGSEGV persists, next step is reverting `dd-trace` to `4.55.0` on bookworm-slim.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05d64-ab5e-7ee0-81f2-18218451aa7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05d64-ab5e-7ee0-81f2-18218451aa7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

