### PR TITLE
chore: fix backend tsconfig path alias

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["es2021", "ES2022.Error", "ES2022.Object"],
@@ -9,7 +8,7 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["./src/*"]
     },
     "skipLibCheck": true,
     "sourceMap": true,


### PR DESCRIPTION
## Problem

The backend `tsconfig.json` had `baseUrl: "./src"` combined with the path mapping `"@/*": ["*"]`. This relied on implicit resolution against `baseUrl`, which some tsserver setups misresolved, producing spurious editor type errors for `@/` imports.

Closes N/A

## Solution

Removed `baseUrl` and made the `@/*` mapping target explicit: `"@/*": ["./src/*"]`. Without `baseUrl`, TypeScript resolves `paths` entries relative to the `tsconfig.json` file itself, so `./src/*` now points directly at `packages/backend/src/*`.

Verified `@/` imports resolve correctly with `tsc --noEmit` and lint passing.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Fixed `@/*` path alias resolution so it does not depend on implicit `baseUrl` resolution, which some tsserver setups misresolved.

## Before & After Screenshots

**BEFORE**:

N/A (tsconfig-only change)

**AFTER**:

N/A (tsconfig-only change)

## Tests

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes the backend `@/*` alias explicit while removing the old `baseUrl`, preserving resolution to `packages/backend/src/*`.
- Removes `compilerOptions.baseUrl`.
- Maps `@/*` directly to `./src/*`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/tsconfig.json | The mapping now resolves relative to the configuration directory; removing `baseUrl` avoids the previously reported `src/src` duplication. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix tsconfig"](https://github.com/opengovsg/plumber/commit/edcbbbb81dcdd6c62193941f3eb15b0145e999c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59406942)</sub>

<!-- /greptile_comment -->