### PR TITLE
PLU-807 (feat): append chat ID to Plumber support form link

### DIFF
--- a/packages/backend/src/helpers/ai/build-support-form-url.test.ts
+++ b/packages/backend/src/helpers/ai/build-support-form-url.test.ts
@@ -5,11 +5,13 @@ import { buildSupportFormUrl } from './build-support-form-url'
 describe('buildSupportFormUrl', () => {
   it('appends the chat ID as a pre-filled field when provided', () => {
     expect(buildSupportFormUrl('123e4567-e89b-12d3-a456-426614174000')).toBe(
-      'TODO_SUPPORT_FORM_BASE_URL?TODO_SUPPORT_FORM_CHAT_ID_FIELD=123e4567-e89b-12d3-a456-426614174000',
+      'https://form.gov.sg/64929532701266001209ac32?6a979221b8ae314641032f5c=123e4567-e89b-12d3-a456-426614174000',
     )
   })
 
   it('returns the bare form URL when chatId is empty', () => {
-    expect(buildSupportFormUrl('')).toBe('TODO_SUPPORT_FORM_BASE_URL')
+    expect(buildSupportFormUrl('')).toBe(
+      'https://form.gov.sg/64929532701266001209ac32',
+    )
   })
 })

--- a/packages/backend/src/helpers/ai/build-support-form-url.test.ts
+++ b/packages/backend/src/helpers/ai/build-support-form-url.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSupportFormUrl } from './build-support-form-url'
+
+describe('buildSupportFormUrl', () => {
+  it('appends the chat ID as a pre-filled field when provided', () => {
+    expect(buildSupportFormUrl('123e4567-e89b-12d3-a456-426614174000')).toBe(
+      'TODO_SUPPORT_FORM_BASE_URL?TODO_SUPPORT_FORM_CHAT_ID_FIELD=123e4567-e89b-12d3-a456-426614174000',
+    )
+  })
+
+  it('returns the bare form URL when chatId is empty', () => {
+    expect(buildSupportFormUrl('')).toBe('TODO_SUPPORT_FORM_BASE_URL')
+  })
+})

--- a/packages/backend/src/helpers/ai/build-support-form-url.ts
+++ b/packages/backend/src/helpers/ai/build-support-form-url.ts
@@ -1,8 +1,7 @@
 export const SUPPORT_FORM_URL_PLACEHOLDER = '{{SUPPORT_FORM_URL}}'
 
-// TODO: fill in the real form.gov.sg support form URL and chat-ID field ID.
-const SUPPORT_FORM_BASE_URL = 'TODO_SUPPORT_FORM_BASE_URL'
-const SUPPORT_FORM_CHAT_ID_FIELD = 'TODO_SUPPORT_FORM_CHAT_ID_FIELD'
+const SUPPORT_FORM_BASE_URL = 'https://form.gov.sg/64929532701266001209ac32'
+const SUPPORT_FORM_CHAT_ID_FIELD = '6a979221b8ae314641032f5c'
 
 export function buildSupportFormUrl(chatId: string | undefined): string {
   if (!chatId) {

--- a/packages/backend/src/helpers/ai/build-support-form-url.ts
+++ b/packages/backend/src/helpers/ai/build-support-form-url.ts
@@ -1,0 +1,14 @@
+export const SUPPORT_FORM_URL_PLACEHOLDER = '{{SUPPORT_FORM_URL}}'
+
+// TODO: fill in the real form.gov.sg support form URL and chat-ID field ID.
+const SUPPORT_FORM_BASE_URL = 'TODO_SUPPORT_FORM_BASE_URL'
+const SUPPORT_FORM_CHAT_ID_FIELD = 'TODO_SUPPORT_FORM_CHAT_ID_FIELD'
+
+export function buildSupportFormUrl(chatId: string | undefined): string {
+  if (!chatId) {
+    return SUPPORT_FORM_BASE_URL
+  }
+
+  const params = new URLSearchParams({ [SUPPORT_FORM_CHAT_ID_FIELD]: chatId })
+  return `${SUPPORT_FORM_BASE_URL}?${params.toString()}`
+}

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -218,7 +218,7 @@ describe('chat handler — GitBook MCP integration', () => {
           expect.objectContaining({
             role: 'system',
             content: expect.stringContaining(
-              'TODO_SUPPORT_FORM_BASE_URL?TODO_SUPPORT_FORM_CHAT_ID_FIELD=123e4567-e89b-12d3-a456-426614174000',
+              'https://form.gov.sg/64929532701266001209ac32?6a979221b8ae314641032f5c=123e4567-e89b-12d3-a456-426614174000',
             ),
           }),
         ]),
@@ -234,11 +234,9 @@ describe('chat handler — GitBook MCP integration', () => {
     const [[{ messages }]] = vi.mocked(streamText).mock.calls
     const systemMessage = messages.find((m) => m.role === 'system')
     expect(systemMessage?.content).toContain(
-      'Support: TODO_SUPPORT_FORM_BASE_URL',
+      'Support: https://form.gov.sg/64929532701266001209ac32',
     )
-    expect(systemMessage?.content).not.toContain(
-      'TODO_SUPPORT_FORM_CHAT_ID_FIELD=',
-    )
+    expect(systemMessage?.content).not.toContain('6a979221b8ae314641032f5c=')
   })
 })
 

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -56,7 +56,7 @@ vi.mock('@/models/connection', () => ({
 
 vi.mock('@/helpers/ai/get-prompt', () => ({
   getPrompt: vi.fn().mockResolvedValue({
-    prompt: 'You are a helpful assistant.',
+    prompt: 'You are a helpful assistant. Support: {{SUPPORT_FORM_URL}}',
     toJSON: () => ({}),
   }),
 }))
@@ -199,6 +199,45 @@ describe('chat handler — GitBook MCP integration', () => {
       expect.objectContaining({
         tools: { ...mockBridgeTools },
       }),
+    )
+  })
+
+  it('substitutes the support form URL placeholder with the chat ID pre-filled', async () => {
+    const handler = router.stack[0].route.stack[0].handle
+    await handler(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeReq({ chatId: '123e4567-e89b-12d3-a456-426614174000' }) as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRes() as any,
+      vi.fn(),
+    )
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'system',
+            content: expect.stringContaining(
+              'TODO_SUPPORT_FORM_BASE_URL?TODO_SUPPORT_FORM_CHAT_ID_FIELD=123e4567-e89b-12d3-a456-426614174000',
+            ),
+          }),
+        ]),
+      }),
+    )
+  })
+
+  it('falls back to the bare support form URL when chatId is absent', async () => {
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+
+    const [[{ messages }]] = vi.mocked(streamText).mock.calls
+    const systemMessage = messages.find((m) => m.role === 'system')
+    expect(systemMessage?.content).toContain(
+      'Support: TODO_SUPPORT_FORM_BASE_URL',
+    )
+    expect(systemMessage?.content).not.toContain(
+      'TODO_SUPPORT_FORM_CHAT_ID_FIELD=',
     )
   })
 })

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -22,6 +22,10 @@ import { Router } from 'express'
 
 import appConfig from '@/config/app'
 import { BadUserInputError } from '@/errors/graphql-errors'
+import {
+  buildSupportFormUrl,
+  SUPPORT_FORM_URL_PLACEHOLDER,
+} from '@/helpers/ai/build-support-form-url'
 import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
 import { getPrompt } from '@/helpers/ai/get-prompt'
 import {
@@ -170,8 +174,10 @@ const handleChatStream = observe(
       const systemMessage = {
         role: 'system' as const,
         content:
-          buildSystemPrompt(prompt.prompt, restrictedApps) +
-          buildEstablishedConnectionReminder(establishedFormConnection),
+          buildSystemPrompt(prompt.prompt, restrictedApps).replaceAll(
+            SUPPORT_FORM_URL_PLACEHOLDER,
+            buildSupportFormUrl(chatId),
+          ) + buildEstablishedConnectionReminder(establishedFormConnection),
       }
       const allMessages = [systemMessage, ...messages]
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Flex, Link, Text } from '@chakra-ui/react'
 import { StickToBottom } from 'use-stick-to-bottom'
 
 import * as URLS from '@/config/urls'
@@ -8,6 +8,7 @@ import { Message } from '@/hooks/useChatStream'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import ChatMessages from '@/pages/AiBuilder/components/ChatMessages'
 import { PLACEHOLDER_MESSAGES } from '@/pages/AiBuilder/constants'
+import { buildSupportFormUrl } from '@/pages/AiBuilder/helpers'
 import { createNewChatDraft } from '@/pages/AiBuilder/new-chat'
 
 import MessageLimitBanner from './MessageLimitBanner'
@@ -54,8 +55,14 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   } = props
   const navigate = useNavigate()
   const location = useLocation()
-  const { chatInput, isMobile, isDrawerOpen, setIsDrawerOpen, setChatState } =
-    useAiBuilderContext()
+  const {
+    chatId,
+    chatInput,
+    isMobile,
+    isDrawerOpen,
+    setIsDrawerOpen,
+    setChatState,
+  } = useAiBuilderContext()
 
   const hasMessages = messages.length > 0 || isStreaming
 
@@ -228,6 +235,15 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   textAlign="center"
                 >
                   This feature is new and still improving. It can make mistakes.
+                  Still need help?{' '}
+                  <Link
+                    href={buildSupportFormUrl(chatId)}
+                    isExternal
+                    textDecoration="underline"
+                  >
+                    Contact us here
+                  </Link>
+                  .
                 </Text>
               )}
             </Box>

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -42,6 +42,12 @@ export const PLACEHOLDER_MESSAGES = [
 // Keep in sync with backend/src/routes/api/chat/{schema,index}.ts.
 export const MAX_MESSAGES = 150
 
+// Support form URL, pre-filled with the chat ID for tracing. Keep in sync with
+// backend/src/helpers/ai/build-support-form-url.ts.
+export const SUPPORT_FORM_BASE_URL =
+  'https://form.gov.sg/64929532701266001209ac32'
+export const SUPPORT_FORM_CHAT_ID_FIELD = '6a979221b8ae314641032f5c'
+
 // App keys that support AI Builder's generic in-chat "add connection" flow
 // (secret-key or OAuth-via-popup apps, driven entirely by each app's
 // auth.fields/auth.authenticationSteps — see components/AddAppConnection).

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -8,6 +8,10 @@ import {
   IsChatReadyPart,
   Message,
 } from '@/hooks/useChatStream'
+import {
+  SUPPORT_FORM_BASE_URL,
+  SUPPORT_FORM_CHAT_ID_FIELD,
+} from '@/pages/AiBuilder/constants'
 
 // Strip HTML comment blocks from AI chat text before display.
 // Complete comments (<!-- ... -->) are invisible in HTML but some markdown parsers
@@ -35,6 +39,17 @@ export const normalizeMarkdownHeadings = (text: string): string =>
 
 export const prepareAiText = (text: string): string =>
   normalizeMarkdownHeadings(stripHtmlComments(text))
+
+// Support form URL with the chat ID pre-filled, so a submitted request can be
+// traced back to its Langfuse session.
+export const buildSupportFormUrl = (chatId: string | undefined): string => {
+  if (!chatId) {
+    return SUPPORT_FORM_BASE_URL
+  }
+
+  const params = new URLSearchParams({ [SUPPORT_FORM_CHAT_ID_FIELD]: chatId })
+  return `${SUPPORT_FORM_BASE_URL}?${params.toString()}`
+}
 
 // First user message sent after connecting a form from the empty state.
 // The parenthetical carries the connection id (for assigning the trigger in

--- a/packages/frontend/src/pages/AiBuilder/helpers/buildSupportFormUrl.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/buildSupportFormUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSupportFormUrl } from '../helpers'
+
+describe('buildSupportFormUrl', () => {
+  it('appends the chat ID as a pre-filled field when provided', () => {
+    expect(buildSupportFormUrl('123e4567-e89b-12d3-a456-426614174000')).toBe(
+      'https://form.gov.sg/64929532701266001209ac32?6a979221b8ae314641032f5c=123e4567-e89b-12d3-a456-426614174000',
+    )
+  })
+
+  it('returns the bare form URL when chatId is absent', () => {
+    expect(buildSupportFormUrl(undefined)).toBe(
+      'https://form.gov.sg/64929532701266001209ac32',
+    )
+  })
+})


### PR DESCRIPTION
## TL;DR

Adds the chat ID to the AI Builder's support form link, so a submitted support request can be traced back to its Langfuse session.

## What changed?

- Backend: the AI Builder system prompt now substitutes a `{{SUPPORT_FORM_URL}}` placeholder with `https://form.gov.sg/64929532701266001209ac32?<field>=<chatId>` (`buildSupportFormUrl` in `packages/backend/src/helpers/ai/build-support-form-url.ts`), so whenever the model directs a user to support, the link carries their chat ID pre-filled.
- Frontend: added a "Still need help? **Contact us here**" link to the chat footer (`ChatInterface/index.tsx`), opening the same pre-filled form in a new tab regardless of what the model says in-conversation.
- The form/field IDs are duplicated as constants on both sides (`build-support-form-url.ts` on the backend, `constants.ts`/`helpers.ts` on the frontend), each with a "keep in sync" comment pointing at the other, matching the existing `MAX_MESSAGES` convention.

## Tests

- [ ] Submit a support request from the AI Builder chat footer link and confirm the chat ID shows up pre-filled on the form.
- [ ] Trigger an in-chat "direct to support" response (e.g. ask for an unsupported capability with no workaround) and confirm the link the assistant shows also carries the chat ID.
- [ ] Confirm the link opens in a new tab.

## Deploy notes

- The AI Builder system prompt in Langfuse must be upgraded to **v178** (or take the equivalent `{{SUPPORT_FORM_URL}}` substitution from `v178`) for the in-chat support link to actually appear — without that prompt update, the model has no placeholder to substitute and won't mention the support link at all.




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds chat-specific support-form links to AI Builder so support requests can be traced to their Langfuse sessions.
- Replaces the support-form placeholder in the backend system prompt with a URL containing the chat ID.
- Adds an external support link beneath the frontend chat controls.
- Encodes the chat ID as a support-form query parameter and covers URL construction with tests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/routes/api/chat/index.ts | Substitutes the URL-encoded, schema-validated chat ID into the support-form placeholder in the system prompt. |
| packages/backend/src/helpers/ai/build-support-form-url.ts | Builds the backend support-form URL using a fixed base URL and URLSearchParams. |
| packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx | Adds a chat-footer support link pre-filled with the current chat ID; the previously reported spacing issue is invalid. |
| packages/frontend/src/pages/AiBuilder/helpers.ts | Adds the frontend support-form URL builder with safe query-parameter encoding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(ai-builder): add support link with ..."](https://github.com/opengovsg/plumber/commit/9e83c0deaa8710cf48e67957bffd28d152689efb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59431576)</sub>

<!-- /greptile_comment -->