### PR TITLE
feat: ops script to resend Postman emails from stored data_in

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,6 +25,7 @@
     "dynamodb:seed": "ts-node src/db/dynamodb_seeds/seed_rows.ts",
     "readme:dynamodb:setup": "echo 'Run this function to create the required tile table in dynamodb locally.'",
     "dynamodb:setup": "ts-node src/db/dynamodb_seeds/create_table.ts",
+    "resend:postman-execution-steps": "ts-node --swc src/scripts/resend-postman-execution-steps.ts",
     "copy-statics": "cpy '**/*.{graphql,json,svg}' ../dist --cwd=src"
   },
   "dependencies": {

--- a/packages/backend/src/scripts/resend-postman-execution-steps.ts
+++ b/packages/backend/src/scripts/resend-postman-execution-steps.ts
@@ -1,0 +1,145 @@
+/* eslint-disable no-console */
+import '@/config/app-env-vars'
+import '@/config/orm'
+
+import { readFileSync } from 'fs'
+import { z } from 'zod'
+
+import { client as db } from '@/config/database'
+import {
+  ResendPostmanStepError,
+  resendPostmanExecutionStepById,
+} from '@/services/resend-postman-execution-step'
+
+const uuidSchema = z.string().uuid()
+
+function printUsage(): void {
+  console.error(`Usage:
+  npx ts-node --swc src/scripts/resend-postman-execution-steps.ts --ids <uuid>[,<uuid>...]
+  npx ts-node --swc src/scripts/resend-postman-execution-steps.ts --file <path>
+
+Options:
+  --dry-run          Load rows and print recipients. Do not send.
+  --max-attempts N   Retries for RetriableError. Default 5.
+  --delay-ms N       Pause between execution steps. Default 50.
+
+Reads stored execution_steps.data_in and resends that Postman email.
+Does not expose a user-facing retry. Does not write a new execution_step.
+`)
+}
+
+function parseIdsFromText(raw: string): string[] {
+  const tokens = raw
+    .split(/[\s,]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0 && !token.startsWith('#'))
+
+  const ids: string[] = []
+  const seen = new Set<string>()
+  for (const token of tokens) {
+    const parsed = uuidSchema.safeParse(token)
+    if (!parsed.success) {
+      throw new Error(`Invalid execution step id: ${token}`)
+    }
+    if (seen.has(parsed.data)) {
+      continue
+    }
+    seen.add(parsed.data)
+    ids.push(parsed.data)
+  }
+  return ids
+}
+
+function parseArgs(argv: string[]): {
+  ids: string[]
+  dryRun: boolean
+  maxAttempts: number | undefined
+  delayMs: number
+} {
+  const get = (flag: string) => {
+    const idx = argv.indexOf(flag)
+    return idx !== -1 ? argv[idx + 1] : undefined
+  }
+
+  const dryRun = argv.includes('--dry-run')
+  const idsArg = get('--ids')
+  const fileArg = get('--file')
+  const maxAttemptsArg = get('--max-attempts')
+  const delayMsArg = get('--delay-ms')
+
+  if (!idsArg && !fileArg) {
+    printUsage()
+    process.exit(1)
+  }
+
+  const raw = fileArg ? readFileSync(fileArg, 'utf8') : (idsArg ?? '')
+  const ids = parseIdsFromText(raw)
+  if (ids.length === 0) {
+    throw new Error('No execution step ids provided')
+  }
+
+  return {
+    ids,
+    dryRun,
+    maxAttempts: maxAttemptsArg ? Number(maxAttemptsArg) : undefined,
+    delayMs: delayMsArg ? Number(delayMsArg) : 50,
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function main(): Promise<void> {
+  const { ids, dryRun, maxAttempts, delayMs } = parseArgs(process.argv.slice(2))
+
+  console.log(
+    JSON.stringify({
+      count: ids.length,
+      dryRun,
+      maxAttempts: maxAttempts ?? 5,
+    }),
+  )
+
+  let failed = 0
+  for (let i = 0; i < ids.length; i++) {
+    const executionStepId = ids[i]
+    try {
+      const result = await resendPostmanExecutionStepById(executionStepId, {
+        dryRun,
+        maxAttempts,
+      })
+      if (result.error) {
+        failed += 1
+      }
+      console.log(JSON.stringify(result))
+    } catch (error) {
+      failed += 1
+      const message =
+        error instanceof ResendPostmanStepError || error instanceof Error
+          ? error.message
+          : String(error)
+      console.log(
+        JSON.stringify({
+          executionStepId,
+          error: message,
+        }),
+      )
+    }
+
+    if (i < ids.length - 1 && delayMs > 0) {
+      await sleep(delayMs)
+    }
+  }
+
+  if (failed > 0) {
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await db.destroy()
+  })

--- a/packages/backend/src/services/__tests__/resend-postman-execution-step.test.ts
+++ b/packages/backend/src/services/__tests__/resend-postman-execution-step.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PartialStepError from '@/errors/partial-error'
+import RetriableError from '@/errors/retriable-error'
+
+import {
+  ResendPostmanStepError,
+  resendPostmanExecutionStepById,
+} from '../resend-postman-execution-step'
+
+const mocks = vi.hoisted(() => {
+  const run = vi.fn()
+  const getApp = vi.fn(async () => ({
+    key: 'postman',
+    apiBaseUrl: 'https://api.postman.gov.sg',
+  }))
+  const relatedQuery = vi.fn(async () => null)
+  const globalVariable = vi.fn()
+  const findById = vi.fn()
+
+  return { run, getApp, relatedQuery, globalVariable, findById }
+})
+
+vi.mock('@/apps/postman/actions/send-transactional-email', () => ({
+  default: {
+    run: mocks.run,
+  },
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: mocks.globalVariable,
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/models/execution-step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: mocks.findById,
+    })),
+  },
+}))
+
+function mockQueryResult(executionStep: unknown) {
+  mocks.findById.mockReturnValue({
+    withGraphFetched: vi.fn(() => ({
+      withSoftDeleted: vi.fn(async () => executionStep),
+    })),
+  })
+}
+
+function makeExecutionStep(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+    status: 'success',
+    dataIn: {
+      destinationEmail: 'user@open.gov.sg',
+      subject: 'Original subject',
+      body: 'Original body',
+      senderName: 'Plumber',
+    },
+    metadata: {},
+    execution: {
+      id: '22222222-2222-2222-2222-222222222222',
+      testRun: false,
+      flow: {
+        id: '33333333-3333-3333-3333-333333333333',
+        name: 'Test flow',
+        user: { email: 'owner@open.gov.sg' },
+      },
+    },
+    step: {
+      id: '44444444-4444-4444-4444-444444444444',
+      getApp: mocks.getApp,
+      $relatedQuery: mocks.relatedQuery,
+    },
+    ...overrides,
+  }
+}
+
+describe('resendPostmanExecutionStepById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.globalVariable.mockImplementation(async () => ({
+      step: { parameters: {} },
+      actionOutput: { data: { raw: null } },
+      getLastExecutionStep: vi.fn(),
+    }))
+    mocks.run.mockResolvedValue(undefined)
+    mocks.getApp.mockResolvedValue({
+      key: 'postman',
+      apiBaseUrl: 'https://api.postman.gov.sg',
+    })
+    mocks.relatedQuery.mockResolvedValue(null)
+  })
+
+  it('sends using stored data_in and ignores last execution step', async () => {
+    mockQueryResult(makeExecutionStep())
+    const $ = {
+      step: { parameters: { destinationEmail: 'stale@open.gov.sg' } },
+      actionOutput: {
+        data: {
+          raw: { status: ['ACCEPTED'], recipient: ['user@open.gov.sg'] },
+        },
+      },
+      getLastExecutionStep: vi.fn(),
+    }
+    mocks.globalVariable.mockResolvedValue($)
+    mocks.run.mockImplementation(async (globalVar) => {
+      globalVar.actionOutput.data = {
+        raw: { status: ['ACCEPTED'], recipient: ['user@open.gov.sg'] },
+      }
+    })
+
+    const result = await resendPostmanExecutionStepById(
+      '11111111-1111-1111-1111-111111111111',
+    )
+
+    expect($.step.parameters).toEqual({
+      destinationEmail: 'user@open.gov.sg',
+      subject: 'Original subject',
+      body: 'Original body',
+      senderName: 'Plumber',
+    })
+    expect(await $.getLastExecutionStep()).toBeUndefined()
+    expect(result.error).toBeNull()
+    expect(result.dataOut).toEqual({
+      status: ['ACCEPTED'],
+      recipient: ['user@open.gov.sg'],
+    })
+    expect(mocks.run).toHaveBeenCalledOnce()
+  })
+
+  it('does not send on dry run', async () => {
+    mockQueryResult(makeExecutionStep())
+
+    const result = await resendPostmanExecutionStepById(
+      '11111111-1111-1111-1111-111111111111',
+      { dryRun: true },
+    )
+
+    expect(result.dryRun).toBe(true)
+    expect(result.destinationEmail).toBe('user@open.gov.sg')
+    expect(mocks.run).not.toHaveBeenCalled()
+    expect(mocks.globalVariable).not.toHaveBeenCalled()
+  })
+
+  it('retries RetriableError then succeeds', async () => {
+    mockQueryResult(makeExecutionStep())
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    mocks.run
+      .mockRejectedValueOnce(
+        new RetriableError({
+          error: 'rate limited',
+          delayInMs: 10,
+          delayType: 'step',
+        }),
+      )
+      .mockResolvedValueOnce(undefined)
+
+    const result = await resendPostmanExecutionStepById(
+      '11111111-1111-1111-1111-111111111111',
+      { sleep, maxAttempts: 3 },
+    )
+
+    expect(result.error).toBeNull()
+    expect(mocks.run).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(10)
+  })
+
+  it('returns partial success without throwing', async () => {
+    mockQueryResult(makeExecutionStep())
+    mocks.run.mockRejectedValue(
+      new PartialStepError({
+        name: 'Blacklisted recipient email',
+        solution: 'Remove the recipient',
+        partialRetry: { buttonMessage: 'Retry' },
+      }),
+    )
+
+    const result = await resendPostmanExecutionStepById(
+      '11111111-1111-1111-1111-111111111111',
+    )
+
+    expect(result.error).toContain('Blacklisted recipient email')
+  })
+
+  it.each([
+    {
+      name: 'missing row',
+      row: null,
+      message: 'was not found',
+    },
+    {
+      name: 'wrong app',
+      row: makeExecutionStep({ appKey: 'slack' }),
+      message: 'not a Postman send-email action',
+    },
+    {
+      name: 'failed status',
+      row: makeExecutionStep({ status: 'failure' }),
+      message: 'not success',
+    },
+    {
+      name: 'missing data_in',
+      row: makeExecutionStep({ dataIn: null }),
+      message: 'has no data_in',
+    },
+    {
+      name: 'test run',
+      row: makeExecutionStep({
+        execution: {
+          id: '22222222-2222-2222-2222-222222222222',
+          testRun: true,
+          flow: {
+            id: '33333333-3333-3333-3333-333333333333',
+            user: { email: 'owner@open.gov.sg' },
+          },
+        },
+      }),
+      message: 'test run',
+    },
+  ])('rejects $name', async ({ row, message }) => {
+    mockQueryResult(row)
+
+    await expect(
+      resendPostmanExecutionStepById('11111111-1111-1111-1111-111111111111'),
+    ).rejects.toBeInstanceOf(ResendPostmanStepError)
+
+    await expect(
+      resendPostmanExecutionStepById('11111111-1111-1111-1111-111111111111'),
+    ).rejects.toThrow(message)
+  })
+})

--- a/packages/backend/src/services/resend-postman-execution-step.ts
+++ b/packages/backend/src/services/resend-postman-execution-step.ts
@@ -1,0 +1,239 @@
+import { IJSONObject } from '@plumber/types'
+
+import sendTransactionalEmail from '@/apps/postman/actions/send-transactional-email'
+import PartialStepError from '@/errors/partial-error'
+import RetriableError from '@/errors/retriable-error'
+import globalVariable from '@/helpers/global-variable'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+
+const POSTMAN_APP_KEY = 'postman'
+const SEND_EMAIL_ACTION_KEY = 'sendTransactionalEmail'
+
+export const DEFAULT_MAX_ATTEMPTS = 5
+
+export class ResendPostmanStepError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ResendPostmanStepError'
+  }
+}
+
+export type SleepFn = (ms: number) => Promise<void>
+
+export type ResendPostmanStepResult = {
+  executionStepId: string
+  executionId: string
+  flowId: string | null
+  dryRun: boolean
+  destinationEmail: unknown
+  subject: unknown
+  dataOut: IJSONObject | null
+  error: string | null
+}
+
+const defaultSleep: SleepFn = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+type LoadedPostmanExecutionStep = ExecutionStep & {
+  dataIn: IJSONObject
+  execution: Execution & { flow: Flow }
+  step: Step
+}
+
+function isRecord(value: unknown): value is IJSONObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export async function loadPostmanExecutionStep(
+  executionStepId: string,
+): Promise<LoadedPostmanExecutionStep> {
+  const executionStep = await ExecutionStep.query()
+    .findById(executionStepId)
+    .withGraphFetched({
+      execution: {
+        flow: {
+          user: true,
+        },
+      },
+      step: true,
+    })
+    .withSoftDeleted()
+
+  if (!executionStep) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} was not found`,
+    )
+  }
+
+  if (
+    executionStep.appKey !== POSTMAN_APP_KEY ||
+    executionStep.key !== SEND_EMAIL_ACTION_KEY
+  ) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} is not a Postman send-email action`,
+    )
+  }
+
+  if (executionStep.status !== 'success') {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} status is ${executionStep.status}, not success`,
+    )
+  }
+
+  if (!isRecord(executionStep.dataIn)) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} has no data_in`,
+    )
+  }
+
+  if (!executionStep.execution) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} has no execution`,
+    )
+  }
+
+  if (executionStep.execution.testRun) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} belongs to a test run`,
+    )
+  }
+
+  if (!executionStep.step) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} has no step`,
+    )
+  }
+
+  if (!executionStep.execution.flow) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} has no flow`,
+    )
+  }
+
+  return executionStep as LoadedPostmanExecutionStep
+}
+
+/**
+ * Resends using stored data_in so a later pipe edit cannot change the email.
+ * Does not write execution_steps, so this stays off the owner UI.
+ */
+export async function resendPostmanExecutionStepById(
+  executionStepId: string,
+  options: {
+    dryRun?: boolean
+    maxAttempts?: number
+    sleep?: SleepFn
+  } = {},
+): Promise<ResendPostmanStepResult> {
+  const dryRun = options.dryRun ?? false
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  const sleep = options.sleep ?? defaultSleep
+
+  const executionStep = await loadPostmanExecutionStep(executionStepId)
+  const dataIn = executionStep.dataIn
+  const execution = executionStep.execution
+  const step = executionStep.step
+  const flow = execution.flow
+
+  const result: ResendPostmanStepResult = {
+    executionStepId: executionStep.id,
+    executionId: execution.id,
+    flowId: flow.id,
+    dryRun,
+    destinationEmail: dataIn.destinationEmail,
+    subject: dataIn.subject,
+    dataOut: null,
+    error: null,
+  }
+
+  if (dryRun) {
+    logger.info('Dry-run Postman execution step resend', {
+      event: 'ops-resend-postman-execution-step-dry-run',
+      executionStepId: executionStep.id,
+      executionId: execution.id,
+      flowId: flow.id,
+    })
+    return result
+  }
+
+  const app = await step.getApp()
+  if (!app) {
+    throw new ResendPostmanStepError(
+      `Execution step ${executionStepId} step has no app`,
+    )
+  }
+
+  const $ = await globalVariable({
+    flow,
+    app,
+    step,
+    connection: await step.$relatedQuery('connection'),
+    execution,
+    testRun: false,
+    metadata: executionStep.metadata,
+  })
+
+  $.step.parameters = dataIn
+  // Original ACCEPTED rows may not have been delivered. Resend every recipient.
+  $.getLastExecutionStep = async () => undefined
+
+  let lastError: unknown = null
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await sendTransactionalEmail.run($)
+      lastError = null
+      break
+    } catch (error) {
+      lastError = error
+      if (error instanceof RetriableError && attempt < maxAttempts) {
+        logger.warn('Retrying Postman execution step resend', {
+          event: 'ops-resend-postman-execution-step-retry',
+          executionStepId: executionStep.id,
+          attempt,
+          delayInMs: error.delayInMs,
+        })
+        await sleep(error.delayInMs)
+        continue
+      }
+      break
+    }
+  }
+
+  result.dataOut = ($.actionOutput.data?.raw as IJSONObject | null) ?? null
+
+  if (lastError instanceof PartialStepError) {
+    result.error = lastError.message
+    logger.warn('Postman execution step resend had partial success', {
+      event: 'ops-resend-postman-execution-step-partial',
+      executionStepId: executionStep.id,
+      executionId: execution.id,
+      error: lastError.message,
+    })
+    return result
+  }
+
+  if (lastError) {
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError)
+    result.error = message
+    logger.error('Postman execution step resend failed', {
+      event: 'ops-resend-postman-execution-step-failed',
+      executionStepId: executionStep.id,
+      executionId: execution.id,
+      error: message,
+    })
+    return result
+  }
+
+  logger.info('Postman execution step resend succeeded', {
+    event: 'ops-resend-postman-execution-step-success',
+    executionStepId: executionStep.id,
+    executionId: execution.id,
+    flowId: flow.id,
+  })
+  return result
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Some Postman `sendTransactionalEmail` steps were stored as `success` in `executions` / `execution_steps`, but recipients reported no email. Existing retries cannot fix that:

- `retryExecutionStep` only loads `status = failure` BullMQ jobs and then continues the pipe.
- `retryPartialStep` requires `errorDetails` and recomputes parameters from the current step config.

This adds a **manual ops script** that is not exposed in GraphQL or the UI.

## What it does

For each `execution_steps.id`:

1. Load that row and require `app_key = postman`, `key = sendTransactionalEmail`, `status = success`, non-test execution, and a `data_in` object.
2. Run the Postman send action with **that stored `data_in`** (the original computed recipients, subject, body, attachments).
3. Ignore the previous execution step so every recipient in `data_in` is sent again, including those previously marked `ACCEPTED`.
4. Do **not** enqueue later steps.
5. Do **not** insert a new `execution_step`, so the pipe owner UI is unchanged.

## How to run

Dry run first:

```sh
npm run -w backend resend:postman-execution-steps -- --dry-run --ids <uuid>[,<uuid>...]
```

Or a file of UUIDs (comma or newline separated):

```sh
npm run -w backend resend:postman-execution-steps -- --file ids.txt
```

Run against the same env as a worker so Postman, SES, S3, and Postgres config match production.

## Tests

Unit tests cover data_in reuse, dry-run, RetriableError retry, partial success, and validation. Node/npm was blocked in this agent environment, so they were not executed here. Please run:

```sh
npm run -w backend test:unit -- src/services/__tests__/resend-postman-execution-step.test.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d26c16c2-9578-47e3-bdaf-a3ef6a9d4987?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26c16c2-9578-47e3-bdaf-a3ef6a9d4987&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

