### PR TITLE
feat(flows): allow editors and viewers to leave a pipe

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -93,12 +93,47 @@ describe('delete flow collaborators', () => {
     ).rejects.toThrow(NotFoundError)
   })
 
-  it('should throw an error when deleting oneself', async () => {
+  it('should allow an editor to leave the pipe', async () => {
     context.currentUser = editor
+    await deleteFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: editor.email } },
+      context,
+    )
+
+    const editorRow = await FlowCollaborator.query()
+      .findOne({
+        flow_id: dummyFlow.id,
+        user_id: editor.id,
+      })
+      .where('deleted_at', null)
+
+    expect(editorRow).toBeUndefined()
+  })
+
+  it('should allow a viewer to leave the pipe', async () => {
+    context.currentUser = viewer
+    await deleteFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: viewer.email } },
+      context,
+    )
+
+    const viewerRow = await FlowCollaborator.query()
+      .findOne({
+        flow_id: dummyFlow.id,
+        user_id: viewer.id,
+      })
+      .where('deleted_at', null)
+
+    expect(viewerRow).toBeUndefined()
+  })
+
+  it('should throw an error when the owner tries to leave', async () => {
     await expect(
       deleteFlowCollaborator(
         null,
-        { input: { flowId: dummyFlow.id, email: editor.email } },
+        { input: { flowId: dummyFlow.id, email: owner.email } },
         context,
       ),
     ).rejects.toThrow(BadUserInputError)

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -139,6 +139,31 @@ describe('delete flow collaborators', () => {
     ).rejects.toThrow(BadUserInputError)
   })
 
+  it('should not distinguish nonexistent and inaccessible flows when leaving', async () => {
+    context.currentUser = nonCollaborator
+    const otherOwnerFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'other owner flow',
+      userId: owner.id,
+    })
+
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: randomUUID(), email: nonCollaborator.email } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: otherOwnerFlow.id, email: nonCollaborator.email } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+  })
+
   it('should throw an error if trying to delete owner', async () => {
     context.currentUser = editor
     await expect(

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,7 +1,6 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import logger from '@/helpers/logger'
-import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import User from '@/models/user'
 
@@ -22,12 +21,13 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
     const isSelf = validatedEmail === context.currentUser.email
 
     if (isSelf) {
-      const flow = await Flow.query()
+      // Scope to accessible flows so missing and inaccessible IDs share one error.
+      const flow = await context.currentUser
+        .withAccessibleFlows({ requiredRole: 'viewer' })
         .findById(flowId)
-        .throwIfNotFound({ message: 'Flow not found' })
+        .throwIfNotFound()
 
-      // Ownership lives on flows.user_id, not flow_collaborators.
-      if (flow.userId === context.currentUser.id) {
+      if (flow.role === 'owner') {
         throw new BadUserInputError(
           'Owners cannot leave. Transfer ownership first.',
         )

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,6 +1,7 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import User from '@/models/user'
 
@@ -18,11 +19,46 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
       throw new BadUserInputError('Invalid collaborator email')
     }
 
-    if (validatedEmail === context.currentUser.email) {
-      throw new BadUserInputError('Cannot remove yourself')
+    const isSelf = validatedEmail === context.currentUser.email
+
+    if (isSelf) {
+      const flow = await Flow.query()
+        .findById(flowId)
+        .throwIfNotFound({ message: 'Flow not found' })
+
+      // Ownership lives on flows.user_id, not flow_collaborators.
+      if (flow.userId === context.currentUser.id) {
+        throw new BadUserInputError(
+          'Owners cannot leave. Transfer ownership first.',
+        )
+      }
+
+      try {
+        await FlowCollaborator.query()
+          .delete()
+          .where({
+            flow_id: flowId,
+            user_id: context.currentUser.id,
+          })
+          .returning('*')
+          .throwIfNotFound({ message: 'No such collaborator found' })
+      } catch (e) {
+        logger.error({
+          message: 'Failed to leave pipe as collaborator',
+          data: {
+            flowId,
+            email,
+          },
+          userId: context.currentUser.id,
+          error: e,
+        })
+        throw new Error(e.message ?? 'Failed to leave pipe')
+      }
+
+      return true
     }
 
-    // only editor or owner can delete collaborators
+    // only editor or owner can delete other collaborators
     await FlowCollaborator.hasAccess({
       userId: context.currentUser.id,
       flowId,

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -42,7 +42,7 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
           })
           .returning('*')
           .throwIfNotFound({ message: 'No such collaborator found' })
-      } catch (e) {
+      } catch {
         logger.error({
           message: 'Failed to leave pipe as collaborator',
           data: {
@@ -50,9 +50,8 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
             email,
           },
           userId: context.currentUser.id,
-          error: e,
         })
-        throw new Error(e.message ?? 'Failed to leave pipe')
+        throw new Error('Failed to leave pipe')
       }
 
       return true

--- a/packages/frontend/src/components/EditorSettings/FlowCollaborators/CollaboratorsTable.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowCollaborators/CollaboratorsTable.tsx
@@ -1,7 +1,8 @@
 import { IFlow, IFlowCollaborator, IFlowCollabRole } from '@plumber/types'
 
-import { useCallback, useContext, useState } from 'react'
-import { BiTrash } from 'react-icons/bi'
+import { useCallback, useContext, useRef, useState } from 'react'
+import { BiLogOut, BiTrash } from 'react-icons/bi'
+import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
   Center,
@@ -14,11 +15,14 @@ import {
   Th,
   Thead,
   Tr,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { IconButton, Tag, useToast } from '@opengovsg/design-system-react'
 
 import CollaboratorRoleSelect from '@/components/CollaboratorRoleSelect'
+import MenuAlertDialog from '@/components/MenuAlertDialog'
 import PrimarySpinner from '@/components/PrimarySpinner'
+import * as URLS from '@/config/urls'
 import { AuthenticationContext } from '@/contexts/Authentication'
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { DELETE_FLOW_COLLABORATOR } from '@/graphql/mutations/delete-flow-collaborator'
@@ -51,6 +55,7 @@ const TableRow = (props: TableRowProps) => {
   const { collaborator, flow, hasEditPermission, onRoleChange } = props
   const { currentUser } = useContext(AuthenticationContext)
   const { email = '', role } = collaborator
+  const navigate = useNavigate()
 
   const toast = useToast({
     status: 'success',
@@ -61,9 +66,17 @@ const TableRow = (props: TableRowProps) => {
   const [deleteCollaborator] = useMutation(DELETE_FLOW_COLLABORATOR)
   const [isDeleting, setIsDeleting] = useState(false)
 
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const {
+    isOpen: isLeaveDialogOpen,
+    onOpen: onLeaveDialogOpen,
+    onClose: onLeaveDialogClose,
+  } = useDisclosure()
+
   const isOwner = role === 'owner'
   const isSelf = email === currentUser?.email
   const isEditable = hasEditPermission && !isOwner && !isSelf
+  const canLeave = isSelf && !isOwner
 
   const onDeleteHandler = useCallback(async () => {
     setIsDeleting(true)
@@ -84,6 +97,33 @@ const TableRow = (props: TableRowProps) => {
       setIsDeleting(false)
     }
   }, [deleteCollaborator, email, flow.id, toast])
+
+  const onLeaveHandler = useCallback(async () => {
+    setIsDeleting(true)
+    try {
+      await deleteCollaborator({
+        variables: {
+          input: { flowId: flow.id, email },
+        },
+        onCompleted: () => {
+          onLeaveDialogClose()
+          toast({
+            title: 'You have left this pipe',
+          })
+          navigate(URLS.FLOWS)
+        },
+      })
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [
+    deleteCollaborator,
+    email,
+    flow.id,
+    navigate,
+    onLeaveDialogClose,
+    toast,
+  ])
 
   return (
     <Tr key={email}>
@@ -117,6 +157,27 @@ const TableRow = (props: TableRowProps) => {
             isLoading={isDeleting}
             icon={<BiTrash />}
           />
+        )}
+        {canLeave && (
+          <>
+            <IconButton
+              colorScheme="critical"
+              onClick={onLeaveDialogOpen}
+              aria-label="leave pipe"
+              variant="clear"
+              isLoading={isDeleting}
+              icon={<BiLogOut />}
+            />
+            <MenuAlertDialog
+              cancelRef={cancelRef}
+              isLoading={isDeleting}
+              isDialogOpen={isLeaveDialogOpen}
+              onDialogClose={onLeaveDialogClose}
+              dialogType="leave"
+              dialogHeader="Pipe"
+              onClick={onLeaveHandler}
+            />
+          </>
         )}
       </Td>
     </Tr>

--- a/packages/frontend/src/components/EditorSettings/FlowCollaborators/CollaboratorsTable.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowCollaborators/CollaboratorsTable.tsx
@@ -116,14 +116,7 @@ const TableRow = (props: TableRowProps) => {
     } finally {
       setIsDeleting(false)
     }
-  }, [
-    deleteCollaborator,
-    email,
-    flow.id,
-    navigate,
-    onLeaveDialogClose,
-    toast,
-  ])
+  }, [deleteCollaborator, email, flow.id, navigate, onLeaveDialogClose, toast])
 
   return (
     <Tr key={email}>

--- a/packages/frontend/src/components/MenuAlertDialog/index.tsx
+++ b/packages/frontend/src/components/MenuAlertDialog/index.tsx
@@ -16,6 +16,7 @@ export type AlertDialogType =
   | 'duplicate'
   | 'duplicate-branch'
   | 'share-connections'
+  | 'leave'
 export type AlertHeaderType =
   | 'Connection'
   | 'Pipe'
@@ -78,6 +79,14 @@ function getAlertDialogContent(
           customBody ??
           `The collaborator will have access to your connections.`,
         buttonText: 'Yes, add editor',
+      }
+    case 'leave':
+      return {
+        header: 'Leave pipe',
+        body:
+          customBody ??
+          'Are you sure you want to leave this pipe? You will lose access.',
+        buttonText: 'Leave',
       }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Editors and viewers can remove themselves as collaborators on a Pipe. Owners cannot leave and must transfer ownership first.

## Changes
- **Backend** `deleteFlowCollaborator`: self-removal soft-deletes the caller’s `flow_collaborators` row without requiring editor permission. Owners get a clear error.
- Removing other collaborators still requires editor/owner.
- **Frontend**: leave button (with confirm dialog) on the self row for non-owners. Redirects to the pipes list after leaving.
- **Tests**: editor leave, viewer leave, owner leave rejected.

## Test plan
- [ ] As editor, open Share settings, leave pipe, confirm redirect and loss of access
- [ ] As viewer, leave pipe successfully
- [ ] As owner, no leave control; calling leave API returns ownership-transfer error
- [ ] Viewer still cannot remove another collaborator
- [ ] Editor can still remove another collaborator

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06532-9d72-7869-b484-e621c33f8035?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06532-9d72-7869-b484-e621c33f8035&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR allows editors and viewers to leave a pipe while preventing owners from leaving before transferring ownership.
- Scopes self-removal lookups to flows accessible by the caller.
- Soft-deletes the caller’s collaborator record and preserves permission checks for removing others.
- Adds a confirmation dialog, success notification, and redirect after leaving.
- Adds integration coverage for editor, viewer, owner, and inaccessible-flow cases.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/graphql/mutations/delete-flow-collaborator.ts | Adds caller-scoped self-removal, rejects owner departure, and resolves the previously reported flow-existence disclosure. |
| packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts | Covers editor and viewer departure, owner rejection, and equivalent handling of inaccessible and nonexistent flows. |
| packages/frontend/src/components/EditorSettings/FlowCollaborators/CollaboratorsTable.tsx | Adds the non-owner self-leave control, confirmation workflow, mutation handling, and post-departure redirect. |
| packages/frontend/src/components/MenuAlertDialog/index.tsx | Adds reusable content for the leave-pipe confirmation dialog. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(flows): scope leave to accessible fl..."](https://github.com/opengovsg/plumber/commit/17b6314d2ee3583f87dc2695d8a9df2c2638b64a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59833553)</sub>

<!-- /greptile_comment -->