### PR TITLE
chore: add flag to block domains from logging in to plumber

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -4,6 +4,14 @@
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
 
 /**
+ * Gates first-time logins for domains we need to temporarily turn away. The
+ * string variation is the user-facing message, and the domain is chosen by an
+ * LD targeting rule on the context key (the email). Blocking another domain or
+ * changing the message therefore needs no deploy.
+ */
+export const BLOCK_NEW_LOGINS_FLAG = 'block-new-logins'
+
+/**
  * App flags regex
  */
 export const APP_FLAG_REGEX = /^app_.*$/

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import TableMetadata from '@/models/table-metadata'
@@ -9,6 +9,15 @@ import Context from '@/types/express/context'
 import upsertTableCollaborator from '../../../mutations/tiles/upsert-table-collaborator'
 
 import { generateMockContext, generateMockTable } from './table.mock'
+
+const mocks = vi.hoisted(() => ({
+  // Empty string means no login block, so new collaborators are allowed.
+  getLdFlagValue: vi.fn().mockResolvedValue(''),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
 
 describe.each([['ddb'], ['pg']])(
   'update table collaborators: %s',

--- a/packages/backend/src/helpers/__tests__/auth.test.ts
+++ b/packages/backend/src/helpers/__tests__/auth.test.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import appConfig from '@/config/app'
+import { BLOCK_NEW_LOGINS_FLAG } from '@/config/flags'
 import User from '@/models/user'
 
 import {
@@ -12,6 +13,7 @@ import {
   sendOnboardingEmail,
   updateLastLogin,
 } from '../auth'
+import { getLdFlagValue } from '../launch-darkly'
 
 const mockPatchWhere = vi.fn()
 
@@ -52,6 +54,9 @@ vi.mock('@/config/app', () => ({
     onboardingEmailWebhookUrl: 'https://test-webhook.com',
     adminJwtSecretKey: 'test-secret-key',
   },
+}))
+vi.mock('../launch-darkly', () => ({
+  getLdFlagValue: vi.fn(),
 }))
 
 describe('Auth helpers', () => {
@@ -104,6 +109,10 @@ describe('Auth helpers', () => {
   })
 
   describe('getOrCreateUser', () => {
+    beforeEach(() => {
+      vi.mocked(getLdFlagValue).mockResolvedValue('')
+    })
+
     afterEach(() => {
       vi.clearAllMocks() // Clear mocks after each test
     })
@@ -189,6 +198,43 @@ describe('Auth helpers', () => {
       expect(mocks.insertAndFetch).toHaveBeenCalledWith({
         email: email.toLowerCase(),
       })
+    })
+
+    it('should reject a new login with the message served by LD', async () => {
+      mocks.findOne.mockResolvedValueOnce(null)
+      vi.mocked(getLdFlagValue).mockResolvedValue(
+        'Logins are paused while we migrate your agency.',
+      )
+
+      await expect(getOrCreateUser('chef@kitchen.com')).rejects.toThrowError(
+        'Logins are paused while we migrate your agency.',
+      )
+
+      expect(mocks.insertAndFetch).not.toHaveBeenCalled()
+    })
+
+    it('should evaluate the block flag against the lowercased email', async () => {
+      mocks.findOne.mockResolvedValueOnce(null)
+      mocks.insertAndFetch.mockResolvedValueOnce({ id: 'new-user-id' })
+
+      await getOrCreateUser('  Chef@KITCHEN.com  ')
+
+      expect(getLdFlagValue).toHaveBeenCalledWith(
+        BLOCK_NEW_LOGINS_FLAG,
+        'chef@kitchen.com',
+        '',
+      )
+    })
+
+    it('should not consult LD for an existing user', async () => {
+      mocks.findOne.mockResolvedValueOnce({
+        id: 'test-user-id',
+        email: 'barista@coffee.com',
+      })
+
+      await getOrCreateUser('barista@coffee.com')
+
+      expect(getLdFlagValue).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/backend/src/helpers/auth.ts
+++ b/packages/backend/src/helpers/auth.ts
@@ -3,8 +3,11 @@ import { Request, Response } from 'express'
 import jwt, { JsonWebTokenError } from 'jsonwebtoken'
 
 import appConfig from '@/config/app'
+import { BLOCK_NEW_LOGINS_FLAG } from '@/config/flags'
+import BaseError from '@/errors/base'
 import User from '@/models/user'
 
+import { getLdFlagValue } from './launch-darkly'
 import logger from './logger'
 
 const AUTH_COOKIE_NAME = 'plumber.sid'
@@ -67,11 +70,32 @@ export function deleteAuthCookie(res: Response) {
   res.clearCookie(AUTH_COOKIE_NAME)
 }
 
+/**
+ * Rejects a first-time login when LD targets the email's domain.
+ *
+ * The flag serves the user-facing message itself, so an empty value means the
+ * domain is not blocked. That keeps an LD outage from locking new users out.
+ */
+async function assertLoginNotBlocked(email: string): Promise<void> {
+  const blockedMessage = await getLdFlagValue(BLOCK_NEW_LOGINS_FLAG, email, '')
+
+  if (!blockedMessage) {
+    return
+  }
+
+  logger.info({
+    event: 'block-new-logins-rejected',
+    email,
+  })
+  throw new BaseError(blockedMessage)
+}
+
 export async function getOrCreateUser(email: string): Promise<User> {
   email = email.trim().toLowerCase()
 
   let user = await User.query().findOne({ email })
   if (!user) {
+    await assertLoginNotBlocked(email)
     user = await User.query().insertAndFetch({ email })
   }
 


### PR DESCRIPTION
## Problem

We need to temporarily stop **new** users from a specific email domain from logging in to Plumber, and tell them why.

## Solution

Move both the targeting and the message into a LaunchDarkly flag, so neither needs a deploy.

**Features**:

- New LD **String** flag `block-new-logins`, declared in `packages/backend/src/config/flags.ts`. The variation value **is** the user-facing message. An empty string means the domain is not blocked.
- `assertLoginNotBlocked` in `packages/backend/src/helpers/auth.ts` evaluates the flag with the email as the LD context key, matching how `getLdFlagValue` keys contexts.
- The check sits inside the `if (!user)` branch of `getOrCreateUser`, so only first-time logins are affected. Existing users never evaluate the flag.
- Which domain is blocked lives in an LD targeting rule on the context key (`key ends with @<domain>`). The backend never names a domain.
- A blocked attempt throws `BaseError`, which the existing Apollo error link renders as a toast on the login page. No frontend change.
- Rejections log `block-new-logins-rejected` with the email.

**Coverage**: `getOrCreateUser` is the single choke point for every login path, so one check covers all of them.

| Path | Entry point |
| --- | --- |
| Email OTP | `graphql/mutations/request-otp.ts` |
| sgid | `graphql/mutations/login-with-sgid.ts` |
| sgid (multi-hat) | `graphql/mutations/login-with-selected-sgid.ts` |
| OGP SSO | `graphql/mutations/login-with-sso.ts` |

Note that collaborator invites also route through `getOrCreateUser`, so while the flag is on, a blocked domain cannot be added as a pipe collaborator (`upsert-flow-collaborator.ts`) or a tile collaborator (`tiles/upsert-table-collaborator.ts`) either. They see the same message. This matches the behaviour of the earlier hardcoded block.

**Failure behaviour**: the fallback is `''`. A missing flag, an LD outage, or a misconfigured environment all allow logins rather than locking every new user out.

## Before & After Screenshots

**BEFORE**:
N/A. No such block exists today.

**AFTER**:
[insert screenshot of the login page error toast]

## Tests

**Unit tests** (3 added to `packages/backend/src/helpers/__tests__/auth.test.ts`):

```
npx vitest run packages/backend/src/helpers/__tests__/auth.test.ts
```

They cover the block throwing the LD-served message, the flag being evaluated against the trimmed and lowercased email, and existing users never consulting LD. LD targeting itself is not unit tested, since it is configured in the LD dashboard.

**Manual test.** First set up the flag in a non-production LD environment:

1. Create a String flag with key `block-new-logins`.
2. Variations: `Allowed` = `""`, and `Blocked` = your message text.
3. Set both the off variation and the default rule to `Allowed`.
4. Add a rule: context kind `user`, attribute `key`, operator `ends with`, value a lowercase domain you can test with (for example `@open.gov.sg`), serving `Blocked`.
5. Turn targeting on.

IMPORTANT: keep the rule value lowercase. `getOrCreateUser` lowercases the email before evaluating, and LD string operators are case-sensitive.

Then check each case:

| Case | Expected |
| --- | --- |
| Request an OTP with a **new** email on the targeted domain | Error toast showing your message. No OTP email sent. No row in `users`. |
| Log in with an **existing** user on the same domain | Normal login. Proves existing users are unaffected. |
| Request an OTP with an email on a **non-targeted** domain | Normal sign-up. |
| Add a targeted-domain email as a pipe collaborator | Same error message. |
| Toggle the flag off, then retry the first case | Normal sign-up. |

Confirm no user was created after a blocked attempt:

```sql
select id, email from users where email = '<blocked email>';
```

Check the rejection was logged by searching for `block-new-logins-rejected`.

## Deploy Notes

**Order does not matter.** Deploying before the flag exists is safe, because the `''` fallback allows all logins. Create the flag in each LD environment when you are ready to use it.

**To turn the block off**: toggle the flag off, or point the default rule at `Allowed`. No deploy needed.

**New environment variables**: none.

**New scripts**: none.

**New dependencies**: none.

**New dev dependencies**: none.




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces a LaunchDarkly-controlled gate that prevents targeted first-time users from being created while allowing existing users to continue logging in.
- Adds the `block-new-logins` string flag.
- Evaluates the normalized email before inserting a new user and reports the configured rejection message.
- Adds unit coverage for blocked, normalized, and existing-user paths.
- Updates table-collaborator integration setup with an allowing flag response.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/helpers/auth.ts | Adds normalized-email LaunchDarkly evaluation before creating a user while preserving the existing-user path. |
| packages/backend/src/config/flags.ts | Declares and documents the new string-valued login-block flag. |
| packages/backend/src/helpers/__tests__/auth.test.ts | Covers rejection messaging, normalized flag context, and bypassing flag evaluation for existing users. |
| packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts | Configures collaborator integration tests with the allowing flag fallback. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Login or collaborator flow
    participant Auth as getOrCreateUser
    participant DB as Users database
    participant LD as LaunchDarkly
    Caller->>Auth: getOrCreateUser(email)
    Auth->>Auth: Trim and lowercase email
    Auth->>DB: Find user by email
    alt Existing user
        DB-->>Auth: User
        Auth-->>Caller: Existing user
    else New user
        DB-->>Auth: Not found
        Auth->>LD: Evaluate block-new-logins
        alt Non-empty block message
            LD-->>Auth: Rejection message
            Auth-->>Caller: Throw BaseError
        else Empty value
            LD-->>Auth: Empty string
            Auth->>DB: Insert user
            DB-->>Auth: New user
            Auth-->>Caller: New user
        end
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix failing tests"](https://github.com/opengovsg/plumber/commit/18cdcead7021acd02c4bb3f64f317d5aec57c375) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59873517)</sub>

<!-- /greptile_comment -->