### PR TITLE
[IF-THEN-V2] Fix add step erroring in MRF pipes if-then on reject branch

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts
@@ -28,12 +28,25 @@ const trigger = (position: number): Fixture => ({
   position,
 })
 
-const plain = (id: string, position: number): Fixture => ({
+const plain = (
+  id: string,
+  position: number,
+  config: IStepConfig = {},
+): Fixture => ({
   id,
   appKey: 'postman',
   key: 'sendTransactionalEmail',
   position,
+  config,
 })
+
+const REJECT_MANAGER = {
+  approval: { branch: 'reject', stepId: 'mrfManager' },
+} satisfies IStepConfig
+
+const REJECT_DIRECTOR = {
+  approval: { branch: 'reject', stepId: 'mrfDirector' },
+} satisfies IStepConfig
 
 const ifThen = (
   id: string,
@@ -113,7 +126,7 @@ describe('deriveIfThenV1EndStep', () => {
     expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
   })
 
-  it('treats a following (reject-branch) if-then as an MRF boundary', () => {
+  it('clamps a main-flow block to the step before an mrfSubmission', () => {
     const ifThenA = ifThen('ifThenA', 2)
     const rejectIfThen = ifThen('rejectIfThen', 5, {
       parameters: { depth: '0' },
@@ -127,7 +140,76 @@ describe('deriveIfThenV1EndStep', () => {
       plain('stepAfter', 6),
     ]
 
-    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mrf')
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+  })
+
+  it('clamps a rejection-branch block to the step before the next mrfSubmission', () => {
+    const ifThenA = ifThen('ifThenA', 3, { config: REJECT_MANAGER })
+    const steps = [
+      trigger(1),
+      mrfSubmission('mrfManager', 2),
+      ifThenA,
+      plain('rejectChild', 4, REJECT_MANAGER),
+      mrfSubmission('mrfDirector', 5),
+      plain('mainAfter', 6),
+      ifThen('ifThenB', 7),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('rejectChild')
+  })
+
+  it('clamps a main-flow block to the step before a rejection branch starts', () => {
+    const ifThenA = ifThen('ifThenA', 3)
+    const steps = [
+      trigger(1),
+      mrfSubmission('mrfDirector', 2),
+      ifThenA,
+      plain('mainChild', 4),
+      plain('rejectChild', 5, REJECT_DIRECTOR),
+      ifThen('rejectIfThen', 6, { config: REJECT_DIRECTOR }),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mainChild')
+  })
+
+  it('clamps at a step belonging to a different rejection branch', () => {
+    const ifThenA = ifThen('ifThenA', 3, { config: REJECT_MANAGER })
+    const steps = [
+      trigger(1),
+      mrfSubmission('mrfManager', 2),
+      ifThenA,
+      plain('managerChild', 4, REJECT_MANAGER),
+      plain('directorChild', 5, REJECT_DIRECTOR),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('managerChild')
+  })
+
+  it('clamps the no-following-if-then case instead of running to the flow end', () => {
+    const ifThenA = ifThen('ifThenA', 3, { config: REJECT_MANAGER })
+    const steps = [
+      trigger(1),
+      mrfSubmission('mrfManager', 2),
+      ifThenA,
+      plain('rejectChild', 4, REJECT_MANAGER),
+      mrfSubmission('mrfDirector', 5),
+      plain('mainAfter', 6),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('rejectChild')
+  })
+
+  it('returns the if-then itself when its region ends immediately after it', () => {
+    const ifThenA = ifThen('ifThenA', 3, { config: REJECT_MANAGER })
+    const steps = [
+      trigger(1),
+      mrfSubmission('mrfManager', 2),
+      ifThenA,
+      mrfSubmission('mrfDirector', 4),
+      plain('mainAfter', 5),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
   })
 
   it('does not treat a deeper (nested) if-then as a boundary (mirrors V1 depth scan)', () => {

--- a/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts
@@ -736,7 +736,31 @@ describe('upgradeIfThenV1BlocksIfEnabled', () => {
     expect(stepPatchMocks.patchCalls).toHaveLength(0)
   })
 
-  it('throws end-step-write-rejected when a derived extent violates region confinement', async () => {
+  it('pins a rejection-branch block to its last member inside the branch', async () => {
+    const rejection = { approval: REJECTION_BRANCH }
+    const block = ifThen('block', 3, rejection)
+    const flowSteps = [
+      trigger(1),
+      mrfSubmission('mrf', 2),
+      block,
+      plain('rejectChild', 4, rejection),
+      mrfSubmission('mrfNext', 5),
+      plain('mainAfter', 6),
+    ]
+    getLdFlagValueMock.mockResolvedValue(true)
+
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('rejectChild') },
+    ])
+  })
+
+  it('pins a block whose region ends immediately after it to itself', async () => {
     const block = ifThen('block', 3, { approval: REJECTION_BRANCH })
     const flowSteps = [
       trigger(1),
@@ -746,14 +770,15 @@ describe('upgradeIfThenV1BlocksIfEnabled', () => {
     ]
     getLdFlagValueMock.mockResolvedValue(true)
 
-    await expect(
-      upgradeIfThenV1BlocksIfEnabled(
-        trx,
-        fakeFlow('owner@example.com'),
-        flowSteps,
-      ),
-    ).rejects.toThrow()
-    expect(stepPatchMocks.patchCalls).toHaveLength(0)
+    await upgradeIfThenV1BlocksIfEnabled(
+      trx,
+      fakeFlow('owner@example.com'),
+      flowSteps,
+    )
+
+    expect(stepPatchMocks.patchCalls).toEqual([
+      { id: 'block', patch: pinPatch('block') },
+    ])
   })
 
   it('deletes a lone blank member and self-references the emptied block', async () => {

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts
@@ -2,9 +2,11 @@ import type { IStep } from '@plumber/types'
 
 import {
   BLOCK_END_STEP_ID,
+  getRejectionBranchId,
   isBlankPlaceholderStep,
   isIfThenStep,
   isIfThenV2,
+  isMrfSubmissionStep,
   type StepLike,
 } from '../../../common/constants'
 
@@ -34,10 +36,13 @@ function parseDepth(step: ExtentStep): number {
 /**
  * Computes a V1 if-then block's derived extent (the last step, inclusive).
  *
- * IMPORTANT: this is a plain positional scan with no MRF awareness, so it can
- * derive an extent that crosses an mrfSubmission or a rejection-branch
- * boundary — region-confinement write validation is the safety net that
- * refuses to pin one that does.
+ * The extent stops at the block's own MRF region boundary, on half-open
+ * bounds, so an mrfSubmission is never a member. FormSG never sends a
+ * sub-trigger after a rejection, so a rejection branch always ends at the
+ * next mrfSubmission.
+ *
+ * IMPORTANT: returns the if-then itself (an empty block) when its region ends
+ * immediately after it.
  */
 export function deriveIfThenV1EndStep<T extends ExtentStep>(
   flowSteps: T[],
@@ -50,11 +55,20 @@ export function deriveIfThenV1EndStep<T extends ExtentStep>(
     (step, index) =>
       index > startIndex && isIfThenStep(step) && parseDepth(step) <= currDepth,
   )
+  const lastIndex =
+    nextBoundaryIndex === -1 ? flowSteps.length - 1 : nextBoundaryIndex - 1
 
-  if (nextBoundaryIndex === -1) {
-    return flowSteps[flowSteps.length - 1]
+  const blockRejectionBranchId = getRejectionBranchId(ifThenStep)
+  for (let index = startIndex + 1; index <= lastIndex; index++) {
+    const step = flowSteps[index]
+    if (
+      isMrfSubmissionStep(step) ||
+      getRejectionBranchId(step) !== blockRejectionBranchId
+    ) {
+      return flowSteps[index - 1]
+    }
   }
-  return flowSteps[nextBoundaryIndex - 1]
+  return flowSteps[lastIndex]
 }
 
 /**

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -62,6 +62,23 @@ export function isBlankPlaceholderStep(
   return !step?.appKey && !step?.key
 }
 
+export function isMrfSubmissionStep(
+  step: StepLike | null | undefined,
+): boolean {
+  return step?.appKey === 'formsg' && step?.key === 'mrfSubmission'
+}
+
+/**
+ * Which MRF rejection branch a step belongs to, or null for the main flow.
+ * `config.approval` is only ever written for rejection branches, so its
+ * `stepId` identifies the branch on its own.
+ */
+export function getRejectionBranchId(
+  step: StepLike | null | undefined,
+): string | null {
+  return step?.config?.approval?.stepId ?? null
+}
+
 // IMPORTANT: presence (Object.hasOwn), not value, distinguishes an if-then V2
 // step from if-then V1.
 export function isIfThenV2(step: StepLike | null | undefined): boolean {

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -17,8 +17,10 @@ import Step from '@/models/step'
 
 import {
   BLOCK_END_STEP_ID,
+  getRejectionBranchId,
   isIfThenStep,
   isIfThenV2,
+  isMrfSubmissionStep,
   type StepLike,
 } from './constants'
 
@@ -82,23 +84,9 @@ function rejectPublishEndStep(
   )
 }
 
-function isMrfSubmissionStep(step: ValidationStep): boolean {
-  return step.appKey === 'formsg' && step.key === 'mrfSubmission'
-}
-
 interface EndStepViolation {
   reason: string
   details: Record<string, unknown>
-}
-
-/**
- * Which MRF rejection branch a step belongs to, or null for the main flow.
- * `config.approval` is only ever written for rejection branches (its `branch`
- * is typed `'reject'`), so its `stepId` — the approval step the branch hangs
- * off — identifies the branch on its own.
- */
-function getRejectionBranchId(step: ValidationStep): string | null {
-  return step.config?.approval?.stepId ?? null
 }
 
 /**
@@ -391,8 +379,8 @@ export async function deriveV1EndStepDroppingBlankMembers(
  * pinned, the existing V2 repair logic protects the block forever after, so
  * this only ever needs to run once per block.
  *
- * IMPORTANT: a region-confinement violation on a pre-existing block throws
- * here too. This is an accepted risk on prod data, not a bug to soften.
+ * IMPORTANT: the derived extent is already region-confined, so an MRF pipe
+ * upgrades without tripping the region checks in `checkEndStepWrite`.
  */
 export async function upgradeIfThenV1BlocksIfEnabled(
   trx: Transaction,

--- a/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
+++ b/packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts
@@ -104,7 +104,7 @@ describe('deriveIfThenV1EndStep', () => {
     expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('ifThenA')
   })
 
-  it('treats a following if-then as a boundary across an MRF submission step', () => {
+  it('clamps a main-flow block to the step before an MRF submission step', () => {
     const ifThenA = ifThen('ifThenA')
     const rejectIfThen = ifThen('rejectIfThen', {
       config: { approval: { branch: 'reject', stepId: 'ifThenA' } },
@@ -117,7 +117,45 @@ describe('deriveIfThenV1EndStep', () => {
       plain('stepAfter'),
     ]
 
-    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('mrf')
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+  })
+
+  it('clamps a main-flow block to the step before a rejection branch starts', () => {
+    const ifThenA = ifThen('ifThenA')
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [
+      ifThenA,
+      plain('stepA'),
+      approvalStep('rejectChild'),
+      rejectIfThen,
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, ifThenA).id).toBe('stepA')
+  })
+
+  it('clamps a rejection-branch block to the step before the next MRF submission', () => {
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [
+      rejectIfThen,
+      approvalStep('rejectChild'),
+      mrfSubmission('mrfNext'),
+      plain('mainAfter'),
+    ]
+
+    expect(deriveIfThenV1EndStep(steps, rejectIfThen).id).toBe('rejectChild')
+  })
+
+  it('returns the if-then itself when its region ends immediately after it', () => {
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [rejectIfThen, mrfSubmission('mrfNext'), plain('mainAfter')]
+
+    expect(deriveIfThenV1EndStep(steps, rejectIfThen).id).toBe('rejectIfThen')
   })
 
   it('skips a deeper (nested) if-then when scanning for the boundary', () => {
@@ -371,8 +409,8 @@ describe('buildStepsList', () => {
         endStepId: 's2',
       },
     })
-    const s2 = plain('s2')
-    const s3 = plain('s3')
+    const s2 = approvalStep('s2')
+    const s3 = approvalStep('s3')
 
     expect(buildStepsList([approvalIf, s2, s3], GROUPING_ACTIONS)).toEqual([
       {
@@ -394,8 +432,8 @@ describe('buildStepsList', () => {
     const approvalIf = ifThen('approvalIf', {
       config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
     })
-    const s2 = plain('s2')
-    const s3 = plain('s3')
+    const s2 = approvalStep('s2')
+    const s3 = approvalStep('s3')
 
     expect(buildStepsList([approvalIf, s2, s3], GROUPING_ACTIONS)).toEqual([
       {
@@ -491,7 +529,24 @@ describe('isIfThenBlockRegionConfined', () => {
     ]
 
     expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(true)
-    expect(isIfThenBlockRegionConfined(steps, ifThenB)).toBe(false)
+    // The clamp ends ifThenB's extent at the MRF submission, leaving it empty.
+    expect(isIfThenBlockRegionConfined(steps, ifThenB)).toBe(true)
+  })
+
+  it('is true for a main-flow block whose next if-then sits in a rejection branch', () => {
+    const ifThenA = ifThen('ifThenA')
+    const rejectIfThen = ifThen('rejectIfThen', {
+      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+    })
+    const steps = [
+      ifThenA,
+      plain('a1'),
+      plain('a2'),
+      approvalStep('rejectChild'),
+      rejectIfThen,
+    ]
+
+    expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(true)
   })
 
   it('is true for an explicit if-then V2 block confined to one region', () => {
@@ -508,26 +563,15 @@ describe('isIfThenBlockRegionConfined', () => {
     expect(isIfThenBlockRegionConfined(steps, block)).toBe(true)
   })
 
-  it('is false when an MRF submission step sits inside the derived extent', () => {
-    // ifThenA's derived extent runs up to the step before the reject-branch
-    // if-then, i.e. it includes the MRF submission — a straddling block.
-    const ifThenA = ifThen('ifThenA')
-    const rejectIfThen = ifThen('rejectIfThen', {
-      config: { approval: { branch: 'reject', stepId: 'ifThenA' } },
-    })
-    const steps = [
-      ifThenA,
-      plain('a1'),
-      mrfSubmission('mrf'),
-      rejectIfThen,
-      plain('after'),
-    ]
+  it('is false when an MRF submission step sits inside an explicit region', () => {
+    const ifThenA = markedIfThen('ifThenA', 'after')
+    const steps = [ifThenA, plain('a1'), mrfSubmission('mrf'), plain('after')]
 
     expect(isIfThenBlockRegionConfined(steps, ifThenA)).toBe(false)
   })
 
-  it('is false when a top-level block reaches into a rejection branch', () => {
-    const ifThenA = ifThen('ifThenA')
+  it('is false when an explicit top-level block reaches into a rejection branch', () => {
+    const ifThenA = markedIfThen('ifThenA', 'a3')
     const steps = [
       ifThenA,
       plain('a1'),
@@ -556,18 +600,24 @@ describe('isIfThenBlockRegionConfined', () => {
     expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(true)
   })
 
-  it('is false when a rejection-branch block reaches back out to the main flow', () => {
+  it('is false when an explicit rejection-branch block reaches back out to the main flow', () => {
     const approvalIfThen = ifThen('approvalIf', {
-      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      config: {
+        approval: { branch: 'reject', stepId: 'someApprovalStep' },
+        endStepId: 'topLevel',
+      },
     })
     const steps = [approvalIfThen, approvalStep('a1'), plain('topLevel')]
 
     expect(isIfThenBlockRegionConfined(steps, approvalIfThen)).toBe(false)
   })
 
-  it('is false for a block spanning two different rejection branches', () => {
+  it('is false for an explicit block spanning two different rejection branches', () => {
     const approvalIfThen = ifThen('approvalIf', {
-      config: { approval: { branch: 'reject', stepId: 'someApprovalStep' } },
+      config: {
+        approval: { branch: 'reject', stepId: 'someApprovalStep' },
+        endStepId: 'otherBranch',
+      },
     })
     const otherBranchStep = {
       ...plain('otherBranch'),

--- a/packages/frontend/src/components/Editor/helpers/steps-utils.ts
+++ b/packages/frontend/src/components/Editor/helpers/steps-utils.ts
@@ -58,16 +58,26 @@ function parseDepth(step: IStep): number {
 }
 
 /**
+ * Mirrors the backend's `getRejectionBranchId`. `config.approval` is only
+ * ever written for rejection branches, so its `stepId` identifies the branch
+ * on its own.
+ */
+function getRejectionBranchId(step: IStep): string | null {
+  return step.config?.approval?.stepId ?? null
+}
+
+function isMrfSubmissionStep(step: IStep): boolean {
+  return step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY
+}
+
+/**
  * Derives an if-then V1 (marker-less) block's extent: the last step
  * (inclusive) inside the block. This mirrors the backend's
- * `deriveIfThenV1EndStep` so an if-then V1 displays over exactly the range it
- * actually executes over. An empty block (the next if-then immediately
- * follows) resolves to the if-then itself (self-reference).
+ * `deriveIfThenV1EndStep`, including its clamp to the block's own MRF region,
+ * so an if-then V1 displays over exactly the range it actually executes over.
  *
- * `actionSteps` is the MRF-filtered action-step list (trigger removed), ordered
- * by position. Because that list is already filtered to a single approval
- * branch, "the next if-then that passes the MRF same-approval-branch check" is
- * simply "the next if-then in the list".
+ * IMPORTANT: callers may pass either the MRF-filtered display list or the full
+ * `flow.steps`. The region clamp is what makes both agree.
  */
 export function deriveIfThenV1EndStep(
   actionSteps: IStep[],
@@ -80,15 +90,20 @@ export function deriveIfThenV1EndStep(
     (step, index) =>
       index > startIndex && isIfThenStep(step) && parseDepth(step) <= currDepth,
   )
+  const lastIndex =
+    nextBoundaryIndex === -1 ? actionSteps.length - 1 : nextBoundaryIndex - 1
 
-  if (nextBoundaryIndex === -1) {
-    return actionSteps[actionSteps.length - 1]
+  const blockRejectionBranchId = getRejectionBranchId(ifThenStep)
+  for (let index = startIndex + 1; index <= lastIndex; index++) {
+    const step = actionSteps[index]
+    if (
+      isMrfSubmissionStep(step) ||
+      getRejectionBranchId(step) !== blockRejectionBranchId
+    ) {
+      return actionSteps[index - 1]
+    }
   }
-  return actionSteps[nextBoundaryIndex - 1]
-}
-
-function isMrfSubmissionStep(step: IStep): boolean {
-  return step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY
+  return actionSteps[lastIndex]
 }
 
 /**
@@ -108,15 +123,6 @@ function resolveBlockEndStep(
     }
   }
   return deriveIfThenV1EndStep(flowSteps, ifThenStep)
-}
-
-/**
- * Mirrors the backend's `getRejectionBranchId`. `config.approval` is only
- * ever written for rejection branches, so its `stepId` (the approval step
- * the branch hangs off) identifies the branch on its own.
- */
-function getRejectionBranchId(step: IStep): string | null {
-  return step.config?.approval?.stepId ?? null
 }
 
 /**


### PR DESCRIPTION
# Problem

In an MRF pipe with a legacy if-then on the reject branch, adding steps after that if-then will result in an error - "_endStepId write rejected: mrf-step-in-region_".

> Example:
>
> 1. MRF Respondent 1 Reject
> 2. If-Then ...
> 3. MRF Respondent 2 Approve
> 4. \<Steps>
> 5. MRF Respondent 2 Reject
> 6. \<Steps>
>
> Adding steps to section 4 or 6 will result in an error

**Root cause**

The if-then v2 validation check scanned section 2's If-Then and assumed that it ended in section 6, because it didn't know that the pipe "ends" when the rejection branch ends. It then tries to error out because it thinks the pipe is in an invalid state (_an if-then block should never span MRF submissions_).

# Fix

Update if-then v2's validation check to account for MRF reject branches

# Tests

- Check that I can now add steps anywhere in MRF pipes (including in if-then blocks)
- [Regression test] Check that I can still add steps anywhere in non-MRF pipes (including in if-then blocks)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes legacy If-Then extent derivation MRF-region-aware so blocks stop before submissions or transitions into another rejection branch.
- Adds shared backend helpers for identifying MRF submissions and rejection-branch ownership.
- Applies equivalent region clamping in backend migration/validation and frontend editor grouping.
- Expands regression coverage for main-flow, rejection-branch, cross-branch, and immediately terminated blocks.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

Backend and frontend derivation consistently stop legacy If-Then blocks at MRF region boundaries, and the changed tests cover the important main-flow, rejection-branch, and empty-region transitions.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/apps/toolbox/actions/if-then/infra/end-step-utils.ts | Region-aware V1 extent derivation now stops before MRF submissions and rejection-branch transitions. |
| packages/backend/src/apps/toolbox/common/constants.ts | Adds reusable predicates for MRF submission steps and rejection-branch identity. |
| packages/backend/src/apps/toolbox/common/validate-end-step.ts | Reuses the shared MRF helpers while allowing region-confined legacy blocks to be upgraded and pinned. |
| packages/frontend/src/components/Editor/helpers/steps-utils.ts | Mirrors backend region clamping so editor grouping and insertion boundaries agree with persisted block extents. |
| packages/backend/src/apps/toolbox/__tests__/actions/if-then/infra/end-step-utils.test.ts | Covers derivation across main-flow, rejection-branch, submission, and immediate-boundary cases. |
| packages/backend/src/apps/toolbox/__tests__/common/validate-end-step.test.ts | Verifies region-confined rejection blocks are pinned rather than rejected during upgrade. |
| packages/frontend/src/components/Editor/helpers/__tests__/steps-utils.test.ts | Updates frontend regression coverage for region-aware derivation and explicit invalid extents. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start at legacy If-Then] --> B[Find next same-or-shallower If-Then]
    B --> C[Scan candidate members]
    C --> D{MRF submission?}
    D -- Yes --> G[End at previous step]
    D -- No --> E{Rejection branch changed?}
    E -- Yes --> G
    E -- No --> F{Candidate extent exhausted?}
    F -- No --> C
    F -- Yes --> H[Use final candidate step]
    G --> I[Validate and pin endStepId]
    H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(if-then): mirror the MRF region clam..."](https://github.com/opengovsg/plumber/commit/1308793f0663668ded117323890e76419ff8044b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59924516)</sub>

<!-- /greptile_comment -->