### PR TITLE
PLU-743: [IF-THEN-THEN-V2-23] Support custom step name

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -139,7 +139,7 @@ export default function ForEach(props: ForEachProps) {
       <BlockHeader
         badgeLabel="REPEAT"
         previewParts={previewParts}
-        stepId={conditionStep.id}
+        step={conditionStep}
         isSelected={isSelected}
         actions={
           readOnly ? undefined : (

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -253,7 +253,7 @@ export default function IfThen({
             <BlockHeader
               badgeLabel="IF"
               previewParts={conditionPreviewParts}
-              stepId={ifThenStep.id}
+              step={ifThenStep}
               isSelected={isSelected}
               actions={
                 !readOnly ? (

--- a/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
@@ -138,7 +138,7 @@ export default function OnlyContinueIf({
               <BlockHeader
                 badgeLabel="CONTINUE IF"
                 previewParts={previewParts}
-                stepId={step.id}
+                step={step}
                 isSelected={isSelected}
                 actions={
                   isDeletable && !readOnly ? (

--- a/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
@@ -1,3 +1,5 @@
+import type { IStep } from '@plumber/types'
+
 import type { ReactNode } from 'react'
 import {
   useCallback,
@@ -24,7 +26,7 @@ import type { ConditionPreviewPart } from '../helpers/getConditionBlockPreview'
 interface BlockHeaderProps {
   badgeLabel: string
   previewParts: ConditionPreviewPart[]
-  stepId: string
+  step: IStep
   isSelected?: boolean
   actions?: ReactNode
 }
@@ -38,7 +40,7 @@ interface BlockHeaderProps {
 export default function BlockHeader({
   badgeLabel,
   previewParts,
-  stepId,
+  step,
   isSelected = false,
   actions,
 }: BlockHeaderProps): JSX.Element {
@@ -59,13 +61,13 @@ export default function BlockHeader({
     handleLeave: discardChanges,
   } = useUnsavedChanges({
     onProceed: () => {
-      setCurrentStepId(stepId)
+      setCurrentStepId(step.id)
       onDrawerOpen()
     },
   })
 
   const handleClick = useCallback(() => {
-    if (isDrawerOpen && currentStepId === stepId) {
+    if (isDrawerOpen && currentStepId === step.id) {
       setCurrentStepId(null)
       onDrawerClose()
       return
@@ -78,19 +80,26 @@ export default function BlockHeader({
     isDrawerOpen,
     onDrawerClose,
     setCurrentStepId,
-    stepId,
+    step.id,
   ])
 
   const headerBg = isSelected ? 'primary.50' : conditionBlockStyles.header.bg
 
-  const { parts, fullSentence, isLeadingTruncated } = useMemo(
+  // Not `useStepMetadata`'s stepName, which falls back to "If-then" and would
+  // mask the condition on every unnamed block.
+  // IMPORTANT: clearing the name saves `''`, which must read as no name.
+  const customStepName = step.config?.stepName || undefined
+
+  const conditionSentence = useMemo(
     () =>
-      buildConditionSentence(
-        badgeLabel,
-        previewParts,
-        (id) => varInfoMap.get(`{{${id}}}`)?.label,
-      ),
-    [badgeLabel, previewParts, varInfoMap],
+      customStepName
+        ? undefined
+        : buildConditionSentence(
+            badgeLabel,
+            previewParts,
+            (id) => varInfoMap.get(`{{${id}}}`)?.label,
+          ),
+    [badgeLabel, customStepName, previewParts, varInfoMap],
   )
 
   // The value half is cut by layout, so only the rendered box can report a
@@ -111,7 +120,7 @@ export default function BlockHeader({
     const observer = new ResizeObserver(measure)
     observer.observe(element)
     return () => observer.disconnect()
-  }, [parts])
+  }, [conditionSentence, customStepName])
 
   return (
     <>
@@ -127,8 +136,12 @@ export default function BlockHeader({
       >
         <Tooltip
           // A tooltip repeating text already fully on screen is noise.
-          isDisabled={!isLeadingTruncated && !isClamped}
-          label={fullSentence}
+          isDisabled={!conditionSentence?.isLeadingTruncated && !isClamped}
+          label={
+            customStepName
+              ? `${badgeLabel} ${customStepName}`
+              : conditionSentence?.fullSentence
+          }
           placement="top-start"
           openDelay={300}
           hasArrow
@@ -162,26 +175,29 @@ export default function BlockHeader({
             >
               {badgeLabel}
             </Text>
-            {parts.map((part, index) => {
-              if (part.type === 'text' || part.type === 'literal') {
-                return <span key={`${part.type}-${index}`}>{part.display}</span>
-              }
+            {customStepName ??
+              conditionSentence?.parts.map((part, index) => {
+                if (part.type === 'text' || part.type === 'literal') {
+                  return (
+                    <span key={`${part.type}-${index}`}>{part.display}</span>
+                  )
+                }
 
-              return (
-                <Text
-                  as="span"
-                  key={
-                    part.type === 'emphasis'
-                      ? `em-${index}`
-                      : `var-${part.id}-${index}`
-                  }
-                  fontWeight="700"
-                  color="base.content.strong"
-                >
-                  {part.display}
-                </Text>
-              )
-            })}
+                return (
+                  <Text
+                    as="span"
+                    key={
+                      part.type === 'emphasis'
+                        ? `em-${index}`
+                        : `var-${part.id}-${index}`
+                    }
+                    fontWeight="700"
+                    color="base.content.strong"
+                  >
+                    {part.display}
+                  </Text>
+                )
+              })}
           </Text>
         </Tooltip>
 


### PR DESCRIPTION
# Problem

The new blocks don't display custom step names

# Fix

You think leh

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates condition-block headers to display the user-configured step name when present, while retaining the generated condition preview for unnamed or explicitly cleared steps.

- Passes complete step objects into `BlockHeader` for IF, REPEAT, and CONTINUE IF blocks.
- Uses `config.stepName` as the header title and tooltip content when set.
- Preserves existing drawer targeting and condition-preview fallback behavior.
- Greptile automatically discovered a related ticket that helped explain the purpose of this PR: workflow steps should display the admin-configured step name.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap in regression coverage for its new custom-name and cleared-name rendering paths.

The affected callers provide compatible step objects, persisted-name semantics match the implementation, and no behavioral or security failure was established; only focused coverage for the newly introduced rendering branch is missing.

**Files Needing Attention:** packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx | Adds custom step-name rendering and preserves the condition-sentence fallback, but the new rendering branch lacks focused component tests. |
| packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx | Passes the repeat condition step to the shared block header. |
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx | Passes the if-then step to the shared block header. |
| packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx | Passes the only-continue-if step to the shared block header. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fplumber%20PR%20%232112%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fplumber&pr=2112&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FFlowStepGroup%2Fcomponents%2FBlockHeader.tsx%3A91%0A**Custom%20name%20paths%20untested**%0A%0AThe%20new%20custom-name%20branch%20has%20no%20component-level%20coverage.%20Please%20add%20focused%20tests%20proving%20that%20a%20non-empty%20%60config.stepName%60%20replaces%20the%20generated%20condition%20sentence%20and%20that%20clearing%20it%20to%20%60''%60%20restores%20the%20condition%20preview.%20Without%20these%20tests%2C%20the%20feature's%20main%20display%20and%20fallback%20behavior%20could%20regress%20unnoticed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FFlowStepGroup%2Fcomponents%2FBlockHeader.tsx%3A91%0A**Custom%20name%20paths%20untested**%0A%0AThe%20new%20custom-name%20branch%20has%20no%20component-level%20coverage.%20Please%20add%20focused%20tests%20proving%20that%20a%20non-empty%20%60config.stepName%60%20replaces%20the%20generated%20condition%20sentence%20and%20that%20clearing%20it%20to%20%60''%60%20restores%20the%20condition%20preview.%20Without%20these%20tests%2C%20the%20feature's%20main%20display%20and%20fallback%20behavior%20could%20regress%20unnoticed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fplumber%22%20on%20the%20existing%20branch%20%22feat%2Fif-then-then-real%2Ffe-block-header-step-name%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fif-then-then-real%2Ffe-block-header-step-name%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FFlowStepGroup%2Fcomponents%2FBlockHeader.tsx%3A91%0A**Custom%20name%20paths%20untested**%0A%0AThe%20new%20custom-name%20branch%20has%20no%20component-level%20coverage.%20Please%20add%20focused%20tests%20proving%20that%20a%20non-empty%20%60config.stepName%60%20replaces%20the%20generated%20condition%20sentence%20and%20that%20clearing%20it%20to%20%60''%60%20restores%20the%20condition%20preview.%20Without%20these%20tests%2C%20the%20feature's%20main%20display%20and%20fallback%20behavior%20could%20regress%20unnoticed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx:91
**Custom name paths untested**

The new custom-name branch has no component-level coverage. Please add focused tests proving that a non-empty `config.stepName` replaces the generated condition sentence and that clearing it to `''` restores the condition preview. Without these tests, the feature's main display and fallback behavior could regress unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(editor): title condition blocks wit..."](https://github.com/opengovsg/plumber/commit/4ed2e9d7b8a20911e0a38c1686174188c0740355) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61297848)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Linear — [Add step name to workflow steps](https://linear.app/ogp/issue/FRM-1636/add-step-name-to-workflow-steps)

<!-- /greptile_comment -->