### PR TITLE
PLU-743: [IF-THEN-THEN-V2-22] Support multi-condition if-thens in title

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
@@ -250,7 +250,7 @@ describe('getConditionBlockPreviewParts', () => {
     ).toBe('42 is equal to true')
   })
 
-  it('previews the first non-empty row, skipping blank rows and groups', () => {
+  it('previews the only non-empty row, skipping blank rows and groups', () => {
     expect(
       asText(
         getConditionBlockPreviewParts(
@@ -259,12 +259,63 @@ describe('getConditionBlockPreviewParts', () => {
             [
               { field: '', condition: '', text: '' },
               { field: variable('Second'), condition: 'equals', text: 'yes' },
-              { field: variable('Third'), condition: 'equals', text: 'no' },
             ],
           ]),
         ),
       ),
     ).toBe('Second is equal to yes')
+  })
+
+  it('labels two filled rows in one group as multiple conditions', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [
+            { field: variable('First'), condition: 'equals', text: 'yes' },
+            { field: variable('Second'), condition: 'equals', text: 'no' },
+          ],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
+  })
+
+  it('labels one filled row per group as multiple conditions', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [{ field: variable('First'), condition: 'equals', text: 'yes' }],
+          [{ field: variable('Second'), condition: 'equals', text: 'no' }],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
+  })
+
+  it('keeps the sentence when the second row is still blank', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              { field: variable('First'), condition: 'equals', text: 'yes' },
+              { field: '', condition: '', text: '' },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('First is equal to yes')
+  })
+
+  it('counts a half-filled second row as another condition', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [
+            { field: variable('First'), condition: 'equals', text: 'yes' },
+            { field: variable('Second'), condition: '', text: '' },
+          ],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
   })
 
   it('tolerates a group with no rows array', () => {

--- a/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
@@ -30,6 +30,10 @@ const EMPTY_FOR_EACH_PREVIEW: ConditionPreviewPart[] = [
   { type: 'text', text: 'Specify list' },
 ]
 
+const MULTIPLE_CONDITIONS_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Multiple conditions' },
+]
+
 // Not `GLOBAL_VARIABLE_REGEX` from RichTextEditor/utils.ts, which captures the
 // whole match rather than the path segment.
 const STEP_VARIABLE_GLOBAL_REGEX =
@@ -97,22 +101,32 @@ const OPERATOR_PHRASES: Record<
 /**
  * Structured preview of a toolbox condition step for the block header.
  * Variables are separate parts so the header can bold / truncate them.
+ *
+ * IMPORTANT: one condition reads as a sentence, several collapse to a label,
+ * since a sentence describing only the first would misstate the step.
  */
 export function getConditionBlockPreviewParts(
   parameters: IJSONObject | undefined,
 ): ConditionPreviewPart[] {
   const groups = conditionGroupsSchema.parse(parameters?.conditions)
+  let firstRowParts: ConditionPreviewPart[] | undefined
 
   for (const group of groups) {
     for (const row of group.rows) {
       const parts = formatConditionRow(row)
-      if (parts.length > 0) {
-        return parts
+      if (parts.length === 0) {
+        continue
       }
+
+      if (firstRowParts) {
+        return MULTIPLE_CONDITIONS_PREVIEW
+      }
+
+      firstRowParts = parts
     }
   }
 
-  return EMPTY_CONDITION_PREVIEW
+  return firstRowParts ?? EMPTY_CONDITION_PREVIEW
 }
 
 export function getForEachBlockPreviewParts(


### PR DESCRIPTION
# Problem

The new if-then blocks don't multiple conditions

# Fix

Use "multiple conditions" to describe if-then blocks with multiple conditions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates condition-block headers to summarize multiple non-empty condition rows instead of displaying only the first condition.
- Retains the detailed sentence when exactly one row contains input.
- Displays “Multiple conditions” when input exists in multiple rows or groups.
- Adds coverage for blank, partially filled, and fully filled additional rows.
- Greptile automatically discovered a related ticket that helped explain the purpose of this PR: enabling the revised If-Then experience while retaining the existing condition editor.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

The updated helper preserves existing empty and single-condition behavior, detects additional condition input across rows and groups, and has focused tests covering the relevant boundaries.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts | Scans all condition rows and collapses previews with multiple non-empty rows to a generic label. |
| packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts | Covers multiple rows and groups, blank additional rows, and partially configured rows. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(editor): label a multi-condition bl..."](https://github.com/opengovsg/plumber/commit/41578dc48acea982c6ec448a67e1d1356aabd750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61298631)</sub>

**Context used:**

- Linear — [Allow If-Then anywhere in a pipe](https://linear.app/ogp/issue/PLU-743/allow-if-then-anywhere-in-a-pipe)

<!-- /greptile_comment -->