### PR TITLE
chore(deps): restore @datadog/native-metrics 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,9 +4415,9 @@
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.1.tgz",
-      "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-3.1.2.tgz",
+      "integrity": "sha512-7AEWt0ZLr/ogR/9if1DmFBDTg3y67xM+gdhXUXKs+UQMxK0lnjrOHgN7fkpEmUG1uL+EkX2BDE3ENDlQ23J7OQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack Context

The Turborepo lockfile rewrite in #2036 rolled `@datadog/native-metrics` from 3.1.2 back to 3.1.1. That was a rebase artifact, not a pin needed for turbo.

## What?

Restore the lockfile resolution to `3.1.2`. `dd-trace@4.55.0` still declares `^3.1.0`. No `package.json` change.

## Why?

#2091 resolved this transitive dep to 3.1.2 when reverting dd-trace to 4.55.0. 3.1.2 only updates native prebuilds vs 3.1.1. Turbo does not depend on this package.

The same squash also reverted `fast-uri` 3.1.7 → 3.1.5 (later fixed in #2110). This PR undoes the remaining accidental rollback.

## Test plan

- Confirm `package-lock.json` only changes the `@datadog/native-metrics` version, resolved URL, and integrity.
- `nvm use && npm ci`
- CI setup job: packages stay hoisted (no `packages/backend/node_modules` or `packages/frontend/node_modules`)
- `npx turbo run lint typecheck build` (turbo graph still works)
- `npx turbo run test:unit --filter=backend` (dd-trace loads with the restored native addon)
- Frontend tests are not needed for this lockfile-only Datadog transitive bump.
- Integration tests are optional here. They do not exercise native-metrics prebuilds beyond dd-trace init.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb92f993-93c5-4466-b4c1-0e5e324aca3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb92f993-93c5-4466-b4c1-0e5e324aca3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

