### PR TITLE
chore(backend): implement strict-mode carve-out, seed with src/errors

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -74,6 +74,19 @@ jobs:
       - run: npm run typecheck
       - run: echo "✅ Typecheck passed."
 
+  typecheck-strict:
+    name: Typecheck (strict)
+    runs-on: ubuntu-latest
+    needs: setup
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Generate graphql artifacts
+        run: npm run postinstall
+      - run: npm run typecheck:strict
+      - run: echo "✅ Strict typecheck passed."
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "typecheck": "turbo run typecheck",
+    "typecheck:strict": "turbo run typecheck:strict",
     "test": "turbo run test test:unit test:integration",
     "test:ui": "vitest --ui",
     "migrate": "npm run -w backend db:migrate",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "typecheck": "tsc --noEmit",
+    "typecheck:strict": "tsc -p tsconfig.strict.json --noEmit",
     "db": "DOTENV_CONFIG_PATH=.env knex",
     "readme:db:migration:create": "HOW TO USE: npm run -w backend db:migration:create your_migration_name",
     "db:migration:create": "npm run db -- migrate:make",

--- a/packages/backend/src/errors/__tests__/http.test.ts
+++ b/packages/backend/src/errors/__tests__/http.test.ts
@@ -1,3 +1,4 @@
+import type { InternalAxiosRequestConfig } from 'axios'
 import { AxiosError, AxiosHeaders } from 'axios'
 import { describe, expect, it } from 'vitest'
 
@@ -25,7 +26,9 @@ describe('http error', () => {
         status: 429,
         statusText: 'Too many requests',
         data: '',
-        config: null,
+        // Unused by HttpError (it reads error.config, not error.response.config);
+        // stubbed since AxiosResponse.config is required.
+        config: {} as InternalAxiosRequestConfig,
         headers: responseHeaders,
       },
     )
@@ -34,6 +37,6 @@ describe('http error', () => {
     expect(httpError.response.headers).toStrictEqual({
       'retry-after': '10',
     })
-    expect(httpError.response.config.headers).toBeUndefined()
+    expect(httpError.response.config?.headers).toBeUndefined()
   })
 })

--- a/packages/backend/src/errors/base.ts
+++ b/packages/backend/src/errors/base.ts
@@ -8,7 +8,7 @@ export default class BaseError extends Error {
     try {
       computedError = JSON.parse(error as string)
     } catch {
-      computedError = typeof error === 'string' ? { error } : error
+      computedError = typeof error === 'string' ? { error } : error ?? {}
     }
 
     let computedMessage: string

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -1,11 +1,29 @@
 import { IJSONObject } from '@plumber/types'
 
-import type { AxiosError, AxiosResponse } from 'axios'
+import type {
+  AxiosError,
+  AxiosRequestHeaders,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios'
 
 import BaseError from './base'
 
+// error.response is only present on AxiosError when the server actually
+// replied, so status/statusText/config can genuinely be absent here.
+type SanitisedAxiosResponse = Omit<
+  AxiosResponse,
+  'status' | 'statusText' | 'config'
+> & {
+  status?: number
+  statusText?: string
+  config?: Omit<InternalAxiosRequestConfig, 'headers'> & {
+    headers?: AxiosRequestHeaders
+  }
+}
+
 export default class HttpError extends BaseError {
-  response: AxiosResponse
+  response: SanitisedAxiosResponse
   code?: string
   resolvedIp?: string
 

--- a/packages/backend/tsconfig.strict.json
+++ b/packages/backend/tsconfig.strict.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "exclude": [
+    "src/app.ts",
+    "src/apps",
+    "src/config",
+    "src/controllers",
+    "src/db",
+    "src/graphql",
+    "src/helpers",
+    "src/instrumentation.ts",
+    "src/models",
+    "src/queues",
+    "src/routes",
+    "src/server.ts",
+    "src/services",
+    "src/types",
+    "src/worker.ts",
+    "src/workers"
+  ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,9 @@
     "typecheck": {
       "outputs": []
     },
+    "typecheck:strict": {
+      "outputs": []
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Stack Context

Second PR in the backend strict-mode rollout (stacked on #2116, ADR-0001). This one makes the carve-out mechanism real and working, seeded with one fixed directory.

## What?

- `packages/backend/tsconfig.strict.json`: extends the base config, sets `strict: true`, `exclude`s every backend directory not yet fixed. `src/errors` is the first directory removed from the exclude list.
- `typecheck:strict` script (backend + root) and a new `Typecheck (strict)` CI job, running alongside the existing `typecheck` job so nothing goes unchecked mid-migration.
- Fixes to make `src/errors` pass under `strict: true`, following ADR-0001's rules:
  - `base.ts`: `computedError` defaults to `{}` when the constructor's `error` param is absent, instead of assigning `undefined` to a `Record<string, unknown>`.
  - `http.ts`: `HttpError.response`'s `status`/`statusText`/`config` are now typed as genuinely optional (`error.response` and `error.config` are optional on `AxiosError`), matching runtime reality instead of asserting them non-null. `config.headers` is separately typed nullable since the constructor deliberately clears it.
  - `http.test.ts`: adjusted for the above; the mock `config: null` (a field `HttpError` never reads) is stubbed with a cast instead, since building a fully valid `InternalAxiosRequestConfig` by hand for an unused field isn't meaningful.

## Why?

`exclude` alone would silently drop excluded files from *any* type-checking (even today's `noImplicitAny`), so a second tsconfig + CI job was needed to keep full coverage during the staged rollout (see ADR-0001's "Considered Options").

`src/errors` was picked as the seed because it has zero internal `@/` imports — it doesn't drag any other backend directory into strict-mode checking transitively (TypeScript's `exclude` only controls root-file discovery; a file reachable via `import` from an included file is still type-checked regardless of `exclude`).

Caught mid-implementation: an earlier draft of `SanitisedAxiosResponse` also narrowed `data` to `unknown` and `headers` to `Record<string, unknown>`, which broke 15 real call sites elsewhere in backend that read `error.response.data.*` (verified against a stashed before/after typecheck diff). Fixed by only widening the three fields that actually needed it (`status`, `statusText`, `config`) via `Omit<AxiosResponse, ...>`, leaving `data`/`headers` exactly as axios already types them.
