### PR TITLE
PLU-834 feat(ai-builder): add create_tile and add_tile_columns MCP tools

### DIFF
--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -5,19 +5,25 @@ import { BadUserInputError } from '@/errors/graphql-errors'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
+import {
+  MAX_COLUMN_NAME_LENGTH,
+  MAX_TILE_NAME_LENGTH,
+} from '@/models/tiles/constants'
 import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
 export const updateTableSchema = z.object({
   id: z.string().uuid(),
-  name: z.string().trim().min(1).max(64).optional(),
-  addedColumns: z.array(z.string().trim().min(1).max(255)).optional(),
+  name: z.string().trim().min(1).max(MAX_TILE_NAME_LENGTH).optional(),
+  addedColumns: z
+    .array(z.string().trim().min(1).max(MAX_COLUMN_NAME_LENGTH))
+    .optional(),
   modifiedColumns: z
     .array(
       z.object({
         id: z.string().uuid(),
-        name: z.string().trim().min(1).max(255).optional(),
+        name: z.string().trim().min(1).max(MAX_COLUMN_NAME_LENGTH).optional(),
         position: z.number().int().min(0).optional(),
         config: z
           .object({

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -10,6 +10,21 @@ vi.mock('@/services/mcp/list-columns', () => ({
     truncated: false,
   }),
 }))
+vi.mock('@/services/mcp/create-tile', () => ({
+  createTileService: vi.fn().mockResolvedValue({
+    id: 'tile-1',
+    name: 'Leave applications',
+    columns: [{ id: 'col-1', name: 'Name', position: 0 }],
+  }),
+}))
+vi.mock('@/services/mcp/add-tile-columns', () => ({
+  addTileColumnsService: vi.fn().mockResolvedValue({
+    id: 'tile-1',
+    name: 'Leave applications',
+    columns: [{ id: 'col-1', name: 'Name', position: 0 }],
+    skipped: [],
+  }),
+}))
 vi.mock('@/services/mcp/create-flow-with-steps', () => ({
   createFlowWithStepsService: vi
     .fn()
@@ -43,9 +58,11 @@ vi.mock('@/services/mcp/register-connection', () => ({
     .mockResolvedValue({ connectionRegistered: true }),
 }))
 
+import { addTileColumnsService } from '@/services/mcp/add-tile-columns'
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import { createTileService } from '@/services/mcp/create-tile'
 import { deleteStepService } from '@/services/mcp/delete-step'
 import { getFormSchemaService } from '@/services/mcp/get-form-schema'
 import { listColumnsService } from '@/services/mcp/list-columns'
@@ -63,6 +80,8 @@ describe('createMcpBridgeTools', () => {
     expect(Object.keys(tools)).toEqual([
       'list_apps',
       'list_columns',
+      'create_tile',
+      'add_tile_columns',
       'create_pipe',
       'update_step_parameters',
       'create_step',
@@ -96,6 +115,40 @@ describe('createMcpBridgeTools', () => {
     expect(vi.mocked(listColumnsService)).toHaveBeenCalledWith({
       user: mockUser,
       stepId: '123e4567-e89b-12d3-a456-426614174000',
+    })
+  })
+
+  it('create_tile calls createTileService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await tools.create_tile.execute(
+      {
+        name: 'Leave applications',
+        columns: ['Name'],
+        pipe_id: '123e4567-e89b-12d3-a456-426614174000',
+      },
+      { toolCallId: 'create_tile', messages: [] },
+    )
+    expect(vi.mocked(createTileService)).toHaveBeenCalledWith({
+      user: mockUser,
+      name: 'Leave applications',
+      columns: ['Name'],
+      pipeId: '123e4567-e89b-12d3-a456-426614174000',
+    })
+  })
+
+  it('add_tile_columns calls addTileColumnsService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await tools.add_tile_columns.execute(
+      {
+        table_id: '123e4567-e89b-12d3-a456-426614174111',
+        columns: ['Notes'],
+      },
+      { toolCallId: 'add_tile_columns', messages: [] },
+    )
+    expect(vi.mocked(addTileColumnsService)).toHaveBeenCalledWith({
+      user: mockUser,
+      tableId: '123e4567-e89b-12d3-a456-426614174111',
+      columns: ['Notes'],
     })
   })
 

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -58,6 +58,7 @@ vi.mock('@/services/mcp/register-connection', () => ({
     .mockResolvedValue({ connectionRegistered: true }),
 }))
 
+import { UserFacingError } from '@/errors/user-facing-error'
 import { addTileColumnsService } from '@/services/mcp/add-tile-columns'
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
@@ -136,6 +137,23 @@ describe('createMcpBridgeTools', () => {
     })
   })
 
+  it('create_tile returns { error } instead of throwing', async () => {
+    vi.mocked(createTileService).mockRejectedValueOnce(
+      new UserFacingError('Pipe not found'),
+    )
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await expect(
+      tools.create_tile.execute(
+        {
+          name: 'Leave applications',
+          columns: ['Name'],
+          pipe_id: '123e4567-e89b-12d3-a456-426614174000',
+        },
+        { toolCallId: 'create_tile', messages: [] },
+      ),
+    ).resolves.toEqual({ error: 'Pipe not found' })
+  })
+
   it('add_tile_columns calls addTileColumnsService with camelCase args', async () => {
     const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.add_tile_columns.execute(
@@ -150,6 +168,38 @@ describe('createMcpBridgeTools', () => {
       tableId: '123e4567-e89b-12d3-a456-426614174111',
       columns: ['Notes'],
     })
+  })
+
+  it('add_tile_columns accepts a ULID table_id', async () => {
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await tools.add_tile_columns.execute(
+      {
+        table_id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        columns: ['Notes'],
+      },
+      { toolCallId: 'add_tile_columns', messages: [] },
+    )
+    expect(vi.mocked(addTileColumnsService)).toHaveBeenCalledWith({
+      user: mockUser,
+      tableId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      columns: ['Notes'],
+    })
+  })
+
+  it('add_tile_columns returns { error } instead of throwing', async () => {
+    vi.mocked(addTileColumnsService).mockRejectedValueOnce(
+      new UserFacingError('Tile not found'),
+    )
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await expect(
+      tools.add_tile_columns.execute(
+        {
+          table_id: '123e4567-e89b-12d3-a456-426614174111',
+          columns: ['Notes'],
+        },
+        { toolCallId: 'add_tile_columns', messages: [] },
+      ),
+    ).resolves.toEqual({ error: 'Tile not found' })
   })
 
   it('update_step_parameters calls updateStepParametersService with camelCase args', async () => {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -3,6 +3,8 @@ import type { IApp, IJSONObject, IMcpApp } from '@plumber/types'
 import { tool } from 'ai'
 import { z } from 'zod/v4'
 
+import { UserFacingError } from '@/errors/user-facing-error'
+import logger from '@/helpers/logger'
 import type Flow from '@/models/flow'
 import type Step from '@/models/step'
 import type User from '@/models/user'
@@ -43,6 +45,15 @@ import {
 } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
+
+function mcpToolError(error: unknown, fallback: string): { error: string } {
+  if (error instanceof UserFacingError) {
+    return { error: error.message }
+  }
+  const message = error instanceof Error ? error.message : fallback
+  logger.warn('MCP tool failed', { error: message })
+  return { error: fallback }
+}
 
 export function createMcpBridgeTools(
   user: User,
@@ -100,13 +111,17 @@ export function createMcpBridgeTools(
         name,
         columns,
         pipe_id,
-      }): Promise<CreateTileResult> => {
-        return createTileService({
-          user,
-          name,
-          columns,
-          pipeId: pipe_id,
-        })
+      }): Promise<CreateTileResult | { error: string }> => {
+        try {
+          return await createTileService({
+            user,
+            name,
+            columns,
+            pipeId: pipe_id,
+          })
+        } catch (error) {
+          return mcpToolError(error, 'Unable to create tile')
+        }
       },
     }),
 
@@ -114,19 +129,28 @@ export function createMcpBridgeTools(
       description:
         'Add named columns to an existing Tile the user can edit. Names that already exist (case-insensitive) are skipped and returned in skipped rather than erroring. Returns the full column list with ids. Tiles-only; do not rename or delete columns.',
       inputSchema: z.object({
-        table_id: z.uuid().describe('ID of the Tile to add columns to'),
+        table_id: z
+          .union([z.uuid(), z.ulid()])
+          .describe('ID of the Tile to add columns to'),
         columns: z
           .array(z.string())
           .min(1)
           .max(50)
           .describe('Column names to add (1–50 unique names)'),
       }),
-      execute: async ({ table_id, columns }): Promise<AddTileColumnsResult> => {
-        return addTileColumnsService({
-          user,
-          tableId: table_id,
-          columns,
-        })
+      execute: async ({
+        table_id,
+        columns,
+      }): Promise<AddTileColumnsResult | { error: string }> => {
+        try {
+          return await addTileColumnsService({
+            user,
+            tableId: table_id,
+            columns,
+          })
+        } catch (error) {
+          return mcpToolError(error, 'Unable to add tile columns')
+        }
       },
     }),
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -6,12 +6,20 @@ import { z } from 'zod/v4'
 import type Flow from '@/models/flow'
 import type Step from '@/models/step'
 import type User from '@/models/user'
+import {
+  type AddTileColumnsResult,
+  addTileColumnsService,
+} from '@/services/mcp/add-tile-columns'
 import { listAppsService } from '@/services/mcp/apps'
 import {
   createFlowWithStepsService,
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import {
+  type CreateTileResult,
+  createTileService,
+} from '@/services/mcp/create-tile'
 import { deleteStepService } from '@/services/mcp/delete-step'
 import {
   executeStepService,
@@ -68,6 +76,57 @@ export function createMcpBridgeTools(
       }),
       execute: async ({ step_id }): Promise<ListColumnsResult> => {
         return listColumnsService({ user, stepId: step_id })
+      },
+    }),
+
+    create_tile: tool({
+      description:
+        'Create a new Tiles spreadsheet owned by the current user, with the given named columns (no placeholder Column 1/2/3). Returns the tile id and each column id/name/position — use those ids later, never invent UUIDs. Pass pipe_id from create_pipe so pipe collaborators can access the tile. Tiles-only; do not use for Excel, Databricks, or LetterSG.',
+      inputSchema: z.object({
+        name: z.string().describe('Tile name (1–64 characters)'),
+        columns: z
+          .array(z.string())
+          .min(1)
+          .max(50)
+          .describe('Column names to create (1–50 unique names)'),
+        pipe_id: z
+          .uuid()
+          .optional()
+          .describe(
+            'ID of the current pipe from create_pipe. When set, pipe collaborators are granted access to the tile.',
+          ),
+      }),
+      execute: async ({
+        name,
+        columns,
+        pipe_id,
+      }): Promise<CreateTileResult> => {
+        return createTileService({
+          user,
+          name,
+          columns,
+          pipeId: pipe_id,
+        })
+      },
+    }),
+
+    add_tile_columns: tool({
+      description:
+        'Add named columns to an existing Tile the user can edit. Names that already exist (case-insensitive) are skipped and returned in skipped rather than erroring. Returns the full column list with ids. Tiles-only; do not rename or delete columns.',
+      inputSchema: z.object({
+        table_id: z.uuid().describe('ID of the Tile to add columns to'),
+        columns: z
+          .array(z.string())
+          .min(1)
+          .max(50)
+          .describe('Column names to add (1–50 unique names)'),
+      }),
+      execute: async ({ table_id, columns }): Promise<AddTileColumnsResult> => {
+        return addTileColumnsService({
+          user,
+          tableId: table_id,
+          columns,
+        })
       },
     }),
 

--- a/packages/backend/src/models/tiles/constants.ts
+++ b/packages/backend/src/models/tiles/constants.ts
@@ -1,0 +1,2 @@
+export const MAX_TILE_NAME_LENGTH = 64
+export const MAX_COLUMN_NAME_LENGTH = 255

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -171,6 +171,8 @@ const messagePartSchema = z.discriminatedUnion('type', [
   toolPart('tool-get_form_schema'),
   toolPart('tool-execute_step'),
   toolPart('tool-register_connection'),
+  toolPart('tool-create_tile'),
+  toolPart('tool-add_tile_columns'),
 ])
 
 const messageSchema = z.object({

--- a/packages/backend/src/services/mcp/__tests__/add-tile-columns.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/add-tile-columns.itest.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UserFacingError } from '@/errors/user-facing-error'
+import User from '@/models/user'
+
+import {
+  generateMockContext,
+  generateMockTable,
+  generateMockTableColumns,
+} from '../../../graphql/__tests__/mutations/tiles/table.mock'
+import { addTileColumnsService } from '../add-tile-columns'
+
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn().mockResolvedValue('pg'),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
+describe('addTileColumnsService', () => {
+  beforeEach(() => {
+    mocks.getLdFlagValue.mockResolvedValue('pg')
+  })
+
+  it('adds new columns and skips names that already exist', async () => {
+    const context = await generateMockContext()
+    const { table } = await generateMockTable({
+      userId: context.currentUser.id,
+      databaseType: 'pg',
+    })
+    await generateMockTableColumns({
+      tableId: table.id,
+      numColumns: 1,
+      databaseType: 'pg',
+    })
+
+    const result = await addTileColumnsService({
+      user: context.currentUser,
+      tableId: table.id,
+      columns: ['Test Column 0', 'New column'],
+    })
+
+    expect(result.skipped).toEqual(['Test Column 0'])
+    expect(result.columns.map((column) => column.name)).toContain('New column')
+    expect(result.columns.map((column) => column.name)).toContain(
+      'Test Column 0',
+    )
+  })
+
+  it('rejects viewers', async () => {
+    const context = await generateMockContext()
+    const { table, viewer } = await generateMockTable({
+      userId: context.currentUser.id,
+      databaseType: 'pg',
+    })
+
+    await expect(
+      addTileColumnsService({
+        user: viewer,
+        tableId: table.id,
+        columns: ['Secret'],
+      }),
+    ).rejects.toBeInstanceOf(UserFacingError)
+  })
+
+  it('rejects users with no access', async () => {
+    const context = await generateMockContext()
+    const { table } = await generateMockTable({
+      userId: context.currentUser.id,
+      databaseType: 'pg',
+    })
+    const stranger = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `stranger-${randomUUID()}@open.gov.sg`,
+    })
+
+    await expect(
+      addTileColumnsService({
+        user: stranger,
+        tableId: table.id,
+        columns: ['Secret'],
+      }),
+    ).rejects.toBeInstanceOf(UserFacingError)
+  })
+})

--- a/packages/backend/src/services/mcp/__tests__/create-tile.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-tile.itest.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UserFacingError } from '@/errors/user-facing-error'
+import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
+
+import {
+  generateMockCollaborator,
+  generateMockUser,
+} from '../../../graphql/__tests__/mutations/flow.mock'
+import { generateMockContext } from '../../../graphql/__tests__/mutations/tiles/table.mock'
+import { checkIfTableExists } from '../../../graphql/__tests__/mutations/tiles/tiles-pg-helper'
+import { createTileService } from '../create-tile'
+
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn().mockResolvedValue('pg'),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
+describe('createTileService', () => {
+  beforeEach(() => {
+    mocks.getLdFlagValue.mockResolvedValue('pg')
+  })
+
+  it('creates a tile with named columns and no placeholder rows', async () => {
+    const context = await generateMockContext()
+    const result = await createTileService({
+      user: context.currentUser,
+      name: '  Leave applications  ',
+      columns: ['Applicant name', 'Start date'],
+    })
+
+    expect(result.name).toBe('Leave applications')
+    expect(result.columns).toHaveLength(2)
+    expect(result.columns.map((column) => column.name)).toEqual([
+      'Applicant name',
+      'Start date',
+    ])
+    expect(result.columns[0].id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    )
+    expect(await checkIfTableExists(result.id)).toBe(true)
+  })
+
+  it('wires pipe collaborators when pipeId is provided', async () => {
+    const context = await generateMockContext()
+    const flow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'Test Flow',
+      userId: context.currentUser.id,
+    })
+    const editor = await generateMockUser('editor')
+    await generateMockCollaborator(
+      flow.id,
+      editor.id,
+      context.currentUser.id,
+      'editor',
+    )
+
+    const result = await createTileService({
+      user: context.currentUser,
+      name: 'Flow Tile',
+      columns: ['Status'],
+      pipeId: flow.id,
+    })
+
+    const editorCollab = await TableCollaborator.query().findOne({
+      user_id: editor.id,
+      table_id: result.id,
+    })
+    expect(editorCollab?.role).toBe('editor')
+
+    const flowConnection = await FlowConnections.query().findOne({
+      flow_id: flow.id,
+      connection_id: result.id,
+    })
+    expect(flowConnection?.connectionType).toBe('table')
+  })
+
+  it('rejects an unknown pipe before creating a tile', async () => {
+    const context = await generateMockContext()
+    await expect(
+      createTileService({
+        user: context.currentUser,
+        name: 'Orphan',
+        columns: ['A'],
+        pipeId: randomUUID(),
+      }),
+    ).rejects.toBeInstanceOf(UserFacingError)
+  })
+})

--- a/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
@@ -48,8 +48,12 @@ describe('parseColumnNames', () => {
     expect(() => parseColumnNames(['Name', 'name'])).toThrow(UserFacingError)
   })
 
-  it('rejects disallowed characters', () => {
-    expect(() => parseColumnNames(['Name\nbreak'])).toThrow(UserFacingError)
+  it('accepts unicode names, matching updateTable', () => {
+    expect(parseColumnNames(['客户', 'Café', '🎉'])).toEqual([
+      '客户',
+      'Café',
+      '🎉',
+    ])
   })
 })
 

--- a/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
@@ -4,7 +4,9 @@ import { UserFacingError } from '@/errors/user-facing-error'
 
 import {
   MAX_COLUMNS_PER_CALL,
+  parseAddTileColumnsInput,
   parseColumnNames,
+  parseCreateTileInput,
   parseTileName,
 } from '../tile-column-names'
 
@@ -48,5 +50,60 @@ describe('parseColumnNames', () => {
 
   it('rejects disallowed characters', () => {
     expect(() => parseColumnNames(['Name\nbreak'])).toThrow(UserFacingError)
+  })
+})
+
+describe('parseCreateTileInput', () => {
+  it('accepts an optional UUID pipeId', () => {
+    expect(
+      parseCreateTileInput({
+        name: 'Leave',
+        columns: ['Name'],
+        pipeId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    ).toMatchObject({
+      pipeId: '123e4567-e89b-12d3-a456-426614174000',
+    })
+  })
+
+  it('rejects a non-UUID pipeId', () => {
+    expect(() =>
+      parseCreateTileInput({
+        name: 'Leave',
+        columns: ['Name'],
+        pipeId: 'not-a-uuid',
+      }),
+    ).toThrow(UserFacingError)
+  })
+})
+
+describe('parseAddTileColumnsInput', () => {
+  const SAMPLE_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+  it('accepts a UUID tableId', () => {
+    expect(
+      parseAddTileColumnsInput({
+        tableId: '123e4567-e89b-12d3-a456-426614174111',
+        columns: ['Notes'],
+      }),
+    ).toMatchObject({ tableId: '123e4567-e89b-12d3-a456-426614174111' })
+  })
+
+  it('accepts a ULID tableId', () => {
+    expect(
+      parseAddTileColumnsInput({
+        tableId: SAMPLE_ULID,
+        columns: ['Notes'],
+      }),
+    ).toMatchObject({ tableId: SAMPLE_ULID })
+  })
+
+  it('rejects a tableId that is neither UUID nor ULID', () => {
+    expect(() =>
+      parseAddTileColumnsInput({
+        tableId: 'not-an-id',
+        columns: ['Notes'],
+      }),
+    ).toThrow(UserFacingError)
   })
 })

--- a/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { UserFacingError } from '@/errors/user-facing-error'
+import {
+  MAX_COLUMN_NAME_LENGTH,
+  MAX_TILE_NAME_LENGTH,
+} from '@/models/tiles/constants'
 
 import {
   MAX_COLUMNS_PER_CALL,
@@ -19,8 +23,10 @@ describe('parseTileName', () => {
     expect(() => parseTileName('   ')).toThrow(UserFacingError)
   })
 
-  it('rejects names longer than 64 characters', () => {
-    expect(() => parseTileName('a'.repeat(65))).toThrow(UserFacingError)
+  it('rejects names longer than MAX_TILE_NAME_LENGTH', () => {
+    expect(() => parseTileName('a'.repeat(MAX_TILE_NAME_LENGTH + 1))).toThrow(
+      UserFacingError,
+    )
   })
 })
 
@@ -54,6 +60,12 @@ describe('parseColumnNames', () => {
       'Café',
       '🎉',
     ])
+  })
+
+  it('rejects names longer than MAX_COLUMN_NAME_LENGTH', () => {
+    expect(() =>
+      parseColumnNames(['a'.repeat(MAX_COLUMN_NAME_LENGTH + 1)]),
+    ).toThrow(UserFacingError)
   })
 })
 

--- a/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/tile-column-names.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { UserFacingError } from '@/errors/user-facing-error'
+
+import {
+  MAX_COLUMNS_PER_CALL,
+  parseColumnNames,
+  parseTileName,
+} from '../tile-column-names'
+
+describe('parseTileName', () => {
+  it('trims and returns the name', () => {
+    expect(parseTileName('  Leave applications  ')).toBe('Leave applications')
+  })
+
+  it('rejects an empty name', () => {
+    expect(() => parseTileName('   ')).toThrow(UserFacingError)
+  })
+
+  it('rejects names longer than 64 characters', () => {
+    expect(() => parseTileName('a'.repeat(65))).toThrow(UserFacingError)
+  })
+})
+
+describe('parseColumnNames', () => {
+  it('trims names and preserves order', () => {
+    expect(parseColumnNames([' Name ', 'Start date'])).toEqual([
+      'Name',
+      'Start date',
+    ])
+  })
+
+  it('rejects an empty list', () => {
+    expect(() => parseColumnNames([])).toThrow(UserFacingError)
+  })
+
+  it('rejects more than 50 names', () => {
+    expect(() =>
+      parseColumnNames(
+        Array.from({ length: MAX_COLUMNS_PER_CALL + 1 }, (_, i) => `Col ${i}`),
+      ),
+    ).toThrow(UserFacingError)
+  })
+
+  it('rejects duplicate names case-insensitively', () => {
+    expect(() => parseColumnNames(['Name', 'name'])).toThrow(UserFacingError)
+  })
+
+  it('rejects disallowed characters', () => {
+    expect(() => parseColumnNames(['Name\nbreak'])).toThrow(UserFacingError)
+  })
+})

--- a/packages/backend/src/services/mcp/add-tile-columns.ts
+++ b/packages/backend/src/services/mcp/add-tile-columns.ts
@@ -6,7 +6,10 @@ import TableMetadata from '@/models/table-metadata'
 import { getTableOperations } from '@/models/tiles/factory'
 import type User from '@/models/user'
 
-import { parseColumnNames, type TileColumnResult } from './tile-column-names'
+import {
+  parseAddTileColumnsInput,
+  type TileColumnResult,
+} from './tile-column-names'
 
 export interface AddTileColumnsInput {
   user: User
@@ -26,10 +29,11 @@ export async function addTileColumnsService({
   tableId,
   columns,
 }: AddTileColumnsInput): Promise<AddTileColumnsResult> {
-  const columnNames = parseColumnNames(columns)
+  const { tableId: parsedTableId, columns: columnNames } =
+    parseAddTileColumnsInput({ tableId, columns })
 
   try {
-    await TableCollaborator.hasAccess(user.id, tableId, 'editor')
+    await TableCollaborator.hasAccess(user.id, parsedTableId, 'editor')
   } catch (error) {
     if (error instanceof ForbiddenError) {
       throw new UserFacingError(
@@ -39,7 +43,7 @@ export async function addTileColumnsService({
     throw error
   }
 
-  const table = await TableMetadata.query().findById(tableId)
+  const table = await TableMetadata.query().findById(parsedTableId)
   if (!table) {
     throw new UserFacingError('Tile not found')
   }
@@ -77,7 +81,7 @@ export async function addTileColumnsService({
         .returning('id')
 
       await tableOperations.createTableColumns(
-        tableId,
+        parsedTableId,
         inserted.map((column) => column.id),
       )
     })

--- a/packages/backend/src/services/mcp/add-tile-columns.ts
+++ b/packages/backend/src/services/mcp/add-tile-columns.ts
@@ -1,0 +1,98 @@
+import { ForbiddenError } from '@/errors/graphql-errors'
+import { UserFacingError } from '@/errors/user-facing-error'
+import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
+import TableMetadata from '@/models/table-metadata'
+import { getTableOperations } from '@/models/tiles/factory'
+import type User from '@/models/user'
+
+import { parseColumnNames, type TileColumnResult } from './tile-column-names'
+
+export interface AddTileColumnsInput {
+  user: User
+  tableId: string
+  columns: string[]
+}
+
+export interface AddTileColumnsResult {
+  id: string
+  name: string
+  columns: TileColumnResult[]
+  skipped: string[]
+}
+
+export async function addTileColumnsService({
+  user,
+  tableId,
+  columns,
+}: AddTileColumnsInput): Promise<AddTileColumnsResult> {
+  const columnNames = parseColumnNames(columns)
+
+  try {
+    await TableCollaborator.hasAccess(user.id, tableId, 'editor')
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      throw new UserFacingError(
+        'You do not have permission to add columns to this Tile',
+      )
+    }
+    throw error
+  }
+
+  const table = await TableMetadata.query().findById(tableId)
+  if (!table) {
+    throw new UserFacingError('Tile not found')
+  }
+
+  const existing = await table.$relatedQuery('columns')
+  const existingKeys = new Set(
+    existing.map((column) => column.name.toLowerCase()),
+  )
+
+  const skipped: string[] = []
+  const toAdd: string[] = []
+  for (const name of columnNames) {
+    if (existingKeys.has(name.toLowerCase())) {
+      skipped.push(name)
+    } else {
+      toAdd.push(name)
+    }
+  }
+
+  if (toAdd.length) {
+    const tableOperations = getTableOperations(table.db)
+    await TableColumnMetadata.transaction(async (trx) => {
+      const results = await table
+        .$relatedQuery('columns', trx)
+        .max('position as position')
+      const maxPosition = results[0].position || 0
+      const inserted = await table
+        .$relatedQuery('columns', trx)
+        .insert(
+          toAdd.map((name, i) => ({
+            name,
+            position: maxPosition + i + 1,
+          })),
+        )
+        .returning('id')
+
+      await tableOperations.createTableColumns(
+        tableId,
+        inserted.map((column) => column.id),
+      )
+    })
+  }
+
+  const updated = await table.$fetchGraph('columns')
+
+  return {
+    id: updated.id,
+    name: updated.name,
+    columns: updated.columns.map((column) => ({
+      id: column.id,
+      name: column.name,
+      position: column.position,
+    })),
+    skipped,
+  }
+}

--- a/packages/backend/src/services/mcp/create-tile.ts
+++ b/packages/backend/src/services/mcp/create-tile.ts
@@ -1,0 +1,100 @@
+import { UserFacingError } from '@/errors/user-facing-error'
+import { addFlowTableConnection } from '@/helpers/add-flow-connection'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
+import TableMetadata from '@/models/table-metadata'
+import { getTableOperations } from '@/models/tiles/factory'
+import { type DatabaseType } from '@/models/tiles/types'
+import type User from '@/models/user'
+
+import {
+  parseColumnNames,
+  parseTileName,
+  type TileColumnResult,
+} from './tile-column-names'
+
+const DATABASE_TYPE_LD_FLAG_KEY = 'tiles-database-type'
+
+export interface CreateTileInput {
+  user: User
+  name: string
+  columns: string[]
+  pipeId?: string
+}
+
+export interface CreateTileResult {
+  id: string
+  name: string
+  columns: TileColumnResult[]
+}
+
+export async function createTileService({
+  user,
+  name,
+  columns,
+  pipeId,
+}: CreateTileInput): Promise<CreateTileResult> {
+  const tableName = parseTileName(name)
+  const columnNames = parseColumnNames(columns)
+
+  let flow
+  if (pipeId) {
+    flow = await user
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findById(pipeId)
+
+    if (!flow) {
+      throw new UserFacingError('Pipe not found')
+    }
+  }
+
+  const databaseType = (await getLdFlagValue(
+    DATABASE_TYPE_LD_FLAG_KEY,
+    user.email,
+    'ddb',
+  )) as DatabaseType
+
+  const tableOperations = getTableOperations(databaseType)
+
+  const table = await TableMetadata.transaction(async (trx) => {
+    const pendingTable = await user.$relatedQuery('tables', trx).insertGraph({
+      name: tableName,
+      role: 'owner',
+      db: databaseType,
+      columns: columnNames.map((columnName, position) => ({
+        name: columnName,
+        position,
+      })),
+    })
+
+    await tableOperations.createTable(
+      pendingTable.id,
+      pendingTable.columns.map((column) => column.id),
+    )
+
+    return pendingTable
+  })
+
+  if (flow) {
+    await addFlowTableConnection({
+      flowId: flow.id,
+      tableId: table.id,
+      addedBy: user.id,
+      flowOwnerId: flow.userId,
+    })
+  }
+
+  const created = await TableMetadata.query()
+    .findById(table.id)
+    .withGraphFetched('columns')
+    .throwIfNotFound()
+
+  return {
+    id: created.id,
+    name: created.name,
+    columns: created.columns.map((column) => ({
+      id: column.id,
+      name: column.name,
+      position: column.position,
+    })),
+  }
+}

--- a/packages/backend/src/services/mcp/create-tile.ts
+++ b/packages/backend/src/services/mcp/create-tile.ts
@@ -7,8 +7,7 @@ import { type DatabaseType } from '@/models/tiles/types'
 import type User from '@/models/user'
 
 import {
-  parseColumnNames,
-  parseTileName,
+  parseCreateTileInput,
   type TileColumnResult,
 } from './tile-column-names'
 
@@ -33,14 +32,17 @@ export async function createTileService({
   columns,
   pipeId,
 }: CreateTileInput): Promise<CreateTileResult> {
-  const tableName = parseTileName(name)
-  const columnNames = parseColumnNames(columns)
+  const {
+    name: tableName,
+    columns: columnNames,
+    pipeId: parsedPipeId,
+  } = parseCreateTileInput({ name, columns, pipeId })
 
   let flow
-  if (pipeId) {
+  if (parsedPipeId) {
     flow = await user
       .withAccessibleFlows({ requiredRole: 'editor' })
-      .findById(pipeId)
+      .findById(parsedPipeId)
 
     if (!flow) {
       throw new UserFacingError('Pipe not found')

--- a/packages/backend/src/services/mcp/tile-column-names.ts
+++ b/packages/backend/src/services/mcp/tile-column-names.ts
@@ -1,4 +1,7 @@
+import { z } from 'zod'
+
 import { UserFacingError } from '@/errors/user-facing-error'
+import { firstZodParseError } from '@/helpers/zod-utils'
 
 export interface TileColumnResult {
   id: string
@@ -11,52 +14,94 @@ export const MAX_COLUMNS_PER_CALL = 50
 
 const COLUMN_NAME_CHARSET = /^[a-zA-Z0-9 _\-!@#$%^&*()+=[\]{};:'",.<>/?|~]+$/
 
+const tileNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Tile name is required')
+  .max(
+    MAX_TILE_NAME_LENGTH,
+    `Tile name must be ${MAX_TILE_NAME_LENGTH} characters or fewer`,
+  )
+
+const columnNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Column names cannot be empty')
+  .max(
+    MAX_COLUMN_NAME_LENGTH,
+    `Column names must be ${MAX_COLUMN_NAME_LENGTH} characters or fewer`,
+  )
+  .regex(
+    COLUMN_NAME_CHARSET,
+    'Column names can only include letters, numbers, spaces, and common special characters',
+  )
+
+const columnNamesSchema = z
+  .array(columnNameSchema)
+  .min(1, `Provide between 1 and ${MAX_COLUMNS_PER_CALL} column names`)
+  .max(
+    MAX_COLUMNS_PER_CALL,
+    `Provide between 1 and ${MAX_COLUMNS_PER_CALL} column names`,
+  )
+  .superRefine((names, ctx) => {
+    const seen = new Set<string>()
+    for (const name of names) {
+      const key = name.toLowerCase()
+      if (seen.has(key)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Duplicate column name: ${name}`,
+        })
+      }
+      seen.add(key)
+    }
+  })
+
+const createTileFieldsSchema = z.object({
+  name: tileNameSchema,
+  columns: columnNamesSchema,
+  pipeId: z.uuid().optional(),
+})
+
+const addTileColumnsFieldsSchema = z.object({
+  /**
+   * Table and column ids are UUIDs. PG tile row ids are ULIDs.
+   * Accept both so an id copied from either layer still validates.
+   */
+  tableId: z.union([z.uuid(), z.ulid()]),
+  columns: columnNamesSchema,
+})
+
+function parseOrThrow<TSchema extends z.ZodType>(
+  schema: TSchema,
+  data: unknown,
+): z.infer<TSchema> {
+  const result = schema.safeParse(data)
+  if (!result.success) {
+    throw new UserFacingError(firstZodParseError(result.error))
+  }
+  return result.data
+}
+
 export function parseTileName(name: string): string {
-  const trimmed = name.trim()
-  if (!trimmed) {
-    throw new UserFacingError('Tile name is required')
-  }
-  if (trimmed.length > MAX_TILE_NAME_LENGTH) {
-    throw new UserFacingError(
-      `Tile name must be ${MAX_TILE_NAME_LENGTH} characters or fewer`,
-    )
-  }
-  return trimmed
+  return parseOrThrow(tileNameSchema, name)
 }
 
 export function parseColumnNames(columns: string[]): string[] {
-  if (columns.length < 1 || columns.length > MAX_COLUMNS_PER_CALL) {
-    throw new UserFacingError(
-      `Provide between 1 and ${MAX_COLUMNS_PER_CALL} column names`,
-    )
-  }
+  return parseOrThrow(columnNamesSchema, columns)
+}
 
-  const names = columns.map((column) => {
-    const trimmed = column.trim()
-    if (!trimmed) {
-      throw new UserFacingError('Column names cannot be empty')
-    }
-    if (trimmed.length > MAX_COLUMN_NAME_LENGTH) {
-      throw new UserFacingError(
-        `Column names must be ${MAX_COLUMN_NAME_LENGTH} characters or fewer`,
-      )
-    }
-    if (!COLUMN_NAME_CHARSET.test(trimmed)) {
-      throw new UserFacingError(
-        'Column names can only include letters, numbers, spaces, and common special characters',
-      )
-    }
-    return trimmed
-  })
+export function parseCreateTileInput(input: {
+  name: string
+  columns: string[]
+  pipeId?: string
+}): z.infer<typeof createTileFieldsSchema> {
+  return parseOrThrow(createTileFieldsSchema, input)
+}
 
-  const seen = new Set<string>()
-  for (const name of names) {
-    const key = name.toLowerCase()
-    if (seen.has(key)) {
-      throw new UserFacingError(`Duplicate column name: ${name}`)
-    }
-    seen.add(key)
-  }
-
-  return names
+export function parseAddTileColumnsInput(input: {
+  tableId: string
+  columns: string[]
+}): z.infer<typeof addTileColumnsFieldsSchema> {
+  return parseOrThrow(addTileColumnsFieldsSchema, input)
 }

--- a/packages/backend/src/services/mcp/tile-column-names.ts
+++ b/packages/backend/src/services/mcp/tile-column-names.ts
@@ -12,8 +12,6 @@ export const MAX_TILE_NAME_LENGTH = 64
 export const MAX_COLUMN_NAME_LENGTH = 255
 export const MAX_COLUMNS_PER_CALL = 50
 
-const COLUMN_NAME_CHARSET = /^[a-zA-Z0-9 _\-!@#$%^&*()+=[\]{};:'",.<>/?|~]+$/
-
 const tileNameSchema = z
   .string()
   .trim()
@@ -30,10 +28,6 @@ const columnNameSchema = z
   .max(
     MAX_COLUMN_NAME_LENGTH,
     `Column names must be ${MAX_COLUMN_NAME_LENGTH} characters or fewer`,
-  )
-  .regex(
-    COLUMN_NAME_CHARSET,
-    'Column names can only include letters, numbers, spaces, and common special characters',
   )
 
 const columnNamesSchema = z

--- a/packages/backend/src/services/mcp/tile-column-names.ts
+++ b/packages/backend/src/services/mcp/tile-column-names.ts
@@ -1,0 +1,62 @@
+import { UserFacingError } from '@/errors/user-facing-error'
+
+export interface TileColumnResult {
+  id: string
+  name: string
+  position: number
+}
+export const MAX_TILE_NAME_LENGTH = 64
+export const MAX_COLUMN_NAME_LENGTH = 255
+export const MAX_COLUMNS_PER_CALL = 50
+
+const COLUMN_NAME_CHARSET = /^[a-zA-Z0-9 _\-!@#$%^&*()+=[\]{};:'",.<>/?|~]+$/
+
+export function parseTileName(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) {
+    throw new UserFacingError('Tile name is required')
+  }
+  if (trimmed.length > MAX_TILE_NAME_LENGTH) {
+    throw new UserFacingError(
+      `Tile name must be ${MAX_TILE_NAME_LENGTH} characters or fewer`,
+    )
+  }
+  return trimmed
+}
+
+export function parseColumnNames(columns: string[]): string[] {
+  if (columns.length < 1 || columns.length > MAX_COLUMNS_PER_CALL) {
+    throw new UserFacingError(
+      `Provide between 1 and ${MAX_COLUMNS_PER_CALL} column names`,
+    )
+  }
+
+  const names = columns.map((column) => {
+    const trimmed = column.trim()
+    if (!trimmed) {
+      throw new UserFacingError('Column names cannot be empty')
+    }
+    if (trimmed.length > MAX_COLUMN_NAME_LENGTH) {
+      throw new UserFacingError(
+        `Column names must be ${MAX_COLUMN_NAME_LENGTH} characters or fewer`,
+      )
+    }
+    if (!COLUMN_NAME_CHARSET.test(trimmed)) {
+      throw new UserFacingError(
+        'Column names can only include letters, numbers, spaces, and common special characters',
+      )
+    }
+    return trimmed
+  })
+
+  const seen = new Set<string>()
+  for (const name of names) {
+    const key = name.toLowerCase()
+    if (seen.has(key)) {
+      throw new UserFacingError(`Duplicate column name: ${name}`)
+    }
+    seen.add(key)
+  }
+
+  return names
+}

--- a/packages/backend/src/services/mcp/tile-column-names.ts
+++ b/packages/backend/src/services/mcp/tile-column-names.ts
@@ -2,14 +2,18 @@ import { z } from 'zod'
 
 import { UserFacingError } from '@/errors/user-facing-error'
 import { firstZodParseError } from '@/helpers/zod-utils'
+import {
+  MAX_COLUMN_NAME_LENGTH,
+  MAX_TILE_NAME_LENGTH,
+} from '@/models/tiles/constants'
 
 export interface TileColumnResult {
   id: string
   name: string
   position: number
 }
-export const MAX_TILE_NAME_LENGTH = 64
-export const MAX_COLUMN_NAME_LENGTH = 255
+
+/** MCP-only cap. updateTable does not limit how many columns a call may add. */
 export const MAX_COLUMNS_PER_CALL = 50
 
 const tileNameSchema = z


### PR DESCRIPTION
## Stack Context

This 2-PR stack lets the AI builder create a Tile and columns in chat, instead of only picking an existing Tile.

```
#2121 mcp-tiles/create-tile-tools  (this PR, base: trunk/mcp-tools)
  └── #2122 mcp-tiles/tile-setup-ui
```

Merge this PR before #2122.

## Why?

The AI builder can map values onto an existing Tile. It cannot create the Tile or add columns. Users have to leave chat and use the pipe editor.

These MCP tools are the backend for that flow. The chat UI in #2122 depends on them.

## What

- `create_tile`: creates a named Tile with named columns. No placeholder columns. Optional `pipe_id` attaches the Tile to the pipe after the Tile insert. The pipe is checked before insert.
- `add_tile_columns`: adds columns to a Tile the user can edit. Existing names (case-insensitive) go in `skipped`.
- Shared name and column validation in `tile-column-names.ts`.
- Registers both tools on the MCP bridge and in the chat tool schema.

## Test plan

- [ ] Unit tests: `tile-column-names.test.ts`, `mcp-bridge-tools.test.ts`
- [ ] Integration tests: `create-tile.itest.ts`, `add-tile-columns.itest.ts`
- [ ] `create_tile` with a valid `pipe_id` creates the Tile and a flow-table connection
- [ ] `create_tile` with a missing or non-editable `pipe_id` fails before insert
- [ ] `add_tile_columns` skips duplicate names and still adds new ones
- [ ] Editor access is required for `add_tile_columns`


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds MCP tools for creating Tiles with named columns and adding columns to editable Tiles, including chat-schema registration, bridge error handling, validation, authorization checks, and integration tests.

Greptile automatically discovered a related ticket that helped explain the purpose of this PR: enabling AI-assisted creation and modification of Tiles.

- Registers `create_tile` and `add_tile_columns` with the MCP bridge.
- Creates Tile metadata and backend storage, with optional pipe connection and collaborator propagation.
- Adds case-insensitive duplicate skipping and shared name validation.
- Adds bridge, validation, authorization, and integration coverage.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not yet safe to merge because failed pipe attachment can leave created Tiles behind, concurrent column additions can corrupt naming and ordering invariants, and valid Unicode names are rejected.

Three blocking behaviors remain: Tile creation is not atomic or compensating across pipe attachment, column deduplication and position assignment race under concurrent calls, and the new validation contract excludes names supported by existing Tile workflows.

**Files Needing Attention:** packages/backend/src/services/mcp/create-tile.ts, packages/backend/src/services/mcp/add-tile-columns.ts, packages/backend/src/services/mcp/tile-column-names.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/services/mcp/create-tile.ts | Creates Tiles and optionally connects them to pipes, but post-commit connection failures can leave created or partially connected resources behind. |
| packages/backend/src/services/mcp/add-tile-columns.ts | Adds and deduplicates Tile columns, but concurrent calls can insert duplicate names and overlapping positions. |
| packages/backend/src/services/mcp/tile-column-names.ts | Centralizes name and identifier validation but unnecessarily excludes valid Unicode column names. |
| packages/backend/src/helpers/mcp-bridge-tools.ts | Registers the two tools, maps snake-case arguments, and converts service failures into tool-readable errors. |
| packages/backend/src/routes/api/chat/schema.ts | Extends persisted chat-message validation with the two new tool-part types. |
| packages/backend/src/services/mcp/__tests__/create-tile.itest.ts | Covers named Tile creation, successful pipe wiring, and rejection of an unknown pipe. |
| packages/backend/src/services/mcp/__tests__/add-tile-columns.itest.ts | Covers normal duplicate skipping and rejection of viewers and inaccessible users. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[AI builder] --> B{MCP tool}
  B -->|create_tile| C[Validate Tile and column names]
  C --> D[Verify optional pipe editor access]
  D --> E[Insert Tile metadata and columns]
  E --> F[Create backend storage]
  F --> G[Attach Tile to pipe]
  G --> H[Propagate collaborator access]
  B -->|add_tile_columns| I[Validate table ID and names]
  I --> J[Verify Tile editor access]
  J --> K[Load existing columns]
  K --> L[Skip matching names]
  L --> M[Insert new metadata]
  M --> N[Create backend columns]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fplumber%20PR%20%232121%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fplumber&pr=2121&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fcreate-tile.ts%3A79-86%0A**Failed%20Attachments%20Leave%20Tiles**%0A%0AIf%20%60addFlowTableConnection%60%20fails%20while%20creating%20the%20flow%20connection%20or%20propagating%20collaborator%20access%2C%20the%20Tile%20has%20already%20been%20committed.%20The%20tool%20then%20returns%20an%20error%20even%20though%20the%20Tile%20exists%2C%20so%20retrying%20%60create_tile%60%20can%20create%20duplicate%20orphan%20Tiles%20while%20the%20original%20remains%20detached%20or%20only%20partially%20attached%20to%20the%20pipe.%20This%20operation%20needs%20compensation%20or%20atomic%2C%20idempotent%20handling.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fadd-tile-columns.ts%3A51-79%0A**Concurrent%20Adds%20Create%20Duplicates**%0A%0AThe%20existing-name%20check%20occurs%20before%20the%20transaction%2C%20and%20each%20transaction%20independently%20reads%20the%20current%20maximum%20position.%20Two%20concurrent%20calls%20can%20therefore%20both%20accept%20the%20same%20case-insensitive%20name%20and%20assign%20overlapping%20positions%3B%20because%20neither%20field%20has%20a%20matching%20uniqueness%20constraint%2C%20this%20violates%20the%20duplicate-skipping%20contract%20and%20makes%20column%20ordering%20ambiguous.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Ftile-column-names.ts%3A15%0A**Valid%20Unicode%20Names%20Rejected**%0A%0AThe%20ASCII-only%20allowlist%20rejects%20otherwise%20valid%20Unicode%20column%20names%20such%20as%20%60%E5%AE%A2%E6%88%B7%60%2C%20accented%20text%2C%20or%20emoji.%20Existing%20Tile%20add%20and%20rename%20paths%20accept%20arbitrary%20trimmed%20names%2C%20and%20physical%20columns%20use%20generated%20IDs%20rather%20than%20display%20names%2C%20so%20the%20MCP%20tools%20cannot%20create%20names%20that%20users%20can%20create%20in%20the%20normal%20Tile%20editor.%20Greptile%20automatically%20discovered%20a%20related%20ticket%20stating%20that%20Tile%20columns%20must%20be%20created%20with%20the%20correct%20names%2C%20which%20informed%20this%20comment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fcreate-tile.ts%3A79-86%0A**Failed%20Attachments%20Leave%20Tiles**%0A%0AIf%20%60addFlowTableConnection%60%20fails%20while%20creating%20the%20flow%20connection%20or%20propagating%20collaborator%20access%2C%20the%20Tile%20has%20already%20been%20committed.%20The%20tool%20then%20returns%20an%20error%20even%20though%20the%20Tile%20exists%2C%20so%20retrying%20%60create_tile%60%20can%20create%20duplicate%20orphan%20Tiles%20while%20the%20original%20remains%20detached%20or%20only%20partially%20attached%20to%20the%20pipe.%20This%20operation%20needs%20compensation%20or%20atomic%2C%20idempotent%20handling.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fadd-tile-columns.ts%3A51-79%0A**Concurrent%20Adds%20Create%20Duplicates**%0A%0AThe%20existing-name%20check%20occurs%20before%20the%20transaction%2C%20and%20each%20transaction%20independently%20reads%20the%20current%20maximum%20position.%20Two%20concurrent%20calls%20can%20therefore%20both%20accept%20the%20same%20case-insensitive%20name%20and%20assign%20overlapping%20positions%3B%20because%20neither%20field%20has%20a%20matching%20uniqueness%20constraint%2C%20this%20violates%20the%20duplicate-skipping%20contract%20and%20makes%20column%20ordering%20ambiguous.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Ftile-column-names.ts%3A15%0A**Valid%20Unicode%20Names%20Rejected**%0A%0AThe%20ASCII-only%20allowlist%20rejects%20otherwise%20valid%20Unicode%20column%20names%20such%20as%20%60%E5%AE%A2%E6%88%B7%60%2C%20accented%20text%2C%20or%20emoji.%20Existing%20Tile%20add%20and%20rename%20paths%20accept%20arbitrary%20trimmed%20names%2C%20and%20physical%20columns%20use%20generated%20IDs%20rather%20than%20display%20names%2C%20so%20the%20MCP%20tools%20cannot%20create%20names%20that%20users%20can%20create%20in%20the%20normal%20Tile%20editor.%20Greptile%20automatically%20discovered%20a%20related%20ticket%20stating%20that%20Tile%20columns%20must%20be%20created%20with%20the%20correct%20names%2C%20which%20informed%20this%20comment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fplumber%22%20on%20the%20existing%20branch%20%22mcp-tiles%2Fcreate-tile-tools%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mcp-tiles%2Fcreate-tile-tools%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fcreate-tile.ts%3A79-86%0A**Failed%20Attachments%20Leave%20Tiles**%0A%0AIf%20%60addFlowTableConnection%60%20fails%20while%20creating%20the%20flow%20connection%20or%20propagating%20collaborator%20access%2C%20the%20Tile%20has%20already%20been%20committed.%20The%20tool%20then%20returns%20an%20error%20even%20though%20the%20Tile%20exists%2C%20so%20retrying%20%60create_tile%60%20can%20create%20duplicate%20orphan%20Tiles%20while%20the%20original%20remains%20detached%20or%20only%20partially%20attached%20to%20the%20pipe.%20This%20operation%20needs%20compensation%20or%20atomic%2C%20idempotent%20handling.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Fadd-tile-columns.ts%3A51-79%0A**Concurrent%20Adds%20Create%20Duplicates**%0A%0AThe%20existing-name%20check%20occurs%20before%20the%20transaction%2C%20and%20each%20transaction%20independently%20reads%20the%20current%20maximum%20position.%20Two%20concurrent%20calls%20can%20therefore%20both%20accept%20the%20same%20case-insensitive%20name%20and%20assign%20overlapping%20positions%3B%20because%20neither%20field%20has%20a%20matching%20uniqueness%20constraint%2C%20this%20violates%20the%20duplicate-skipping%20contract%20and%20makes%20column%20ordering%20ambiguous.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fbackend%2Fsrc%2Fservices%2Fmcp%2Ftile-column-names.ts%3A15%0A**Valid%20Unicode%20Names%20Rejected**%0A%0AThe%20ASCII-only%20allowlist%20rejects%20otherwise%20valid%20Unicode%20column%20names%20such%20as%20%60%E5%AE%A2%E6%88%B7%60%2C%20accented%20text%2C%20or%20emoji.%20Existing%20Tile%20add%20and%20rename%20paths%20accept%20arbitrary%20trimmed%20names%2C%20and%20physical%20columns%20use%20generated%20IDs%20rather%20than%20display%20names%2C%20so%20the%20MCP%20tools%20cannot%20create%20names%20that%20users%20can%20create%20in%20the%20normal%20Tile%20editor.%20Greptile%20automatically%20discovered%20a%20related%20ticket%20stating%20that%20Tile%20columns%20must%20be%20created%20with%20the%20correct%20names%2C%20which%20informed%20this%20comment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/src/services/mcp/create-tile.ts:79-86
**Failed Attachments Leave Tiles**

If `addFlowTableConnection` fails while creating the flow connection or propagating collaborator access, the Tile has already been committed. The tool then returns an error even though the Tile exists, so retrying `create_tile` can create duplicate orphan Tiles while the original remains detached or only partially attached to the pipe. This operation needs compensation or atomic, idempotent handling.

### Issue 2
packages/backend/src/services/mcp/add-tile-columns.ts:51-79
**Concurrent Adds Create Duplicates**

The existing-name check occurs before the transaction, and each transaction independently reads the current maximum position. Two concurrent calls can therefore both accept the same case-insensitive name and assign overlapping positions; because neither field has a matching uniqueness constraint, this violates the duplicate-skipping contract and makes column ordering ambiguous.

### Issue 3
packages/backend/src/services/mcp/tile-column-names.ts:15
**Valid Unicode Names Rejected**

The ASCII-only allowlist rejects otherwise valid Unicode column names such as `客户`, accented text, or emoji. Existing Tile add and rename paths accept arbitrary trimmed names, and physical columns use generated IDs rather than display names, so the MCP tools cannot create names that users can create in the normal Tile editor. Greptile automatically discovered a related ticket stating that Tile columns must be created with the correct names, which informed this comment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai-builder): validate tile MCP tool ..."](https://github.com/opengovsg/plumber/commit/9df5b4b6890341592595257cdbb4dce3ec7fd569) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61091777)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Linear — [MCP Tool: create Tile and columns, list Tile columns](https://linear.app/ogp/issue/PLU-834/mcp-tool-create-tile-and-columns-list-tile-columns)

<!-- /greptile_comment -->