### PR TITLE
refactor: fetch Langfuse prompts concurrently

### DIFF
--- a/packages/backend/src/helpers/ai/get-prompt.test.ts
+++ b/packages/backend/src/helpers/ai/get-prompt.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getPrompt, getPrompts } from './get-prompt'
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
+vi.mock('@/helpers/langfuse', () => ({
+  getLangfuseClient: () => ({
+    prompt: {
+      get: mocks.get,
+    },
+  }),
+}))
+
+describe('getPrompt', () => {
+  beforeEach(() => {
+    mocks.get.mockReset()
+  })
+
+  it('fetches a prompt by label', async () => {
+    const prompt = { prompt: 'content' }
+    mocks.get.mockResolvedValue(prompt)
+
+    await expect(getPrompt('chat', 'aiBuilder', 'latest')).resolves.toBe(prompt)
+    expect(mocks.get).toHaveBeenCalledWith('chat', { label: 'latest' })
+  })
+
+  it('fetches prompts concurrently and indexes them by name', async () => {
+    const resolvers = new Map<string, (value: { prompt: string }) => void>()
+    mocks.get.mockImplementation(
+      (name: string) =>
+        new Promise((resolve) => {
+          resolvers.set(name, resolve)
+        }),
+    )
+
+    const resultPromise = getPrompts(
+      ['ai-builder/core', 'ai-builder/align'],
+      'aiBuilder',
+      'latest',
+    )
+
+    expect(mocks.get).toHaveBeenCalledTimes(2)
+    resolvers.get('ai-builder/core')?.({ prompt: 'core' })
+    resolvers.get('ai-builder/align')?.({ prompt: 'align' })
+
+    const result = await resultPromise
+    expect(result.get('ai-builder/core')).toEqual({ prompt: 'core' })
+    expect(result.get('ai-builder/align')).toEqual({ prompt: 'align' })
+  })
+})

--- a/packages/backend/src/helpers/ai/get-prompt.ts
+++ b/packages/backend/src/helpers/ai/get-prompt.ts
@@ -13,3 +13,18 @@ export const getPrompt = async (
   )
   return prompt
 }
+
+export const getPrompts = async (
+  promptNames: string[],
+  project: LangfuseProject,
+  version?: string,
+) => {
+  const entries = await Promise.all(
+    promptNames.map(async (promptName) => {
+      const prompt = await getPrompt(promptName, project, version)
+      return [promptName, prompt] as const
+    }),
+  )
+
+  return new Map(entries)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `getPrompts` helper that fetches named prompts concurrently
- return prompts indexed by Langfuse name
- preserve the existing single-prompt chat path

## Test plan
- run focused helper unit tests
- run backend lint and typecheck
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

