### PR TITLE
feat: compose Langfuse skills by chat phase

### DIFF
--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -3,13 +3,13 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import type { ChatRequest } from './schema'
 import {
   composePinnedSystemPrompt,
   inferChatPhase,
   promptManifestSchema,
   selectPromptNames,
 } from './prompt-context'
+import type { ChatRequest } from './schema'
 
 type Message = ChatRequest['messages'][number]
 

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -107,25 +107,22 @@ describe('prompt manifest', () => {
 })
 
 describe('composePinnedSystemPrompt', () => {
-  it('strips restricted apps after composing skills and appends facts', () => {
+  it('joins core and skill prompts', () => {
     const result = composePinnedSystemPrompt({
       corePrompt: 'Core',
-      skillPrompts: ['| Store data | M365 Excel |'],
-      restrictedApps: ['m365-excel'],
-      facts: '\nKnown fact',
+      skillPrompts: ['Align', 'Propose'],
     })
 
-    expect(result).not.toContain('| Store data | M365 Excel |')
-    expect(result).toContain('user does not have access to')
-    expect(result.endsWith('Known fact')).toBe(true)
+    expect(result).toBe('Core\n\n---\n\nAlign\n\n---\n\nPropose')
   })
 })
 
 describe('prompt drafts', () => {
   it('retain runtime output contracts without static app catalogs', () => {
+    // Vitest cwd is packages/backend.
     const promptsDirectory = resolve(
-      __dirname,
-      '../../../../../../tools/langfuse/prompts/ai-builder',
+      process.cwd(),
+      '../../tools/langfuse/prompts/ai-builder',
     )
     const files = [
       'core.md',

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import type { ChatRequest } from './schema'
+import {
+  composePinnedSystemPrompt,
+  inferChatPhase,
+  promptManifestSchema,
+  selectPromptNames,
+} from './prompt-context'
+
+type Message = ChatRequest['messages'][number]
+
+const userMessage = (text: string): Message => ({
+  role: 'user',
+  parts: [{ type: 'text', text }],
+})
+
+const assistantMessage = (text: string): Message => ({
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+})
+
+describe('inferChatPhase', () => {
+  it('defaults workflow requests to align', () => {
+    expect(inferChatPhase([userMessage('Send email when my form submits')])).toBe(
+      'align',
+    )
+  })
+
+  it('detects guide questions without treating workflow requests as guides', () => {
+    expect(inferChatPhase([userMessage('How do I configure FormSG?')])).toBe(
+      'guide',
+    )
+    expect(
+      inferChatPhase([userMessage('How do I send email when a form submits?')]),
+    ).toBe('align')
+  })
+
+  it('keeps proposed workflows in propose', () => {
+    expect(
+      inferChatPhase([
+        assistantMessage('<!-- WORKFLOW_METADATA\nname: Test\n-->'),
+        userMessage('Yes, create it'),
+      ]),
+    ).toBe('propose')
+  })
+
+  it('uses configure or edit after a pipe exists', () => {
+    const pipeState: Message = {
+      role: 'assistant',
+      parts: [
+        {
+          type: 'data-pipeState',
+          data: {
+            pipeId: '123e4567-e89b-12d3-a456-426614174000',
+            steps: [],
+          },
+        },
+      ],
+    }
+
+    expect(inferChatPhase([pipeState, userMessage('Continue')])).toBe(
+      'configure',
+    )
+    expect(inferChatPhase([pipeState, userMessage('Remove the Slack step')])).toBe(
+      'edit',
+    )
+  })
+})
+
+describe('prompt manifest', () => {
+  it('selects core and every skill for a phase', () => {
+    const manifest = promptManifestSchema.parse({
+      core: 'ai-builder/core',
+      summary: 'chat-summary',
+      skills: [
+        {
+          id: 'configure',
+          prompt: 'ai-builder/configure',
+          phases: ['configure', 'edit'],
+        },
+        {
+          id: 'edit',
+          prompt: 'ai-builder/edit',
+          phases: ['edit'],
+        },
+      ],
+    })
+
+    expect(selectPromptNames(manifest, 'edit')).toEqual([
+      'ai-builder/core',
+      'ai-builder/configure',
+      'ai-builder/edit',
+    ])
+  })
+})
+
+describe('composePinnedSystemPrompt', () => {
+  it('strips restricted apps after composing skills and appends facts', () => {
+    const result = composePinnedSystemPrompt({
+      corePrompt: 'Core',
+      skillPrompts: ['| Store data | M365 Excel |'],
+      restrictedApps: ['m365-excel'],
+      facts: '\nKnown fact',
+    })
+
+    expect(result).not.toContain('| Store data | M365 Excel |')
+    expect(result).toContain('user does not have access to')
+    expect(result).toEndWith('Known fact')
+  })
+})
+
+describe('prompt drafts', () => {
+  it('retain runtime output contracts without static app catalogs', () => {
+    const promptsDirectory = fileURLToPath(
+      new URL(
+        '../../../../../../tools/langfuse/prompts/ai-builder/',
+        import.meta.url,
+      ),
+    )
+    const files = [
+      'core.md',
+      'align.md',
+      'propose.md',
+      'configure.md',
+      'edit.md',
+      'guide.md',
+      'unsupported.md',
+      'output-format.md',
+    ]
+    const content = files
+      .map((file) => readFileSync(`${promptsDirectory}${file}`, 'utf8'))
+      .join('\n')
+
+    for (const marker of [
+      'CLARIFICATION_DATA',
+      'WORKFLOW_METADATA',
+      'DYNAMIC_PICKER_DATA',
+      'APP_KEY',
+      'useConfiguredEmails',
+      '{{SUPPORT_FORM_URL}}',
+    ]) {
+      expect(content).toContain(marker)
+    }
+    expect(content).not.toContain('## Available Triggers')
+    expect(content).not.toContain('## Available Actions')
+  })
+})

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import type { ChatRequest } from './schema'
@@ -24,9 +25,9 @@ const assistantMessage = (text: string): Message => ({
 
 describe('inferChatPhase', () => {
   it('defaults workflow requests to align', () => {
-    expect(inferChatPhase([userMessage('Send email when my form submits')])).toBe(
-      'align',
-    )
+    expect(
+      inferChatPhase([userMessage('Send email when my form submits')]),
+    ).toBe('align')
   })
 
   it('detects guide questions without treating workflow requests as guides', () => {
@@ -64,9 +65,9 @@ describe('inferChatPhase', () => {
     expect(inferChatPhase([pipeState, userMessage('Continue')])).toBe(
       'configure',
     )
-    expect(inferChatPhase([pipeState, userMessage('Remove the Slack step')])).toBe(
-      'edit',
-    )
+    expect(
+      inferChatPhase([pipeState, userMessage('Remove the Slack step')]),
+    ).toBe('edit')
   })
 })
 
@@ -108,17 +109,15 @@ describe('composePinnedSystemPrompt', () => {
 
     expect(result).not.toContain('| Store data | M365 Excel |')
     expect(result).toContain('user does not have access to')
-    expect(result).toEndWith('Known fact')
+    expect(result.endsWith('Known fact')).toBe(true)
   })
 })
 
 describe('prompt drafts', () => {
   it('retain runtime output contracts without static app catalogs', () => {
-    const promptsDirectory = fileURLToPath(
-      new URL(
-        '../../../../../../tools/langfuse/prompts/ai-builder/',
-        import.meta.url,
-      ),
+    const promptsDirectory = path.resolve(
+      __dirname,
+      '../../../../../../tools/langfuse/prompts/ai-builder',
     )
     const files = [
       'core.md',
@@ -131,7 +130,7 @@ describe('prompt drafts', () => {
       'output-format.md',
     ]
     const content = files
-      .map((file) => readFileSync(`${promptsDirectory}${file}`, 'utf8'))
+      .map((file) => readFileSync(path.join(promptsDirectory, file), 'utf8'))
       .join('\n')
 
     for (const marker of [

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -142,6 +142,7 @@ describe('prompt drafts', () => {
       'CLARIFICATION_DATA',
       'WORKFLOW_METADATA',
       'DYNAMIC_PICKER_DATA',
+      'TILE_SETUP_DATA',
       'APP_KEY',
       'useConfiguredEmails',
       '{{SUPPORT_FORM_URL}}',

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from 'node:fs'
-import path from 'node:path'
-
+import { readFileSync } from 'fs'
+import { join, resolve } from 'path'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -124,7 +123,7 @@ describe('composePinnedSystemPrompt', () => {
 
 describe('prompt drafts', () => {
   it('retain runtime output contracts without static app catalogs', () => {
-    const promptsDirectory = path.resolve(
+    const promptsDirectory = resolve(
       __dirname,
       '../../../../../../tools/langfuse/prompts/ai-builder',
     )
@@ -139,7 +138,7 @@ describe('prompt drafts', () => {
       'output-format.md',
     ]
     const content = files
-      .map((file) => readFileSync(path.join(promptsDirectory, file), 'utf8'))
+      .map((file) => readFileSync(join(promptsDirectory, file), 'utf8'))
       .join('\n')
 
     for (const marker of [

--- a/packages/backend/src/routes/api/chat/prompt-context.test.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.test.ts
@@ -43,9 +43,18 @@ describe('inferChatPhase', () => {
     expect(
       inferChatPhase([
         assistantMessage('<!-- WORKFLOW_METADATA\nname: Test\n-->'),
-        userMessage('Yes, create it'),
+        userMessage("No, I'll keep refining"),
       ]),
     ).toBe('propose')
+  })
+
+  it('loads configure when the user confirms a proposal', () => {
+    expect(
+      inferChatPhase([
+        assistantMessage('<!-- WORKFLOW_METADATA\nname: Test\n-->'),
+        userMessage('Yes, create it'),
+      ]),
+    ).toBe('configure')
   })
 
   it('uses configure or edit after a pipe exists', () => {

--- a/packages/backend/src/routes/api/chat/prompt-context.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod'
+
+import { buildSystemPrompt } from '@/helpers/build-system-prompt'
+
+import type { ChatRequest } from './schema'
+
+export type ChatPhase = 'align' | 'propose' | 'configure' | 'edit' | 'guide'
+
+export const promptManifestSchema = z.object({
+  core: z.string().min(1),
+  summary: z.string().min(1),
+  skills: z.array(
+    z.object({
+      id: z.string().min(1),
+      prompt: z.string().min(1),
+      phases: z.array(
+        z.enum(['align', 'propose', 'configure', 'edit', 'guide']),
+      ),
+    }),
+  ),
+})
+
+export type PromptManifest = z.infer<typeof promptManifestSchema>
+
+function textFromMessage(message: ChatRequest['messages'][number]): string {
+  return message.parts
+    .flatMap((part) => (part.type === 'text' ? [part.text] : []))
+    .join('\n')
+}
+
+function hasPipe(messages: ChatRequest['messages']): boolean {
+  return messages.some((message) =>
+    message.parts.some((part) => {
+      if (part.type === 'data-pipeState') {
+        return true
+      }
+      if (part.type !== 'tool-create_pipe' && part.type !== 'dynamic-tool') {
+        return false
+      }
+      if (part.type === 'dynamic-tool' && part.toolName !== 'create_pipe') {
+        return false
+      }
+      return (
+        typeof part.output === 'object' &&
+        part.output !== null &&
+        'pipeId' in part.output
+      )
+    }),
+  )
+}
+
+function isEditRequest(text: string): boolean {
+  return /\b(add|change|delete|edit|modify|move|remove|replace|start over|swap|update)\b/i.test(
+    text,
+  )
+}
+
+function isGuideQuestion(text: string): boolean {
+  const asksForHelp =
+    /\?|^(how|what|when|where|why|can|does|is)\b/i.test(text.trim())
+  const mentionsGuidance =
+    /\b(connect|configure|guide|set up|setup|troubleshoot|triggering|work)\b/i.test(
+      text,
+    )
+  const requestsWorkflow =
+    /\b(automate|build|create|pipe|save|send|store|workflow|when .*submitted)\b/i.test(
+      text,
+    )
+  return asksForHelp && mentionsGuidance && !requestsWorkflow
+}
+
+export function inferChatPhase(
+  messages: ChatRequest['messages'],
+): ChatPhase {
+  const latestUserMessage = messages
+    .toReversed()
+    .find((message) => message.role === 'user')
+  const latestUserText = latestUserMessage
+    ? textFromMessage(latestUserMessage)
+    : ''
+
+  if (hasPipe(messages)) {
+    return isEditRequest(latestUserText) ? 'edit' : 'configure'
+  }
+
+  const hasProposal = messages.some(
+    (message) =>
+      message.role === 'assistant' &&
+      textFromMessage(message).includes('<!-- WORKFLOW_METADATA'),
+  )
+  if (hasProposal) {
+    return 'propose'
+  }
+
+  return isGuideQuestion(latestUserText) ? 'guide' : 'align'
+}
+
+export function selectPromptNames(
+  manifest: PromptManifest,
+  phase: ChatPhase,
+): string[] {
+  return [
+    manifest.core,
+    ...manifest.skills
+      .filter((skill) => skill.phases.includes(phase))
+      .map((skill) => skill.prompt),
+  ]
+}
+
+interface ComposePinnedSystemPromptParams {
+  corePrompt: string
+  skillPrompts: string[]
+  restrictedApps: string[]
+  facts?: string
+}
+
+export function composePinnedSystemPrompt({
+  corePrompt,
+  skillPrompts,
+  restrictedApps,
+  facts = '',
+}: ComposePinnedSystemPromptParams): string {
+  const composedPrompt = [corePrompt, ...skillPrompts].join('\n\n---\n\n')
+  return buildSystemPrompt(composedPrompt, restrictedApps) + facts
+}

--- a/packages/backend/src/routes/api/chat/prompt-context.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.ts
@@ -56,8 +56,9 @@ function isEditRequest(text: string): boolean {
 }
 
 function isGuideQuestion(text: string): boolean {
-  const asksForHelp =
-    /\?|^(how|what|when|where|why|can|does|is)\b/i.test(text.trim())
+  const asksForHelp = /\?|^(how|what|when|where|why|can|does|is)\b/i.test(
+    text.trim(),
+  )
   const mentionsGuidance =
     /\b(connect|configure|guide|set up|setup|troubleshoot|triggering|work)\b/i.test(
       text,
@@ -69,11 +70,9 @@ function isGuideQuestion(text: string): boolean {
   return asksForHelp && mentionsGuidance && !requestsWorkflow
 }
 
-export function inferChatPhase(
-  messages: ChatRequest['messages'],
-): ChatPhase {
-  const latestUserMessage = messages
-    .toReversed()
+export function inferChatPhase(messages: ChatRequest['messages']): ChatPhase {
+  const latestUserMessage = [...messages]
+    .reverse()
     .find((message) => message.role === 'user')
   const latestUserText = latestUserMessage
     ? textFromMessage(latestUserMessage)

--- a/packages/backend/src/routes/api/chat/prompt-context.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
 
-import { buildSystemPrompt } from '@/helpers/build-system-prompt'
-
 import type { ChatRequest } from './schema'
 
 export type ChatPhase = 'align' | 'propose' | 'configure' | 'edit' | 'guide'
@@ -115,16 +113,11 @@ export function selectPromptNames(
 interface ComposePinnedSystemPromptParams {
   corePrompt: string
   skillPrompts: string[]
-  restrictedApps: string[]
-  facts?: string
 }
 
 export function composePinnedSystemPrompt({
   corePrompt,
   skillPrompts,
-  restrictedApps,
-  facts = '',
 }: ComposePinnedSystemPromptParams): string {
-  const composedPrompt = [corePrompt, ...skillPrompts].join('\n\n---\n\n')
-  return buildSystemPrompt(composedPrompt, restrictedApps) + facts
+  return [corePrompt, ...skillPrompts].join('\n\n---\n\n')
 }

--- a/packages/backend/src/routes/api/chat/prompt-context.ts
+++ b/packages/backend/src/routes/api/chat/prompt-context.ts
@@ -55,6 +55,12 @@ function isEditRequest(text: string): boolean {
   )
 }
 
+function confirmsProposal(text: string): boolean {
+  return /^(yes|yes, create it|create it|go ahead|set it up|confirm)\b/i.test(
+    text.trim(),
+  )
+}
+
 function isGuideQuestion(text: string): boolean {
   const asksForHelp = /\?|^(how|what|when|where|why|can|does|is)\b/i.test(
     text.trim(),
@@ -88,7 +94,7 @@ export function inferChatPhase(messages: ChatRequest['messages']): ChatPhase {
       textFromMessage(message).includes('<!-- WORKFLOW_METADATA'),
   )
   if (hasProposal) {
-    return 'propose'
+    return confirmsProposal(latestUserText) ? 'configure' : 'propose'
   }
 
   return isGuideQuestion(latestUserText) ? 'guide' : 'align'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- infer align, propose, configure, edit, and guide phases from chat history
- load configuration rules when a user confirms a proposal
- validate the Langfuse skill manifest with Zod
- compose phase prompts only. Chat still applies `buildSystemPrompt` after this
- verify local prompt contracts from the Vitest working directory

## Test plan
- run focused phase/composition unit tests
- run backend lint, typecheck, and build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

