### PR TITLE
feat: load AI Builder skills behind flag

### DIFF
--- a/packages/backend/src/helpers/ai/get-ai-builder-flag.ts
+++ b/packages/backend/src/helpers/ai/get-ai-builder-flag.ts
@@ -3,7 +3,11 @@ import {
   AI_BUILDER_FEATURE_FLAG_FALLBACK,
 } from '@/config/flags'
 
-export type AiBuilderLdFlagValue = typeof AI_BUILDER_FEATURE_FLAG_FALLBACK
+export type AiBuilderLdFlagValue = typeof AI_BUILDER_FEATURE_FLAG_FALLBACK & {
+  config: typeof AI_BUILDER_FEATURE_FLAG_FALLBACK.config & {
+    skillManifestPromptName?: string
+  }
+}
 
 /**
  * Resolves the ai-builder flag from a full LD flag map (e.g. `allFlagsState`),

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -161,7 +161,7 @@ function makePrompt(
     version,
     config,
     toJSON: () => ({ version }),
-  } as Awaited<ReturnType<typeof getPrompt>>
+  } as unknown as Awaited<ReturnType<typeof getPrompt>>
 }
 
 import { createMcpBridgeTools } from '@/helpers/mcp-bridge-tools'
@@ -286,9 +286,7 @@ describe('chat handler — Langfuse skills', () => {
   })
 
   it('loads and composes prompts selected by the manifest', async () => {
-    vi.mocked(getPrompt).mockResolvedValueOnce(
-      makePrompt('{}', 3, manifest),
-    )
+    vi.mocked(getPrompt).mockResolvedValueOnce(makePrompt('{}', 3, manifest))
     vi.mocked(getPrompts).mockResolvedValueOnce(
       new Map([
         ['ai-builder/core', makePrompt('Core', 4)],
@@ -329,11 +327,7 @@ describe('chat handler — Langfuse skills', () => {
       (message) => message.role === 'system',
     )
     expect(systemMessage?.content).toBe('Monolith')
-    expect(getPrompt).toHaveBeenLastCalledWith(
-      'chat',
-      'aiBuilder',
-      'latest',
-    )
+    expect(getPrompt).toHaveBeenLastCalledWith('chat', 'aiBuilder', 'latest')
   })
 })
 

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -57,8 +57,11 @@ vi.mock('@/models/connection', () => ({
 vi.mock('@/helpers/ai/get-prompt', () => ({
   getPrompt: vi.fn().mockResolvedValue({
     prompt: 'You are a helpful assistant. Support: {{SUPPORT_FORM_URL}}',
+    config: {},
+    version: 1,
     toJSON: () => ({}),
   }),
+  getPrompts: vi.fn(),
 }))
 
 vi.mock('@/helpers/build-system-prompt', () => ({
@@ -120,6 +123,7 @@ import { experimental_createMCPClient } from '@ai-sdk/mcp'
 import { streamText } from 'ai'
 
 import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
+import { getPrompt, getPrompts } from '@/helpers/ai/get-prompt'
 import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 
@@ -145,6 +149,19 @@ function makeRes() {
     headersSent: false,
     end: vi.fn(),
   }
+}
+
+function makePrompt(
+  prompt: string,
+  version: number,
+  config: Record<string, unknown> = {},
+): Awaited<ReturnType<typeof getPrompt>> {
+  return {
+    prompt,
+    version,
+    config,
+    toJSON: () => ({ version }),
+  } as Awaited<ReturnType<typeof getPrompt>>
 }
 
 import { createMcpBridgeTools } from '@/helpers/mcp-bridge-tools'
@@ -237,6 +254,86 @@ describe('chat handler — GitBook MCP integration', () => {
       'Support: https://form.gov.sg/64929532701266001209ac32',
     )
     expect(systemMessage?.content).not.toContain('6a979221b8ae314641032f5c=')
+  })
+})
+
+describe('chat handler — Langfuse skills', () => {
+  const manifest = {
+    core: 'ai-builder/core',
+    summary: 'chat-summary',
+    skills: [
+      {
+        id: 'align',
+        prompt: 'ai-builder/align',
+        phases: ['align'],
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getAiBuilderFlag).mockReturnValue({
+      enabled: true,
+      config: {
+        chatPromptName: 'chat',
+        chatSummaryPromptName: 'chat-summary',
+        generateStepsPromptName: 'generate-steps',
+        version: 'latest',
+        mcpStepConfig: true,
+        skillManifestPromptName: 'ai-builder/manifest',
+      },
+    })
+  })
+
+  it('loads and composes prompts selected by the manifest', async () => {
+    vi.mocked(getPrompt).mockResolvedValueOnce(
+      makePrompt('{}', 3, manifest),
+    )
+    vi.mocked(getPrompts).mockResolvedValueOnce(
+      new Map([
+        ['ai-builder/core', makePrompt('Core', 4)],
+        ['ai-builder/align', makePrompt('Align', 5)],
+      ]),
+    )
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+
+    const [[options]] = vi.mocked(streamText).mock.calls
+    const systemMessage = options.messages.find(
+      (message) => message.role === 'system',
+    )
+    expect(systemMessage?.content).toBe('Core\n\n---\n\nAlign')
+    expect(options.experimental_telemetry?.metadata?.promptVersions).toBe(
+      JSON.stringify([
+        { name: 'ai-builder/manifest', version: 3 },
+        { name: 'ai-builder/core', version: 4 },
+        { name: 'ai-builder/align', version: 5 },
+      ]),
+    )
+  })
+
+  it('falls back to the monolith when a skill fetch fails', async () => {
+    vi.mocked(getPrompt)
+      .mockResolvedValueOnce(makePrompt('{}', 3, manifest))
+      .mockResolvedValueOnce(makePrompt('Monolith', 179))
+    vi.mocked(getPrompts).mockRejectedValueOnce(new Error('unavailable'))
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+
+    const [[options]] = vi.mocked(streamText).mock.calls
+    const systemMessage = options.messages.find(
+      (message) => message.role === 'system',
+    )
+    expect(systemMessage?.content).toBe('Monolith')
+    expect(getPrompt).toHaveBeenLastCalledWith(
+      'chat',
+      'aiBuilder',
+      'latest',
+    )
   })
 })
 

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -27,7 +27,7 @@ import {
   SUPPORT_FORM_URL_PLACEHOLDER,
 } from '@/helpers/ai/build-support-form-url'
 import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
-import { getPrompt } from '@/helpers/ai/get-prompt'
+import { getPrompt, getPrompts } from '@/helpers/ai/get-prompt'
 import {
   parseWorkflowMetadata,
   WORKFLOW_METADATA_REGEX,
@@ -51,6 +51,12 @@ import {
 import { parseClarificationBlock } from './parse-clarification-block'
 import { parseColumnTableBlock } from './parse-column-table-block'
 import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
+import {
+  composePinnedSystemPrompt,
+  inferChatPhase,
+  promptManifestSchema,
+  selectPromptNames,
+} from './prompt-context'
 import { chatRequestSchema } from './schema'
 
 // Keep in sync with schema.ts and frontend/src/pages/AiBuilder/constants.ts.
@@ -99,8 +105,12 @@ const handleChatStream = observe(
     // NOTE: we pass restricted apps into the system prompt so the assistant knows which apps the user cannot use
     const restrictedApps = getRestrictedAppKeys(allLdFlags)
 
-    const { chatPromptName, chatSummaryPromptName, version } =
-      aiBuilderFlag.config
+    const {
+      chatPromptName,
+      chatSummaryPromptName,
+      skillManifestPromptName,
+      version,
+    } = aiBuilderFlag.config
 
     try {
       const validationResult = chatRequestSchema.safeParse(req.body)
@@ -147,12 +157,82 @@ const handleChatStream = observe(
       // threshold) so both sides agree on which turn is the last one.
       const isAtLimit = rawMessages.length >= MAX_MESSAGES
 
-      // Get the prompt from Langfuse
-      const prompt = await getPrompt(
-        isAtLimit ? chatSummaryPromptName : chatPromptName,
-        'aiBuilder',
-        version,
+      // Re-derived fresh every turn from the raw message text and verified
+      // against this user's own connections — never trust the connectionId a
+      // user references in their own chat text without checking ownership
+      // first (see resolveEstablishedFormConnection).
+      const establishedFormConnection = await resolveEstablishedFormConnection(
+        context.currentUser,
+        rawMessages,
       )
+      const connectionReminder = buildEstablishedConnectionReminder(
+        establishedFormConnection,
+      )
+
+      let prompt: Awaited<ReturnType<typeof getPrompt>>
+      let systemPrompt: string
+      let promptVersions: Array<{ name: string; version: number }>
+
+      if (skillManifestPromptName && !isAtLimit) {
+        try {
+          const manifestPrompt = await getPrompt(
+            skillManifestPromptName,
+            'aiBuilder',
+            version,
+          )
+          const manifest = promptManifestSchema.parse(manifestPrompt.config)
+          const phase = inferChatPhase(rawMessages)
+          const promptNames = selectPromptNames(manifest, phase)
+          const prompts = await getPrompts(promptNames, 'aiBuilder', version)
+          const corePrompt = prompts.get(manifest.core)
+          if (!corePrompt) {
+            throw new Error('Langfuse skill manifest core prompt is missing')
+          }
+          const skillPrompts = promptNames
+            .filter((name) => name !== manifest.core)
+            .map((name) => {
+              const skillPrompt = prompts.get(name)
+              if (!skillPrompt) {
+                throw new Error(`Langfuse skill prompt is missing: ${name}`)
+              }
+              return skillPrompt
+            })
+
+          prompt = manifestPrompt
+          systemPrompt = composePinnedSystemPrompt({
+            corePrompt: corePrompt.prompt,
+            skillPrompts: skillPrompts.map((skillPrompt) => skillPrompt.prompt),
+            restrictedApps,
+            facts: connectionReminder,
+          })
+          promptVersions = [
+            {
+              name: skillManifestPromptName,
+              version: manifestPrompt.version,
+            },
+            ...promptNames.map((name) => ({
+              name,
+              version: prompts.get(name)!.version,
+            })),
+          ]
+        } catch (error) {
+          logger.warn('Failed to load Langfuse skills; using chat prompt', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+          prompt = await getPrompt(chatPromptName, 'aiBuilder', version)
+          systemPrompt =
+            buildSystemPrompt(prompt.prompt, restrictedApps) + connectionReminder
+          promptVersions = [
+            { name: chatPromptName, version: prompt.version },
+          ]
+        }
+      } else {
+        const promptName = isAtLimit ? chatSummaryPromptName : chatPromptName
+        prompt = await getPrompt(promptName, 'aiBuilder', version)
+        systemPrompt =
+          buildSystemPrompt(prompt.prompt, restrictedApps) + connectionReminder
+        promptVersions = [{ name: promptName, version: prompt.version }]
+      }
 
       logger.info('Starting AI chat stream', {
         traceId,
@@ -162,22 +242,12 @@ const handleChatStream = observe(
         model: MODEL_TYPE,
       })
 
-      // Re-derived fresh every turn from the raw message text and verified
-      // against this user's own connections — never trust the connectionId a
-      // user references in their own chat text without checking ownership
-      // first (see resolveEstablishedFormConnection).
-      const establishedFormConnection = await resolveEstablishedFormConnection(
-        context.currentUser,
-        rawMessages,
-      )
-
       const systemMessage = {
         role: 'system' as const,
-        content:
-          buildSystemPrompt(prompt.prompt, restrictedApps).replaceAll(
-            SUPPORT_FORM_URL_PLACEHOLDER,
-            buildSupportFormUrl(chatId),
-          ) + buildEstablishedConnectionReminder(establishedFormConnection),
+        content: systemPrompt.replaceAll(
+          SUPPORT_FORM_URL_PLACEHOLDER,
+          buildSupportFormUrl(chatId),
+        ),
       }
       const allMessages = [systemMessage, ...messages]
 
@@ -245,8 +315,9 @@ const handleChatStream = observe(
                 ddRumSessionId: rumSessionId || undefined,
                 userId: context.currentUser.email,
                 environment: appConfig.appEnv,
-                promptName: chatPromptName,
+                promptName: promptVersions.map(({ name }) => name).join(','),
                 promptVersion: version,
+                promptVersions: JSON.stringify(promptVersions),
                 langfusePrompt: prompt.toJSON(),
                 tags: [
                   'ai-builder',

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -199,12 +199,16 @@ const handleChatStream = observe(
             })
 
           prompt = manifestPrompt
-          systemPrompt = composePinnedSystemPrompt({
-            corePrompt: corePrompt.prompt,
-            skillPrompts: skillPrompts.map((skillPrompt) => skillPrompt.prompt),
-            restrictedApps,
-            facts: connectionReminder,
-          })
+          systemPrompt =
+            buildSystemPrompt(
+              composePinnedSystemPrompt({
+                corePrompt: corePrompt.prompt,
+                skillPrompts: skillPrompts.map(
+                  (skillPrompt) => skillPrompt.prompt,
+                ),
+              }),
+              restrictedApps,
+            ) + connectionReminder
           promptVersions = [
             {
               name: skillManifestPromptName,

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -221,10 +221,9 @@ const handleChatStream = observe(
           })
           prompt = await getPrompt(chatPromptName, 'aiBuilder', version)
           systemPrompt =
-            buildSystemPrompt(prompt.prompt, restrictedApps) + connectionReminder
-          promptVersions = [
-            { name: chatPromptName, version: prompt.version },
-          ]
+            buildSystemPrompt(prompt.prompt, restrictedApps) +
+            connectionReminder
+          promptVersions = [{ name: chatPromptName, version: prompt.version }]
         }
       } else {
         const promptName = isAtLimit ? chatSummaryPromptName : chatPromptName


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add optional `skillManifestPromptName` to AI Builder configuration
- fetch and compose phase-specific Langfuse skills when enabled
- strip restricted apps after composition, then append connection facts
- trace every selected prompt version
- fall back to the existing monolith on any skill-loading failure

## Test plan
- run focused chat route and prompt context unit tests
- run backend lint, typecheck, and build
- verify the default flag keeps the existing chat path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4012fe-b7c4-41fe-991c-4c15fc596d9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

