### PR TITLE
Support formsg staging env rename

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/trusted-attachment-urls.test.ts
@@ -5,7 +5,7 @@ import { areAttachmentUrlsTrusted } from '../../auth/trusted-attachment-urls'
 const TRUSTED_PROD_URL =
   'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
 const TRUSTED_STAGING_URL =
-  'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
+  'https://s3.ap-southeast-1.amazonaws.com/attachments.stg.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
 const TRUSTED_UAT_URL =
   'https://s3.ap-southeast-1.amazonaws.com/attachments.uat.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123'
 
@@ -28,10 +28,7 @@ describe('areAttachmentUrlsTrusted', () => {
 
   it('accepts FormSG bucket URLs for the staging env', () => {
     expect(
-      areAttachmentUrlsTrusted(
-        { attachField1: TRUSTED_STAGING_URL },
-        'staging',
-      ),
+      areAttachmentUrlsTrusted({ attachField1: TRUSTED_STAGING_URL }, 'stg'),
     ).toBe(true)
   })
 
@@ -44,8 +41,8 @@ describe('areAttachmentUrlsTrusted', () => {
   it.each([
     ['a staging URL against the prod env', TRUSTED_STAGING_URL, 'prod'],
     ['a uat URL against the prod env', TRUSTED_UAT_URL, 'prod'],
-    ['a prod URL against the staging env', TRUSTED_PROD_URL, 'staging'],
-    ['a uat URL against the staging env', TRUSTED_UAT_URL, 'staging'],
+    ['a prod URL against the staging env', TRUSTED_PROD_URL, 'stg'],
+    ['a uat URL against the staging env', TRUSTED_UAT_URL, 'stg'],
     ['a prod URL against the uat env', TRUSTED_PROD_URL, 'uat'],
     ['a staging URL against the uat env', TRUSTED_STAGING_URL, 'uat'],
   ] as const)('rejects %s', (_label, url, formEnv) => {

--- a/packages/backend/src/apps/formsg/__tests__/common/form-env.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/common/form-env.test.ts
@@ -12,12 +12,12 @@ describe('Form environment handling', () => {
   describe('parseFormIdAsUrl', () => {
     it.each([
       'https://form.gov.sg/topkek',
-      'http://staging.form.gov.sg/hmmm',
+      'http://stg.form.gov.sg/hmmm',
       'form.gov.sg/1234',
       'www.form.gov.sg/',
       'uat.form.gov.sg',
       'uat.form.gov.sg/abcd-1234/cup-of-tea',
-      'https://staging.form.gov.sg/url%20encoded%20stuff?query=1234',
+      'https://stg.form.gov.sg/url%20encoded%20stuff?query=1234',
     ])('returns the URL object for valid URLs (%s)', (rawUrl) => {
       expect(parseFormIdAsUrl(rawUrl)).toBeInstanceOf(URL)
     })
@@ -52,8 +52,8 @@ describe('Form environment handling', () => {
         expectedEnv: 'prod',
       },
       {
-        formId: 'https://staging.form.gov.sg/95967305e41b75001293e70c',
-        expectedEnv: 'staging',
+        formId: 'https://stg.form.gov.sg/95967305e41b75001293e70c',
+        expectedEnv: 'stg',
       },
       {
         formId: 'https://uat.form.gov.sg/95967305e41b75001293e70c',
@@ -108,7 +108,7 @@ describe('Form environment handling', () => {
       expect(sdkMode).toEqual('production')
     })
 
-    it.each(['staging', 'uat'] as const)(
+    it.each(['stg', 'uat'] as const)(
       'returns staging sdk if the input environment is not prod',
       (env) => {
         const sdkMode = getSdk(env) as unknown as string

--- a/packages/backend/src/apps/formsg/common/form-env.ts
+++ b/packages/backend/src/apps/formsg/common/form-env.ts
@@ -11,7 +11,7 @@ const PRODUCTION_SDK = formsgSdk({
   mode: 'production',
 })
 
-export const SUPPORTED_FORM_ENVS = ['prod', 'staging', 'uat'] as const
+export const SUPPORTED_FORM_ENVS = ['prod', 'stg', 'uat'] as const
 export type FormEnv = (typeof SUPPORTED_FORM_ENVS)[number]
 
 export function parseFormIdAsUrl(rawUrl: string): URL | null {

--- a/packages/backend/src/config/app-env-vars/formsg.ts
+++ b/packages/backend/src/config/app-env-vars/formsg.ts
@@ -1,7 +1,7 @@
 export const formsgConfig = Object.freeze({
   apiKeys: {
     prod: process.env.FORMSG_API_KEY,
-    staging: process.env.FORMSG_STAGING_API_KEY,
+    stg: process.env.FORMSG_STAGING_API_KEY,
     uat: process.env.FORMSG_UAT_API_KEY,
   },
 })
@@ -10,7 +10,7 @@ if (!formsgConfig.apiKeys.prod) {
   throw new Error('FORMSG_API_KEY env var needs to be set')
 }
 
-if (!formsgConfig.apiKeys.staging) {
+if (!formsgConfig.apiKeys.stg) {
   throw new Error('FORMSG_STAGING_API_KEY env var needs to be set')
 }
 

--- a/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
@@ -55,14 +55,14 @@ describe('getFormSchemaService', () => {
       vi.mocked(axios.get).mockResolvedValue(mockForm())
 
       const result = await getFormSchemaService(
-        `https://staging.form.gov.sg/admin/form/${FORM_ID}`,
+        `https://stg.form.gov.sg/admin/form/${FORM_ID}`,
       )
 
       expect(vi.mocked(axios.get)).toHaveBeenCalledWith(
-        `https://staging.form.gov.sg/api/v3/forms/${FORM_ID}`,
+        `https://stg.form.gov.sg/api/v3/forms/${FORM_ID}`,
         expect.anything(),
       )
-      expect(result).toMatchObject({ env: 'staging' })
+      expect(result).toMatchObject({ env: 'stg' })
     })
 
     it('never fetches a non-form.gov.sg URL', async () => {


### PR DESCRIPTION
# Problem
FormSG renamed their staging env from `staging` to `stg`, this broke our integration. 

Fix: Rename references in our code to follow the new `stg` env name

# Tests
* Check that I can connect to staging forms
* Regression test: check that I can still connect to formsg prod

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the FormSG staging environment identifier and hostname from `staging` to `stg`.
- Aligns the supported environment union and API-key configuration key.
- Updates environment parsing and MCP schema-fetch expectations for `stg.form.gov.sg`.
- Retains the existing staging SDK mode and environment-variable name.
- Leaves some downstream mocked tests using the obsolete environment value.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking need to update the remaining mocked FormSG tests so they cover the renamed staging environment.

Runtime environment parsing, configuration lookup, and API URL construction consistently use `stg`; the remaining issue is stale test coverage that can pass while exercising the retired `staging` value.

**Files Needing Attention:** packages/backend/src/apps/formsg/common/form-env.ts and remaining FormSG environment tests
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/apps/formsg/common/form-env.ts | Renames the supported staging discriminator to `stg`; runtime consumers are aligned, but related mocked coverage remains stale. |
| packages/backend/src/config/app-env-vars/formsg.ts | Renames the API-key map entry to `stg` while retaining the deployed environment-variable name. |
| packages/backend/src/apps/formsg/__tests__/common/form-env.test.ts | Updates focused URL parsing, environment detection, and SDK-selection cases for the new staging hostname. |
| packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts | Updates the MCP schema-fetch test to expect the renamed staging host and environment value. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fplumber%20PR%20%232129%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fplumber&pr=2129&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fapps%2Fformsg%2Fcommon%2Fform-env.ts%3A14%0A**Staging%20tests%20remain%20stale**%0A%0ASeveral%20FormSG%20tests%20still%20exercise%20the%20obsolete%20%60staging%60%20value%20instead%20of%20%60stg%60%2C%20including%20the%20outgoing%20API-base%20and%20attachment%20trust%2Fdecryption%20tests.%20Because%20these%20dependencies%20are%20mocked%2C%20the%20suite%20can%20pass%20without%20verifying%20that%20the%20renamed%20environment%20selects%20%60stg.form.gov.sg%60%20and%20trusts%20%60attachments.stg.form.gov.sg%60.%20Please%20update%20these%20cases%20so%20regressions%20in%20the%20renamed%20integration%20are%20covered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fapps%2Fformsg%2Fcommon%2Fform-env.ts%3A14%0A**Staging%20tests%20remain%20stale**%0A%0ASeveral%20FormSG%20tests%20still%20exercise%20the%20obsolete%20%60staging%60%20value%20instead%20of%20%60stg%60%2C%20including%20the%20outgoing%20API-base%20and%20attachment%20trust%2Fdecryption%20tests.%20Because%20these%20dependencies%20are%20mocked%2C%20the%20suite%20can%20pass%20without%20verifying%20that%20the%20renamed%20environment%20selects%20%60stg.form.gov.sg%60%20and%20trusts%20%60attachments.stg.form.gov.sg%60.%20Please%20update%20these%20cases%20so%20regressions%20in%20the%20renamed%20integration%20are%20covered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fplumber%22%20on%20the%20existing%20branch%20%22chore%2Fformsg%2Fstaging-env%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fformsg%2Fstaging-env%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fapps%2Fformsg%2Fcommon%2Fform-env.ts%3A14%0A**Staging%20tests%20remain%20stale**%0A%0ASeveral%20FormSG%20tests%20still%20exercise%20the%20obsolete%20%60staging%60%20value%20instead%20of%20%60stg%60%2C%20including%20the%20outgoing%20API-base%20and%20attachment%20trust%2Fdecryption%20tests.%20Because%20these%20dependencies%20are%20mocked%2C%20the%20suite%20can%20pass%20without%20verifying%20that%20the%20renamed%20environment%20selects%20%60stg.form.gov.sg%60%20and%20trusts%20%60attachments.stg.form.gov.sg%60.%20Please%20update%20these%20cases%20so%20regressions%20in%20the%20renamed%20integration%20are%20covered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/backend/src/apps/formsg/common/form-env.ts:14
**Staging tests remain stale**

Several FormSG tests still exercise the obsolete `staging` value instead of `stg`, including the outgoing API-base and attachment trust/decryption tests. Because these dependencies are mocked, the suite can pass without verifying that the renamed environment selects `stg.form.gov.sg` and trusts `attachments.stg.form.gov.sg`. Please update these cases so regressions in the renamed integration are covered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: [54b314e](https://github.com/opengovsg/plumber/commit/54b314e01c0331028384abd4304e23db7bfac08b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61120570)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->