### PR TITLE
Fix outdated FormSG staging env tests

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/app.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/app.test.ts
@@ -61,13 +61,13 @@ describe('FormSG app', () => {
   })
 
   it('on each outgoing connection, sets the appropriate base API url for the form environment', async () => {
-    mocks.parseFormEnv.mockReturnValue('staging')
+    mocks.parseFormEnv.mockReturnValue('stg')
     mocks.getApiBaseUrl.mockReturnValue('sample-mock-url')
 
     await $.http.get('localhost')
 
     expect(mocks.parseFormEnv).toBeCalled()
-    expect(mocks.getApiBaseUrl).toBeCalledWith('staging')
+    expect(mocks.getApiBaseUrl).toBeCalledWith('stg')
     expect(mocks.axiosRequestAdapter).toHaveBeenLastCalledWith(
       expect.objectContaining({
         baseURL: 'sample-mock-url',

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -220,10 +220,10 @@ describe('decrypt form response - MRF specific', () => {
 
     it('should trust attachment URLs under the form env-specific prefix for non-prod envs', async () => {
       $.flow.hasFileProcessingActions = true
-      mocks.parseFormEnv.mockReturnValueOnce('staging')
+      mocks.parseFormEnv.mockReturnValueOnce('stg')
       $.request.body.data.attachmentDownloadUrls = {
         attachField1:
-          'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/123',
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.stg.form.gov.sg/123',
       }
 
       mocks.cryptoV3Decrypt.mockReturnValueOnce({
@@ -250,7 +250,7 @@ describe('decrypt form response - MRF specific', () => {
         'mock-secret-key',
         {
           attachField1:
-            'https://s3.ap-southeast-1.amazonaws.com/attachments.staging.form.gov.sg/123',
+            'https://s3.ap-southeast-1.amazonaws.com/attachments.stg.form.gov.sg/123',
         },
         expect.any(Array),
       )
@@ -258,7 +258,7 @@ describe('decrypt form response - MRF specific', () => {
 
     it('should return verified: false when an attachment URL uses the prod prefix for a staging form', async () => {
       $.flow.hasFileProcessingActions = true
-      mocks.parseFormEnv.mockReturnValueOnce('staging')
+      mocks.parseFormEnv.mockReturnValueOnce('stg')
       $.request.body.data.attachmentDownloadUrls = {
         attachField1:
           'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -582,14 +582,14 @@ describe('decrypt form response', () => {
     it('should grab the sdk corresponding to the form environment', async () => {
       $.flow.hasFileProcessingActions = false
       mocks.cryptoDecrypt.mockReturnValueOnce({ responses: [] })
-      mocks.parseFormEnv.mockReturnValue('staging')
+      mocks.parseFormEnv.mockReturnValue('stg')
 
       await expect(decryptFormResponse($)).resolves.toEqual(
         SUCCESS_DECRYPT_RESPONSE,
       )
 
       expect(mocks.parseFormEnv).toBeCalled()
-      expect(mocks.getSdk).toBeCalledWith('staging')
+      expect(mocks.getSdk).toBeCalledWith('stg')
     })
   })
 

--- a/packages/backend/src/apps/formsg/__tests__/auth/verify-credentials.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/verify-credentials.test.ts
@@ -80,10 +80,10 @@ describe('verify credentials', () => {
     it.each([
       'https://form.gov.sg/',
       'https://www.form.gov.sg/',
-      'https://staging.form.gov.sg/',
+      'https://stg.form.gov.sg/',
       'form.gov.sg/',
       'www.form.gov.sg/',
-      'staging.form.gov.sg/admin/',
+      'stg.form.gov.sg/admin/',
     ])('should accept a valid form url (%s)', (url) => {
       const formId = $.auth.data.formId
       $.auth.data.formId = url + formId

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -188,7 +188,7 @@ export const isNoOptionsSignalMessage = (text: string): boolean =>
   text.includes('\nA: [no options available')
 
 // Matches FormSG share links across environments (form.gov.sg,
-// staging.form.gov.sg, …) ending in a 24-hex-char form ID.
+// stg.form.gov.sg, …) ending in a 24-hex-char form ID.
 const FORM_URL_REGEX =
   /https:\/\/(?:[a-z0-9-]+\.)?form\.gov\.sg\/(?:[a-zA-Z0-9/]*\/)?[a-f0-9]{24}/gi
 

--- a/packages/frontend/src/pages/AiBuilder/helpers/extractLastFormUrl.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/extractLastFormUrl.test.ts
@@ -27,11 +27,11 @@ describe('extractLastFormUrl', () => {
   it('extracts a staging admin-form URL', () => {
     const messages = [
       makeMessage(
-        'see https://staging.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
+        'see https://stg.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
       ),
     ]
     expect(extractLastFormUrl(messages)).toBe(
-      'https://staging.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
+      'https://stg.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
     )
   })
 


### PR DESCRIPTION
# Problem
FormSG tests were still mocking `parseFormEnv` to `staging` instead of `stg`; this wasn't caught because we don't use vitest in a way that supports type checkign for mocked return values (e.g. via `mocked()`)

# Fix
Lets fix the tests now, then we migrate to using `mocked` later since we are upgrading vitest anwyay.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates FormSG tests and documentation to use the supported `stg` environment identifier instead of the obsolete `staging` label.

- Corrects backend mocks, assertions, attachment URLs, and accepted URL fixtures.
- Updates the AI Builder FormSG URL example and extraction test.
- Makes no functional production-code change.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because its test and documentation updates consistently match the existing FormSG environment contract.

No actionable failures were found; `stg` is the supported environment value used by parsing, API URL generation, SDK selection, and attachment validation.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/apps/formsg/__tests__/app.test.ts | Updates the mocked environment and API-base assertion to the valid `stg` identifier. |
| packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts | Aligns non-production attachment URL fixtures with the environment-specific `attachments.stg.form.gov.sg` prefix. |
| packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts | Updates SDK-selection expectations to use the supported `stg` environment. |
| packages/backend/src/apps/formsg/__tests__/auth/verify-credentials.test.ts | Replaces obsolete staging host examples with the supported `stg.form.gov.sg` hostname. |
| packages/frontend/src/pages/AiBuilder/helpers.ts | Updates a comment describing the FormSG staging hostname; runtime behavior is unchanged. |
| packages/frontend/src/pages/AiBuilder/helpers/extractLastFormUrl.test.ts | Updates the staging URL extraction fixture and expected value to use `stg.form.gov.sg`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: outdated tests"](https://github.com/opengovsg/plumber/commit/8456cb45d110838e60199af8d22655838119d18a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61136467)</sub>

<!-- /greptile_comment -->