### PR TITLE
chore: remove unused generateStepsPromptName from ai-builder LD flag

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -24,7 +24,6 @@ export const AI_BUILDER_FEATURE_FLAG_FALLBACK = {
   config: {
     chatPromptName: 'chat',
     chatSummaryPromptName: 'chat-summary',
-    generateStepsPromptName: 'generate-steps',
     version: 'production',
     mcpStepConfig: false,
   },

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -30,7 +30,6 @@ describe('createFlowWithSteps mutation integration tests', () => {
       'ai-builder': {
         enabled: true,
         config: {
-          generateStepsPromptName: 'generate-steps',
           version: 'production',
         },
       },

--- a/packages/backend/src/instrumentation.ts
+++ b/packages/backend/src/instrumentation.ts
@@ -3,7 +3,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 
 import appConfig from '@/config/app'
 
-const AI_BUILDER_RESOURCE_NAMES = ['ai-chat-stream', 'generate-steps']
+const AI_BUILDER_RESOURCE_NAMES = ['ai-chat-stream']
 
 const PAIR_ACTION_RESOURCE_NAMES = [
   'pair-action-generate-object',

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -250,7 +250,6 @@ describe('chat handler — data-columnTable emission', () => {
       config: {
         chatPromptName: 'chat',
         chatSummaryPromptName: 'chat-summary',
-        generateStepsPromptName: 'generate-steps',
         version: 'production',
         mcpStepConfig: true,
       },
@@ -331,7 +330,6 @@ describe('chat handler — data-pipeState connectionLabel resolution', () => {
       config: {
         chatPromptName: 'chat',
         chatSummaryPromptName: 'chat-summary',
-        generateStepsPromptName: 'generate-steps',
         version: 'production',
         mcpStepConfig: true,
       },

--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -22,7 +22,6 @@ describe('createFlowWithStepsService', () => {
       'ai-builder': {
         enabled: true,
         config: {
-          generateStepsPromptName: 'generate-steps',
           version: 'production',
         },
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

AI Builder no longer uses `generateStepsPromptName`. Chat loads Langfuse prompts via `chatPromptName` and `chatSummaryPromptName` only.

## What

- Drop `generateStepsPromptName` from `AI_BUILDER_FEATURE_FLAG_FALLBACK`.
- Remove it from test LD flag fixtures.
- Drop leftover `generate-steps` from the Langfuse AI Builder resource-name list.

The LD flag may still send the extra JSON field at runtime. TypeScript no longer types or reads it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17410e12-13f6-4e60-ad22-61228c003ed8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17410e12-13f6-4e60-ad22-61228c003ed8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consistently removes the unused `generateStepsPromptName` configuration and obsolete `generate-steps` instrumentation resource.
- Removes the field from the AI Builder fallback and its inferred TypeScript shape.
- Updates chat and flow-creation test fixtures to match the remaining configuration.
- Retains `ai-chat-stream` as the active AI Builder instrumentation resource.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because all removed configuration and instrumentation references are unused by current production paths.

No actionable failures remain: current AI Builder consumers use only the retained chat prompt fields, flow creation does not depend on the removed field, and no active operation emits the removed resource name.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/src/config/flags.ts | Removes an unused prompt-name field from the AI Builder fallback configuration and inferred flag type. |
| packages/backend/src/instrumentation.ts | Removes an obsolete resource name while preserving instrumentation for the active AI chat operation. |
| packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts | Updates the mocked AI Builder flag to omit a field unused by the exercised mutation. |
| packages/backend/src/routes/api/chat/index.test.ts | Aligns chat handler fixtures with the reduced AI Builder configuration shape. |
| packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts | Updates the service integration-test fixture without changing the exercised behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove unused generateStepsPrompt..."](https://github.com/opengovsg/plumber/commit/060c7946e1e24c8ef4448eb9fb3d61b6587b2c50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61146529)</sub>

<!-- /greptile_comment -->