### PR TITLE
PLU-922: [1PASS-ENV-1] Setup 1password loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ docs/superpowers/
 /.superset/port-registry
 /.superset/port-registry.lock
 /.superset/config.local.json
+
+# local 1Password environment ids (per-developer, never committed)
+/op-dev.json

--- a/op-dev.example.json
+++ b/op-dev.example.json
@@ -1,0 +1,8 @@
+{
+  "accountName": "your 1Password account name or UUID",
+  "environments": {
+    "dev": "your dev environment id",
+    "setup": "your setup environment id",
+    "archival": "your archival environment id"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
+        "@1password/sdk": "0.5.0",
         "@eddeee888/gcg-typescript-resolver-files": "0.7.2",
         "@graphql-codegen/cli": "^5.0.7",
         "@types/node": "^22.18.0",
@@ -38,6 +39,23 @@
           "packages/*"
         ]
       }
+    },
+    "node_modules/@1password/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-k6kov3pcA7PRg2tev9CgTfEf/3JSyAp11BPQNCEsqAD32QbqM032OXC1rfjyC8Ba0sfH+NHYZxcifUZToyGyYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@1password/sdk-core": "0.5.0"
+      }
+    },
+    "node_modules/@1password/sdk-core": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.5.0.tgz",
+      "integrity": "sha512-9g7LWOKRKdePZ85evVgE9xEom3DAg3hRIyQdOwLPvpL/F7KpDXmUHMi72rsqJxKaDbWApXmrYjDExMSPqUg7xw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@75lb/deep-merge": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "form-data": "4.0.6"
   },
   "devDependencies": {
+    "@1password/sdk": "0.5.0",
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",
     "@graphql-codegen/cli": "^5.0.7",
     "@types/node": "^22.18.0",

--- a/scripts/with-op-env.mjs
+++ b/scripts/with-op-env.mjs
@@ -1,0 +1,141 @@
+/**
+ * Runs a command with variables from a 1Password Environment injected.
+ *
+ * Keeps local dev secrets off disk. See README.md for the one-time setup.
+ */
+import { createClient, DesktopAuth } from '@1password/sdk'
+import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const CONFIG_FILE = 'op-dev.json'
+const EXAMPLE_FILE = 'op-dev.example.json'
+const USAGE =
+  'usage: node scripts/with-op-env.mjs [--env <name>] <command> [args...]'
+
+const configPath = path.join(import.meta.dirname, '..', CONFIG_FILE)
+
+function fail(message) {
+  console.error(`with-op-env: ${message}`)
+  process.exit(1)
+}
+
+function readConfig() {
+  let raw
+  try {
+    raw = readFileSync(configPath, 'utf8')
+  } catch {
+    fail(
+      `no ${CONFIG_FILE} at ${configPath}.\n` +
+        `Copy ${EXAMPLE_FILE} to ${CONFIG_FILE}, then fill in your own account name and environment ids.\n` +
+        'Each id comes from the 1Password app, under Developer > View Environments > View environment > Manage environment > Copy environment ID.',
+    )
+  }
+
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    fail(`${CONFIG_FILE} is not valid JSON. ${error.message}`)
+  }
+}
+
+function parseArgs(argv) {
+  let envName = 'dev'
+  let index = 0
+
+  while (index < argv.length) {
+    const arg = argv[index]
+    if (arg === '--env') {
+      envName = argv[index + 1]
+      index += 2
+      continue
+    }
+    if (arg.startsWith('--env=')) {
+      envName = arg.slice('--env='.length)
+      index += 1
+      continue
+    }
+    break
+  }
+
+  if (!envName) {
+    fail(`--env needs a name. ${USAGE}`)
+  }
+
+  return { envName, command: argv.slice(index) }
+}
+
+async function fetchVariables(envName) {
+  const config = readConfig()
+  const environmentId = config.environments?.[envName]
+
+  if (!config.accountName) {
+    fail(`${CONFIG_FILE} has no "accountName".`)
+  }
+  if (!environmentId) {
+    fail(`${CONFIG_FILE} has no environment id for "${envName}".`)
+  }
+
+  try {
+    const client = await createClient({
+      auth: new DesktopAuth(config.accountName),
+      integrationName: 'Plumber local dev',
+      integrationVersion: 'v1.0.0',
+    })
+    const { variables } = await client.environments.getVariables(environmentId)
+    return Object.fromEntries(variables.map(({ name, value }) => [name, value]))
+  } catch (error) {
+    fail(
+      `could not read the "${envName}" 1Password environment.\n` +
+        'Check that:\n' +
+        '  - the 1Password app is running and unlocked\n' +
+        '  - Settings > Developer > Integrate with other apps is on\n' +
+        `  - "accountName" in ${CONFIG_FILE} matches the account name in the app\n` +
+        `  - the "${envName}" environment id in ${CONFIG_FILE} is current\n` +
+        `${error.message}`,
+    )
+  }
+}
+
+function run(command, env) {
+  // npm already split argv through sh -c, so a shell would re-parse quoted --exec values.
+  const child = spawn(command[0], command.slice(1), {
+    stdio: 'inherit',
+    env,
+    shell: false,
+  })
+
+  // turbo signals the loader rather than the child, so Ctrl-C must be relayed to reach nodemon.
+  const relay = (signal) => child.kill(signal)
+  process.on('SIGINT', relay)
+  process.on('SIGTERM', relay)
+
+  child.on('error', (error) =>
+    fail(`cannot run ${command[0]}. ${error.message}`),
+  )
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.removeListener('SIGINT', relay)
+      process.removeListener('SIGTERM', relay)
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 1)
+  })
+}
+
+async function main() {
+  const { envName, command } = parseArgs(process.argv.slice(2))
+
+  if (command.length === 0) {
+    fail(USAGE)
+  }
+
+  const variables = await fetchVariables(envName)
+
+  // Shell exports win, because .superset/run.sh sets PORT, BASE_URL and WEB_APP_URL per worktree.
+  run(command, { ...variables, ...process.env })
+}
+
+main()


### PR DESCRIPTION
# Context

We want to move off storing .env files on disk because agents are starting to get more daring. This is not a perfect fix, but let's add as much friction as we can to prevent agents from reading secrets (regardless of whether they are low value or not, keys are still keys)

We'll move to 1password environments instead. We will strictly use desktop auth to enforce that a human is available.

# Approach

We will create a helper loader script to inject env vars into our processes via a child process.

The alternative is `op run` using the 1password CLI, but the problems are:

- Environments are beta on 1password's CLI
- It's harder to override (e.g. harnesses can no longer override env vars like `PORT`) because 1pass env takes precedence. This feels like a silent footgun
- There are reported perf problems ([example](https://www.1password.community/1password-at-home-31/slow-performance-on-new-macbook-24528))

How it works:

1. The loader script reads the 1password environment ID from `op-dev.json` 
2. It pulls in the env vars from 1password and spawns a sub-process with those vars.
3. Missing env vars are supplemented with default values from `.env-example` via `dotenv`.

Off-laptop agent development will use a dev environment that only relies on `.env-example`. This means they can't do integration tests with actual downstream services but that's intentional.

# This PR

Creates the loader script.

# Tests

See later PR

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a 1Password DesktopAuth-based development environment loader, a per-developer environment configuration template, associated ignore rules, and the 1Password SDK dependency. Greptile automatically discovered a related ticket that helped explain the purpose of this PR: moving development environment values from local `.env` files into 1Password.

- Reads account and environment identifiers from ignored `op-dev.json`.
- Retrieves environment variables through the 1Password desktop application.
- Spawns the requested command while allowing inherited shell variables to override retrieved values.
- Does not yet implement the described `.env-example` fallback for missing values.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the loader implements the promised `.env-example` defaults required when 1Password intentionally omits non-secret development configuration.

The loader directly spawns commands with only 1Password values and inherited shell variables, so the documented clean-machine workflow lacks the fallback configuration it relies on.

**Files Needing Attention:** scripts/with-op-env.mjs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/with-op-env.mjs | Adds argument parsing, DesktopAuth retrieval, environment merging, signal forwarding, and child-process execution, but omits the documented `.env-example` fallback. |
| op-dev.example.json | Provides a non-secret template for the local account and environment identifiers expected by the loader. |
| package.json | Adds the pinned 1Password SDK as a development dependency. |
| package-lock.json | Locks the 1Password SDK and SDK core packages at version 0.5.0. |
| .gitignore | Prevents the per-developer `op-dev.json` configuration from being committed. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[op-dev.json] --> L[with-op-env.mjs]
  D[1Password desktop app] --> S[1Password SDK]
  L --> S
  S --> V[Environment variables]
  P[Inherited process.env] --> M[Merge environment]
  V --> M
  M --> X[Spawn requested command]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fplumber%20PR%20%232133%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fplumber&pr=2133&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fwith-op-env.mjs%3A138%0A**Missing%20environment%20defaults**%0A%0AWhen%20a%201Password%20environment%20omits%20a%20value%20that%20should%20use%20its%20%60.env-example%60%20default%2C%20this%20loader%20only%20merges%20the%20fetched%20variables%20with%20%60process.env%60%3B%20it%20never%20loads%20%60.env-example%60.%20On%20a%20machine%20without%20an%20existing%20%60.env%60%20or%20matching%20shell%20exports%2C%20the%20spawned%20process%20receives%20incomplete%20configuration%20and%20may%20fail%20validation%20or%20startup.%20Please%20load%20the%20documented%20defaults%20before%20invoking%20the%20child%20process.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2133&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fwith-op-env.mjs%3A138%0A**Missing%20environment%20defaults**%0A%0AWhen%20a%201Password%20environment%20omits%20a%20value%20that%20should%20use%20its%20%60.env-example%60%20default%2C%20this%20loader%20only%20merges%20the%20fetched%20variables%20with%20%60process.env%60%3B%20it%20never%20loads%20%60.env-example%60.%20On%20a%20machine%20without%20an%20existing%20%60.env%60%20or%20matching%20shell%20exports%2C%20the%20spawned%20process%20receives%20incomplete%20configuration%20and%20may%20fail%20validation%20or%20startup.%20Please%20load%20the%20documented%20defaults%20before%20invoking%20the%20child%20process.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2133&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fplumber%22%20on%20the%20existing%20branch%20%22chore%2Fop-env-loader%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fop-env-loader%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fwith-op-env.mjs%3A138%0A**Missing%20environment%20defaults**%0A%0AWhen%20a%201Password%20environment%20omits%20a%20value%20that%20should%20use%20its%20%60.env-example%60%20default%2C%20this%20loader%20only%20merges%20the%20fetched%20variables%20with%20%60process.env%60%3B%20it%20never%20loads%20%60.env-example%60.%20On%20a%20machine%20without%20an%20existing%20%60.env%60%20or%20matching%20shell%20exports%2C%20the%20spawned%20process%20receives%20incomplete%20configuration%20and%20may%20fail%20validation%20or%20startup.%20Please%20load%20the%20documented%20defaults%20before%20invoking%20the%20child%20process.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/with-op-env.mjs:138
**Missing environment defaults**

When a 1Password environment omits a value that should use its `.env-example` default, this loader only merges the fetched variables with `process.env`; it never loads `.env-example`. On a machine without an existing `.env` or matching shell exports, the spawned process receives incomplete configuration and may fail validation or startup. Please load the documented defaults before invoking the child process.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dev): add 1Password environment lo..."](https://github.com/opengovsg/plumber/commit/dfb99b3e08bdb1c1cdbddf3f4af9dd5bcf4d1707) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61188668)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Linear — [Move .env to 1Password](https://linear.app/ogp/issue/PLU-922/move-env-to-1password)

<!-- /greptile_comment -->