### PR TITLE
PLU-922: [1PASS-ENV-2] Remove .env and make backend load .env-example as fallback

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,7 +1,7 @@
 {
   "setup-worktree-unix": [
     "npm install",
-    "cp \"$ROOT_WORKTREE_PATH/packages/backend/.env\" packages/backend/.env",
+    "cp \"$ROOT_WORKTREE_PATH/op-dev.json\" op-dev.json",
     "codegraph init"
   ]
 }

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -2,7 +2,7 @@
   "_note": "Frontend/backend ports for Superset worktrees are allocated from PLUMBER_SUPERSET_PORT_BASE (default 13000) by .superset/base_port.sh. To use a different base on your machine (e.g. another Superset project already uses the 13000 range), create a git-ignored .superset/config.local.json containing: { \"run\": { \"before\": [\"export PLUMBER_SUPERSET_PORT_BASE=20000\"] } }",
   "setup": [
     "npm install",
-    "cp \"$SUPERSET_ROOT_PATH/packages/backend/.env\" packages/backend/.env",
+    "cp \"$SUPERSET_ROOT_PATH/op-dev.json\" op-dev.json",
     "codegraph init -i"
   ],
   "teardown": ["bash .superset/base_port.sh --release"],

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,2 @@
 # .worktreeinclude
-.env
+op-dev.json

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Plumber is a no-code solution that helps public officers automate their repetiti
 2. Install code dependencies by running `npm i`
 3. Install global dependencies:
    1. [Codegraph](https://github.com/colbymchenry/codegraph)
-4. Create a `.env` in `packages/backend` based on `.env-example`
-5. Setup services `npm run setup`
-6. Run DB migrations `npm run migrate` (only for first time setup)
-7. Start the server `npm run dev`
+4. Install the [1Password desktop app](https://1password.com/downloads) and sign in
+5. In 1Password, turn on Settings > Developer > Integrate with other apps. Turn on Touch ID (or Windows Hello) under Settings > Security so you can answer the prompt
+6. Copy `op-dev.example.json` to `op-dev.json`, then fill in your account name and your three environment ids. Copy an id from Developer > View Environments > View environment > Manage environment > Copy environment ID
+7. Setup services `npm run setup`
+8. Run DB migrations `npm run migrate` (only for first time setup)
+9. Start the server `npm run dev`
+
+`npm run setup` and `npm run dev` each fetch their secrets from 1Password, so both prompt once and both need the app running. There is no `.env` file.
 
 ### On Windows?
 

--- a/docs/WINDOWS_DEV.md
+++ b/docs/WINDOWS_DEV.md
@@ -19,11 +19,15 @@ npm install
 
 ### 2. Configure environment
 
+Local dev secrets come from 1Password, not from a `.env` file. Install the [1Password desktop app](https://1password.com/downloads) and sign in. Turn on Settings > Developer > Integrate with other apps, and turn on Windows Hello under Settings > Security so you can answer the prompt.
+
 ```powershell
-copy packages\backend\.env-example packages\backend\.env
+copy op-dev.example.json op-dev.json
 ```
 
-Then open `packages/backend/.env` and change these values:
+Then open `op-dev.json` and fill in your account name and your three environment ids. Copy an id from Developer > View Environments > View environment > Manage environment > Copy environment ID.
+
+Set these in your `dev` environment:
 
 ```
 # Required — "..." is not a valid URL and crashes the server at startup
@@ -45,11 +49,15 @@ docker compose -f packages/backend/docker-compose.dev.yml up -d
 
 ### 4. Run DB migrations (first time only)
 
-`npm run migrate` does not work on Windows because it uses Unix-style env var syntax. Run directly:
+```powershell
+npm run migrate
+```
+
+The Unix-style env var prefix that used to break this on Windows is gone. If it still fails, run knex directly:
 
 ```powershell
 cd packages/backend
-$env:DOTENV_CONFIG_PATH=".env"; npx knex migrate:latest
+npx knex migrate:latest
 cd ../..
 ```
 
@@ -59,6 +67,8 @@ cd ../..
 npm run dev
 ```
 
+> **Known gap on Windows:** `npm run dev` goes through `scripts/with-op-env.mjs`, which spawns without a shell. Windows cannot resolve the `.cmd` shims in `node_modules\.bin` that way, so the command fails to start. Nobody has fixed this yet.
+
 - Frontend: http://localhost:3001
 - Backend: http://localhost:3000
 
@@ -67,7 +77,7 @@ npm run dev
 The app uses OTP email login, but in local dev the OTP is printed to the terminal instead of being sent:
 
 1. Go to http://localhost:3001
-2. Enter `admin@example.gov.sg` (from `ADMIN_USER_EMAIL` in your `.env`)
+2. Enter `admin@example.gov.sg` (from `ADMIN_USER_EMAIL` in your `dev` environment)
 3. Watch the `[backend]` terminal output — the OTP appears there in highlighted text
 4. Enter the OTP in the browser
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "packageManager": "npm@11.19.0",
   "scripts": {
     "postinstall": "npm run gqlc",
-    "setup": "npm run -w backend setup",
-    "dev": "turbo watch dev worker --continue",
+    "setup": "node scripts/with-op-env.mjs --env setup npm run -w backend setup",
+    "dev": "node scripts/with-op-env.mjs turbo watch dev worker --continue",
     "gqlc": "graphql-codegen --config gql-codegen.ts",
     "build": "turbo run build",
     "start": "npm run -w backend start",

--- a/packages/backend/.env-example
+++ b/packages/backend/.env-example
@@ -1,3 +1,6 @@
+# Placeholder values, loaded at runtime as a fallback for keys the environment
+# does not set. Real local dev values come from 1Password. See README.md.
+
 PORT=3000
 WEB_APP_URL=http://localhost:3001
 BASE_URL=http://localhost:3000

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
     restart: unless-stopped
     command: tunnel run --protocol http2
     environment:
-      - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN}
+      - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN:-}
   minio:
     image: 'minio/minio:RELEASE.2025-09-07T16-13-09Z'
     user: '0:0'

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
     restart: unless-stopped
     command: tunnel run --protocol http2
     environment:
-      - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN:-}
+      - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN}
   minio:
     image: 'minio/minio:RELEASE.2025-09-07T16-13-09Z'
     user: '0:0'

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "typecheck": "tsc --noEmit",
-    "db": "DOTENV_CONFIG_PATH=.env knex",
+    "db": "knex",
     "readme:db:migration:create": "HOW TO USE: npm run -w backend db:migration:create your_migration_name",
     "db:migration:create": "npm run db -- migrate:make",
     "db:list": "npm run db -- migrate:list",

--- a/packages/backend/src/config/__tests__/app.critical.test.ts
+++ b/packages/backend/src/config/__tests__/app.critical.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Business-critical: local dev environment variable precedence.
+ *
+ *   1. (top priority) shell env vars, so that we support harnesses like
+ *      superset / cursor
+ *   2. 1password environment
+ *   3. vars from .env-example
+ *
+ * Layers 1 and 2 both arrive as process.env, so this file pins the boundary
+ * app.ts owns: .env-example never outranks a key that already has a value.
+ *
+ * IMPORTANT: never mock dotenv here. The real dotenv call is the subject.
+ */
+import { parse } from 'dotenv'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// BASE_URL is one of the keys .superset/run.sh exports per worktree, and app.ts
+// reads it without a hardcoded default.
+const KEY = 'BASE_URL'
+
+const placeholders = parse(
+  readFileSync(path.resolve(__dirname, '../../../.env-example')),
+)
+
+async function loadBaseUrl(value: string | undefined) {
+  vi.stubEnv(KEY, value)
+  vi.resetModules()
+  const { default: appConfig } = await import('@/config/app')
+  return appConfig.baseUrl
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('.env-example placeholders', () => {
+  it('never overwrite a value the environment already set', async () => {
+    const fromHarness = 'https://harness.example.gov.sg'
+    expect(placeholders[KEY]).not.toBe(fromHarness)
+
+    await expect(loadBaseUrl(fromHarness)).resolves.toBe(fromHarness)
+  })
+
+  it('fill a key that neither the shell nor 1Password set', async () => {
+    expect(placeholders[KEY]).toBeTruthy()
+
+    await expect(loadBaseUrl(undefined)).resolves.toBe(placeholders[KEY])
+  })
+})

--- a/packages/backend/src/config/__tests__/app.test.ts
+++ b/packages/backend/src/config/__tests__/app.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Each test re-imports app.ts, which would otherwise re-run dotenv and restore
-// the real .env values on top of the stubbed ones.
-vi.mock('dotenv/config', () => ({}))
+// the .env-example placeholders on top of the stubbed values.
+vi.mock('dotenv', () => ({ config: () => ({}) }))
 
 const SES_ENV_KEYS = [
   'SES_FROM_ADDRESS',

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -1,9 +1,18 @@
-import 'dotenv/config'
 import '@/types/luxon-extensions'
 
 import type { AwsCredentialIdentity } from '@aws-sdk/types'
+import { config } from 'dotenv'
 import { Settings as LuxonSettings } from 'luxon'
+import path from 'node:path'
 import { URL } from 'node:url'
+
+// Placeholders backstop missing keys. Local dev gets its real values from 1Password,
+// which dotenv never overrides.
+// IMPORTANT: without the guard, placeholders would satisfy a deployed environment's
+// missing-env-var checks.
+if ((process.env.APP_ENV ?? 'development') === 'development') {
+  config({ path: path.resolve(__dirname, '../../.env-example') })
+}
 
 type AppConfig = {
   port: string


### PR DESCRIPTION
# Context

See https://github.com/opengovsg/plumber/pull/2133

# This PR

1. Makes our backend load from `.env-example` as a fallback.
2. Stops harnesses from copying `.env`

# Tests

See next PR