### PR TITLE
PLU-922: [1PASS-ENV-5] Update langfuse prompt tool to use 1Password

### DIFF
--- a/tools/langfuse/get-prompt.mjs
+++ b/tools/langfuse/get-prompt.mjs
@@ -1,19 +1,17 @@
 /**
  * Fetches a prompt from Langfuse and saves it to docs/plans/prompts/<name>_v<version>.md
  *
- * Usage:
- *   node get-prompt.mjs <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>] [--env=<path-to-env-file>]
+ * Credentials come from the dev 1Password environment, so run it through npm:
+ *   npm run get-prompt -- <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>]
  *
- * --label and --version are mutually exclusive; defaults to --label=latest if neither is given.
+ * --label and --version are mutually exclusive. Defaults to --label=latest if neither is given.
  *
  * Examples:
- *   node get-prompt.mjs chat
- *   node get-prompt.mjs chat-summary --project=aiBuilder --label=latest
- *   node get-prompt.mjs chat --version=154
- *   node get-prompt.mjs chat --project=aiBuilder --label=latest --env=../../packages/backend/.env
+ *   npm run get-prompt -- chat
+ *   npm run get-prompt -- chat-summary --project=aiBuilder --label=latest
+ *   npm run get-prompt -- chat --version=154
  */
 import { LangfuseClient } from '@langfuse/client'
-import { config } from 'dotenv'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -24,7 +22,7 @@ function parseArgs(argv) {
   const [promptName, ...rest] = argv
   if (!promptName) {
     throw new Error(
-      'Usage: node get-prompt.mjs <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>] [--env=<path>]',
+      'Usage: npm run get-prompt -- <promptName> [--project=aiBuilder|pairAction] [--label=<label>] [--version=<number>]',
     )
   }
 
@@ -45,7 +43,6 @@ function parseArgs(argv) {
     project: flags.project ?? 'aiBuilder',
     label: flags.label,
     version: flags.version ? Number(flags.version) : undefined,
-    envPath: flags.env ?? join(__dirname, '../../packages/backend/.env'),
     outDir: join(__dirname, '../../docs/plans/prompts'),
   }
 }
@@ -64,7 +61,7 @@ function buildLangfuseClient(project, env) {
 
   if (!credentials.publicKey || !credentials.secretKey) {
     throw new Error(
-      `Missing Langfuse credentials for project "${project}" — check your env file`,
+      `Missing Langfuse credentials for project "${project}". Run this through "npm run get-prompt" so 1Password injects them.`,
     )
   }
 
@@ -80,19 +77,14 @@ function buildLangfuseClient(project, env) {
 }
 
 async function main() {
-  const { promptName, project, label, version, envPath, outDir } = parseArgs(
+  const { promptName, project, label, version, outDir } = parseArgs(
     process.argv.slice(2),
   )
-
-  const { parsed: env } = config({ path: envPath })
-  if (!env) {
-    throw new Error(`Could not load env file at ${envPath}`)
-  }
 
   const query = version ? { version } : { label: label ?? 'latest' }
   console.log('fetching prompt: ', promptName, query, project)
 
-  const client = buildLangfuseClient(project, env)
+  const client = buildLangfuseClient(project, process.env)
   const prompt = await client.prompt.get(promptName, query)
 
   console.log('fetched prompt version: ', prompt.version)

--- a/tools/langfuse/package-lock.json
+++ b/tools/langfuse/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@langfuse/client": "4.2.0",
-        "dotenv": "^16.0.3"
+        "@langfuse/client": "4.2.0"
       }
     },
     "node_modules/@langfuse/client": {
@@ -59,18 +58,6 @@
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/mustache": {

--- a/tools/langfuse/package.json
+++ b/tools/langfuse/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "type": "module",
+  "scripts": {
+    "get-prompt": "node ../../scripts/with-op-env.mjs node get-prompt.mjs"
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@langfuse/client": "4.2.0",
-    "dotenv": "^16.0.3"
+    "@langfuse/client": "4.2.0"
   }
 }


### PR DESCRIPTION
# Context

See https://github.com/opengovsg/plumber/pull/2133

# This PR

Updatess our langfuse prompt tool to use 1password env as well.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes the Langfuse prompt-fetching utility through the repository’s 1Password environment loader instead of reading credentials from a local dotenv file.
- Adds an npm script that launches `get-prompt.mjs` through `scripts/with-op-env.mjs`.
- Reads injected credentials from `process.env` and updates the command documentation.
- Removes the unused `dotenv` dependency and corresponding lockfile entry.
- Greptile automatically discovered a related ticket that helped explain the purpose of this PR: migrate development secrets away from plaintext local environment files and inject them through 1Password.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

The loader paths resolve from the package directory, command arguments are forwarded intact, expected credential names match existing configuration, and the dependency metadata remains consistent.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/langfuse/get-prompt.mjs | Replaces dotenv-file loading with credentials supplied through `process.env` and updates usage guidance consistently. |
| tools/langfuse/package.json | Adds the loader-backed `get-prompt` command and removes the obsolete dotenv dependency. |
| tools/langfuse/package-lock.json | Keeps the lockfile synchronized with the dependency removal. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dev): run the langfuse prompt tool..."](https://github.com/opengovsg/plumber/commit/34c3f0cca64e5bf8b98f6080cdc2a9deb6d9d7f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61234446)</sub>

**Context used:**

- Linear — [Modify .env files so we use 1PW CLI to inject secrets](https://linear.app/ogp/issue/PARK-217/modify-env-files-so-we-use-1pw-cli-to-inject-secrets)

<!-- /greptile_comment -->