### PR TITLE
fix: stop backend unit tests aborting with Channel closed

### DIFF
--- a/packages/backend/test/keep-worker-alive-setup.ts
+++ b/packages/backend/test/keep-worker-alive-setup.ts
@@ -1,0 +1,20 @@
+/**
+ * Stops application code from killing the vitest pool worker.
+ *
+ * Our queues and database client call process.exit() when Redis or Postgres
+ * refuses a connection. Unit tests run without either, so that call kills the
+ * worker and vitest aborts the whole run with ERR_IPC_CHANNEL_CLOSED
+ * ("Channel closed") instead of reporting results.
+ */
+let alreadyWarned = false
+
+process.exit = ((code?: number | string | null): never => {
+  if (!alreadyWarned) {
+    alreadyWarned = true
+    console.warn(
+      `Ignored process.exit(${code ?? ''}): tests must not kill the vitest worker.`,
+    )
+  }
+
+  return undefined as never
+}) as typeof process.exit

--- a/packages/backend/test/keep-worker-alive-setup.ts
+++ b/packages/backend/test/keep-worker-alive-setup.ts
@@ -11,9 +11,7 @@ let alreadyWarned = false
 process.exit = ((code?: number | string | null): never => {
   if (!alreadyWarned) {
     alreadyWarned = true
-    console.warn(
-      `Ignored process.exit(${code ?? ''}): tests must not kill the vitest worker.`,
-    )
+    console.warn(`Ignored process.exit(${code ?? ''}) during tests.`)
   }
 
   return undefined as never

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
   test: {
     name: 'backend',
     // load env variables
-    setupFiles: ['dotenv/config'],
+    setupFiles: [
+      'dotenv/config',
+      path.resolve(__dirname, './test/keep-worker-alive-setup.ts'),
+    ],
     include: ['src/**/*.test.{js,ts}'],
     onConsoleLog: (log: string, _type: 'stdout' | 'stderr'): false | void => {
       if (log.startsWith('vite:')) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What?

Unit tests no longer die with `ERR_IPC_CHANNEL_CLOSED` (`Channel closed`) when Redis is down.

A new vitest setup file, `packages/backend/test/keep-worker-alive-setup.ts`, replaces `process.exit` with a no-op. `packages/backend/vitest.config.ts` loads it before each test file.

No application code changed. Integration tests are unchanged.

## Why?

Queue and database modules call `process.exit()` when Redis or Postgres refuses a connection. That is correct for a running server.

The `Test (backend unit)` job does not start Redis. Some unit tests import modules that build a real BullMQ queue at load time. The refused-connection handler then kills the vitest pool worker. The parent process cannot send the next file, so the job fails with `Channel closed` and no test summary.

This is a race. The same commit can pass or fail depending on worker timing.

## How to test

Run backend unit tests with no Redis:

```
npm run -w backend test:unit
```

The suite should finish and print a `Test Files` summary. It must not abort with `Channel closed`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c60b583d-86de-4ec5-866e-a30d64c0f6f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c60b583d-86de-4ec5-866e-a30d64c0f6f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents backend unit-test workers from terminating when application modules call `process.exit()` after unavailable Redis or PostgreSQL connections.
- Adds a unit-test setup file that replaces `process.exit` with a warning no-op.
- Loads the setup for backend `*.test.js` and `*.test.ts` files.
- Leaves the separately configured integration-test suite unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the process override scoped to backend unit tests and no concrete regressions identified.

The new setup prevents fatal application handlers from terminating Vitest workers, while integration tests remain on a separate configuration and existing unit tests do not rely on real process termination.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/test/keep-worker-alive-setup.ts | Adds a test-only `process.exit` override to keep Vitest pool workers alive after dependency connection failures. |
| packages/backend/vitest.config.ts | Registers the worker-preservation setup for the backend unit-test project without affecting the integration configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style(backend): satisfy prettier in vite..."](https://github.com/opengovsg/plumber/commit/f911fd9f43ea756ca931e4a9dc1f0331c29df5c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61184281)</sub>

<!-- /greptile_comment -->