### PR TITLE
PLU-922: [1PASS-ENV-3] Make archival load .env-example as fallback

### DIFF
--- a/packages/backend-archive/.env-example
+++ b/packages/backend-archive/.env-example
@@ -1,3 +1,6 @@
+# Placeholder values, loaded at runtime as a fallback for keys the environment
+# does not set. Real local dev values come from 1Password. See README.md.
+
 APP_ENV=development
 POSTGRES_DATABASE=plumber_dev
 POSTGRES_PORT=5432

--- a/packages/backend-archive/README.md
+++ b/packages/backend-archive/README.md
@@ -34,46 +34,34 @@ npm run setup
 
 This also creates the `plumber-development-archive-bucket` MinIO bucket used below.
 
-### 2. Create `.env.archival`
+The `-local` archive commands run through `scripts/with-op-env.mjs`, so you also need the 1Password desktop app unlocked and an `op-dev.json` holding an `archival` environment id. The [root README](../../README.md) covers that one-time setup.
 
-Create a `.env.archival` file at the repo root (do **not** commit it):
+### 2. Supply the environment
 
-```bash
-# Postgres — matches dev Docker defaults
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
-POSTGRES_DATABASE=plumber_dev
-POSTGRES_USERNAME=postgres
-POSTGRES_PASSWORD=postgres
+There is no `.env` file. Variables come from three places, in descending priority:
 
-# Reader endpoint — required. Use localhost for local dev (same Postgres).
-ARCHIVE_POSTGRES_READER_HOST=localhost
+1. Shell exports, for one-off overrides.
+2. The `archival` 1Password environment, which the loader fetches at spawn time and injects into the process. The `-local` scripts only.
+3. [`.env-example`](.env-example), which `config.ts` loads at runtime for any key still unset. It loads only while `APP_ENV=development`.
 
-# MinIO (local S3)
-S3_ENDPOINT=http://localhost:9000
-S3_ACCESS_KEY=minio-username
-S3_SECRET_KEY=minio-password
-ARCHIVE_BUCKET=plumber-development-archive-bucket
+Those placeholders already point at the dev Docker stack, so a local run needs three overrides:
 
-# Job settings
-ARCHIVE_ENABLED=true
-ARCHIVE_DRY_RUN=true            # flip to false for a live (destructive) run
-ARCHIVE_RETENTION_DAYS=90
-ARCHIVE_BATCH_SIZE=500
-ARCHIVE_BATCH_SLEEP_MS=0        # 0 = no sleep between batches (fine for local)
-ARCHIVE_INTRA_BATCH_CONCURRENCY=10
-ARCHIVE_MAX_RUNTIME_MS=0        # 0 = no wall-clock limit
-ARCHIVE_DELETED_FLOWS_ONLY=true # restrict to soft-deleted flows only
-ARCHIVE_TEST_RUNS=false         # also archive test executions on active flows
-```
+| Variable | Local value | Why |
+|---|---|---|
+| `S3_ACCESS_KEY` | `minio-username` | `.env-example` ships `...`, which MinIO rejects with `InvalidAccessKeyId`. |
+| `S3_SECRET_KEY` | `minio-password` | Same. |
+| `ARCHIVE_ENABLED` | `true` | Defaults to `false`, which exits at once and logs `archival.run.disabled`. |
+
+Keep them in the `archival` 1Password environment, or pass them inline as below.
 
 ### 3. Run the archival script
 
 ```bash
-# Load env vars, then run
-set -a && source .env.archival && set +a
-npm run -w backend-archive archive:backfill
+S3_ACCESS_KEY=minio-username S3_SECRET_KEY=minio-password ARCHIVE_ENABLED=true \
+  npm run -w backend-archive archive:backfill-local
 ```
+
+1Password asks for biometric approval before the script starts. `ARCHIVE_DRY_RUN` defaults to `true`, so the run writes to S3 and deletes nothing. Set `ARCHIVE_DRY_RUN=false` for a live, destructive run.
 
 The script logs structured JSON to stdout. Key events to look for:
 
@@ -100,40 +88,66 @@ mc cat "local/plumber-development-archive-bucket/executions/flow_id=<uuid>/year=
 
 ---
 
-## Running rehydration against a real environment
+## Running against a production target
 
-Rehydration connects to a **live** Postgres and S3 bucket. Run it from a machine with network access to both (e.g. a bastion, a local machine with an AWS SSO session + an SSH tunnel to RDS, or an ad-hoc ECS task).
+Both the archival and the rehydration script can point at a **live** Postgres and S3 bucket. Run them from a machine with network access to both.
 
-### 1. Set environment variables
+**Set `APP_ENV` to any value other than `development`.** That stops `.env-example` from loading and drops `config.ts`'s dev defaults, so a variable you forget throws instead of quietly reaching a local `plumber_dev`.
 
-`DOTENV_CONFIG_PATH` tells the script which `.env` file to load. Create one for the target environment (do **not** commit it):
+**Set `ARCHIVE_DRY_RUN` explicitly for a backfill.** With those placeholders gone it falls back to `false`, and the run deletes rows from the target.
+
+### From your own machine
+
+Repoint `op-dev.json`'s `archival` entry at a 1Password environment holding the target's variables, `APP_ENV` included. Then use the `-local` scripts:
 
 ```bash
-# Example: .env.staging
-POSTGRES_HOST=<rds-writer-endpoint>
-POSTGRES_PORT=5432
-POSTGRES_DATABASE=<db-name>
-POSTGRES_USERNAME=<db-user>
-POSTGRES_PASSWORD=<db-password>
-POSTGRES_ENABLE_SSL=true
+npm run -w backend-archive archive:rehydrate-local -- --flow-id <uuid>
+npm run -w backend-archive archive:backfill-local
+```
 
-ARCHIVE_POSTGRES_READER_HOST=<rds-reader-endpoint>
+The loader injects that environment into the process and writes nothing to disk. Shell exports still outrank it, so you can override a single key inline.
+
+### From a bastion host or an ECS task
+
+1Password does not run there. Export the variables yourself and use the unsuffixed scripts, which take the shell as-is:
+
+```bash
+export APP_ENV=production
+export POSTGRES_HOST=<rds-writer-endpoint>
+export POSTGRES_PORT=5432
+export POSTGRES_DATABASE=<db-name>
+export POSTGRES_USERNAME=<db-user>
+export POSTGRES_PASSWORD=<db-password>
+export POSTGRES_ENABLE_SSL=true
+
+export ARCHIVE_POSTGRES_READER_HOST=<rds-reader-endpoint>
 
 # S3 — IAM role credentials are used automatically in AWS environments.
-# Only set these if running from a non-AWS machine without instance credentials.
-# S3_ACCESS_KEY=...
-# S3_SECRET_KEY=...
+# Only set these if running from a machine without instance credentials.
+# export S3_ACCESS_KEY=...
+# export S3_SECRET_KEY=...
 
-ARCHIVE_BUCKET=<prod-or-staging-bucket-name>
+export ARCHIVE_BUCKET=<prod-or-staging-bucket-name>
+
+# Backfill only. It exits at once without ARCHIVE_ENABLED.
+export ARCHIVE_ENABLED=true
+export ARCHIVE_DRY_RUN=true
 ```
 
-### 2. Run the rehydration CLI
+Then run:
 
 ```bash
-DOTENV_CONFIG_PATH=.env.staging npm run -w backend-archive archive:rehydrate -- --flow-id <uuid>
+npm run -w backend-archive archive:rehydrate -- --flow-id <uuid>
+npm run -w backend-archive archive:backfill
 ```
 
-#### Subcommands
+Both call `ts-node`, a devDependency, so the host needs a full checkout and an install that kept devDependencies. The `Dockerfile.archival` image has neither. Inside that image, call the compiled entrypoint from `/opt/plumber`:
+
+```bash
+node packages/backend-archive/dist/scripts/rehydrate-execution.js --flow-id <uuid>
+```
+
+### Rehydration subcommands
 
 | Goal | Command |
 |---|---|
@@ -142,7 +156,7 @@ DOTENV_CONFIG_PATH=.env.staging npm run -w backend-archive archive:rehydrate -- 
 | Restore all executions for a flow to Postgres | `-- --flow-id <uuid> --restore` |
 | Restore a single execution to Postgres | `-- --flow-id <uuid> --execution-id <uuid> --restore` |
 
-#### What `--restore` does
+### What `--restore` does
 
 1. Sets `archiveDisabled: true` in the flow's `config` JSONB — prevents the nightly archival job from immediately re-archiving the restored rows.
 2. Inserts the execution row (`ON CONFLICT DO NOTHING` — idempotent).
@@ -234,6 +248,7 @@ aws s3 ls s3://<bucket>/_meta/runs/ \
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
+| `APP_ENV` | no | `development` | Any value other than `development` skips the `.env-example` fallback and the dev defaults below. |
 | `POSTGRES_HOST` / `RDS_PROXY_HOST` | yes (dev/prod) | — | Postgres writer host. `RDS_PROXY_HOST` takes precedence. |
 | `POSTGRES_PORT` | no | `5432` | Postgres port. |
 | `POSTGRES_DATABASE` | yes | `plumber_dev` (dev only) | Database name. |
@@ -269,4 +284,4 @@ npm run -w backend-archive test:unit
 
 The archival task runs as a scheduled ECS Fargate task built from `Dockerfile.archival`. The task definition template is at [`ecs/archival-task-definition.json`](../../ecs/archival-task-definition.json). All secrets are sourced from AWS Secrets Manager — no plaintext values in the task definition.
 
-In production, S3 credentials are provided by the task's IAM role; no `S3_ACCESS_KEY` / `S3_SECRET_KEY` are needed.
+The task's IAM role provides S3 credentials, so `S3_ACCESS_KEY` and `S3_SECRET_KEY` are not needed. The scheduled task calls the compiled entrypoint directly and never touches the npm scripts above.

--- a/packages/backend-archive/package.json
+++ b/packages/backend-archive/package.json
@@ -10,7 +10,9 @@
     "lint:fix": "eslint . --fix --ignore-path ../../.eslintignore",
     "typecheck": "tsc --noEmit",
     "archive:backfill": "ts-node --swc src/scripts/archive-executions.ts",
-    "archive:rehydrate": "DOTENV_CONFIG_PATH=\"${DOTENV_CONFIG_PATH:-.env}\" ts-node --swc src/scripts/rehydrate-execution.ts"
+    "archive:backfill-local": "node ../../scripts/with-op-env.mjs --env archival ts-node --swc src/scripts/archive-executions.ts",
+    "archive:rehydrate": "ts-node --swc src/scripts/rehydrate-execution.ts",
+    "archive:rehydrate-local": "node ../../scripts/with-op-env.mjs --env archival ts-node --swc src/scripts/rehydrate-execution.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1027.0",

--- a/packages/backend-archive/src/helpers/archival/__tests__/config.test.ts
+++ b/packages/backend-archive/src/helpers/archival/__tests__/config.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Prevent dotenv from loading the local .env file during tests — config.ts
-// re-executes `import 'dotenv/config'` on every vi.resetModules() + import(),
-// which would restore deleted env vars from .env and break the "throws when X
-// is absent" assertions.
-vi.mock('dotenv/config', () => ({}))
+// config.ts re-runs dotenv on every vi.resetModules() + import(), which would
+// restore deleted env vars from .env-example and break the "throws when X is
+// absent" assertions.
+vi.mock('dotenv', () => ({ config: () => ({}) }))
 
 describe('archival/config', () => {
   const REQUIRED_ENV: Record<string, string> = {

--- a/packages/backend-archive/src/helpers/archival/config.ts
+++ b/packages/backend-archive/src/helpers/archival/config.ts
@@ -1,4 +1,13 @@
-import 'dotenv/config'
+import { config } from 'dotenv'
+import path from 'node:path'
+
+// Placeholders backstop missing keys. Local dev gets its real values from 1Password,
+// which dotenv never overrides.
+// IMPORTANT: without the guard, placeholders would satisfy a deployed environment's
+// missing-env-var checks.
+if ((process.env.APP_ENV ?? 'development') === 'development') {
+  config({ path: path.resolve(__dirname, '../../../.env-example') })
+}
 
 const isDev = (process.env.APP_ENV ?? 'development') === 'development'
 


### PR DESCRIPTION
# Context

See https://github.com/opengovsg/plumber/pull/2133

# This PR

Makes archival code:

1. Support 1Password environments, and also load from `.env-example` as a fallback.
2. Add new `-local` commands to run archival NPM scripts with env vars from 1Password

# Tests

See next PR

<!-- greptile_comment -->

<details>
<summary></summary>

This PR moves archival backfill and rehydration commands onto the shared 1Password environment loader, adds a development-only `.env-example` fallback, and updates the archival documentation for the new precedence model. Greptile automatically discovered a related ticket that helped explain the purpose of this PR: replacing local `.env` usage with 1Password-provided configuration.

- Shell values retain precedence over 1Password values, while `.env-example` fills only unset development values.
- Production archival configuration remains protected by its explicitly supplied non-development `APP_ENV`.
- The new package-script wrapping introduces a Windows startup regression.
- The fallback’s path, guard, and precedence currently lack direct test coverage.

</details>

<details>
<summary></summary>
The PR is not yet safe to merge because both archival commands become unusable on Windows; the missing fallback test is an additional non-blocking maintainability concern.

The loader’s precedence and fallback behavior are sound in the examined Linux and deployment paths, but routing bare `ts-node` commands through a shell-less spawn creates one concrete platform workflow failure.

**Files Needing Attention:** packages/backend-archive/package.json; packages/backend-archive/src/helpers/archival/**tests**/config.test.ts

</details>

<details>
<summary></summary>

| Filename | Overview |
| --- | --- |
| packages/backend-archive/package.json | Wraps both archival commands with the 1Password loader but consequently prevents their npm binary from starting on Windows. |
| packages/backend-archive/src/helpers/archival/config.ts | Adds a correctly guarded and path-resolved development fallback that preserves existing environment values. |
| packages/backend-archive/src/helpers/archival/**tests**/config.test.ts | Updates the dotenv mock for the new import shape but bypasses the fallback and precedence behavior introduced by the PR. |
| packages/backend-archive/README.md | Documents the new shell-to-1Password-to-example precedence and required operational overrides. |
| packages/backend-archive/.env-example | Clarifies that checked-in values are development placeholders used only as unset-key fallbacks. |

</details>

<details>
<summary></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Run archival command] --> B[with-op-env fetches archival environment]
  B --> C[Merge 1Password values with inherited shell environment]
  C --> D[Start archival TypeScript command]
  D --> E{APP_ENV is development or absent?}
  E -- Yes --> F[Load unset keys from .env-example]
  E -- No --> G[Skip development fallback]
  F --> H[Validate archival configuration]
  G --> H
```

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fplumber%20PR%20%232138%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fplumber&pr=2138&platform=github"><img src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2" alt="Fix all with Greploop"></a> <picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture>

<details>
<summary>Prompt To Fix All With AI</summary>

```markdown
### Issue 1
packages/backend-archive/package.json:12-13
**Archival commands fail on Windows**

On Windows, both archival scripts now pass the bare `ts-node` executable through `with-op-env.mjs`. That loader uses `spawn` with `shell: false`, which cannot resolve npm's `ts-node.cmd` shim, so backfill and rehydration terminate before running. Please use a cross-platform executable resolution strategy or otherwise preserve Windows support.

### Issue 2
packages/backend-archive/src/helpers/archival/__tests__/config.test.ts:4-6
**Fallback behavior remains untested**

The test mocks `dotenv.config()` as a no-op, so it does not exercise the behavior introduced here: loading `.env-example`, retaining higher-priority environment values, and skipping the fallback outside development. Existing assertions can still pass using hard-coded development defaults, allowing regressions in the fallback path, guard, or precedence to go undetected. This is non-blocking, but a focused test using the real dotenv call would protect the new behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
```

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(archival): update README for the 1P..."](https://github.com/opengovsg/plumber/commit/3d1b68b5eea72a8ee53e082950d5d8d050557174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61268510)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Linear — [Move .env to 1Password](https://linear.app/ogp/issue/PLU-922/move-env-to-1password)

<!-- /greptile_comment -->