### PR TITLE
PLU-743: [IF-THEN-THEN-V2-25] Disable selecting for-each in empty if-then

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/__tests__/useIsAppSelectable.test.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/__tests__/useIsAppSelectable.test.ts
@@ -1,0 +1,160 @@
+import type { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+
+import {
+  FOR_EACH_INSIDE_BLOCK_REASON,
+  getIfThenV2Selectability,
+  IF_THEN_INSIDE_BLOCK_REASON,
+  LAST_STEP_ONLY_REASON,
+} from '../useIsAppSelectable'
+
+//
+// Fixtures. Selectability runs over the MRF-filtered action-step list (the
+// trigger already removed), ordered by position, so these never include a
+// trigger.
+//
+
+const plain = (id: string): IStep =>
+  ({ id, appKey: 'postman', key: 'sendTransactionalEmail' } as IStep)
+
+// The endStepId marker is what makes an if-then V2, so every block here
+// carries one. A marker pointing at the if-then itself is an empty block.
+const ifThen = (id: string, endStepId: string): IStep => {
+  const marker: Partial<IStep> = { config: { endStepId } }
+  return {
+    id,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    parameters: { depth: '0' },
+    ...marker,
+  } as IStep
+}
+
+const forEach = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'forEach' } as IStep)
+
+const GROUPING_ACTIONS = new Set(['toolbox-ifThen', 'toolbox-forEach'])
+
+describe('getIfThenV2Selectability', () => {
+  describe('inside an if-then block', () => {
+    it('rejects both grouping actions when the launcher states the placement', () => {
+      // The empty-block placeholder's anchor is the if-then step itself, which
+      // is not inside its own block, so it can only say so explicitly.
+      const emptyBlock = ifThen('ifThen', 'ifThen')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'inside-if-then-block',
+        anchorStep: emptyBlock,
+        actionSteps: [emptyBlock],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: FOR_EACH_INSIDE_BLOCK_REASON,
+      })
+      expect(result[TOOLBOX_ACTIONS.IfThen]).toEqual({
+        isSelectable: false,
+        disabledReason: IF_THEN_INSIDE_BLOCK_REASON,
+      })
+    })
+
+    it('rejects both grouping actions when the anchor is a block child', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach].isSelectable).toBe(false)
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(false)
+    })
+  })
+
+  describe('outside every if-then block', () => {
+    it('allows both grouping actions after the last block, at the last step', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'after-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach].isSelectable).toBe(true)
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(true)
+    })
+
+    it('holds for-each to the last step while an if-then goes anywhere', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: false,
+        anchorPlacement: 'after-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child, plain('after')],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: LAST_STEP_ONLY_REASON,
+      })
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(true)
+    })
+
+    it('rejects a second for-each in the flow', () => {
+      const inBody = plain('inBody')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: inBody,
+        actionSteps: [forEach('forEach'), inBody],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: LAST_STEP_ONLY_REASON,
+      })
+    })
+  })
+
+  describe('delay', () => {
+    it('rejects a delay inside a for-each body', () => {
+      const inBody = plain('inBody')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: inBody,
+        actionSteps: [forEach('forEach'), inBody],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result.delay.isSelectable).toBe(false)
+    })
+
+    it('allows a delay inside an if-then block', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'inside-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result.delay.isSelectable).toBe(true)
+    })
+  })
+})

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -26,10 +26,11 @@ export const LAST_STEP_ONLY_REASON = 'This can only be used as the last step'
  * An if-then block runs the steps it contains, so an if-then among them would
  * be a nested branch — which the block model does not support.
  */
-const IF_THEN_INSIDE_BLOCK_REASON =
+export const IF_THEN_INSIDE_BLOCK_REASON =
   'You cannot add an If-then inside another If-then'
 
-const FOR_EACH_INSIDE_BLOCK_REASON = 'For-each cannot be used in an If-then'
+export const FOR_EACH_INSIDE_BLOCK_REASON =
+  'For-each cannot be used in an If-then'
 
 export interface AppSelectability {
   isSelectable: boolean
@@ -119,7 +120,7 @@ function isIfThenSelectable({
  * leaving nesting as the sole restriction. For-each has no such extent, so it
  * still swallows every later step and must stay last.
  */
-function getIfThenV2Selectability({
+export function getIfThenV2Selectability({
   isLastStep,
   anchorPlacement,
   anchorStep,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -292,6 +292,9 @@ export default function IfThen({
                   hideLeadingConnector
                   step={ifThenStep}
                   allowReorder={false}
+                  // The anchor is the if-then step itself, which reads as outside
+                  // its own block.
+                  anchorPlacement="inside-if-then-block"
                 />
               ) : (
                 <SortableList


### PR DESCRIPTION
# Problem

It is possible to select for-each inside an empty if-then block

# Fix

Account for this edge case is useIsAppSelectable.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR marks the add-step launcher in an empty If-Then as being inside the block, preventing users from selecting unsupported grouping actions there. It also exposes the selectability helper and disabled-reason constants for focused regression tests.

- Disables For-each and nested If-then selection in an empty If-Then block.
- Adds coverage for grouping-action placement, last-step restrictions, and delay selection.
- Greptile automatically discovered a related ticket that helped explain the purpose of this PR: If-Then blocks may appear throughout a pipe but cannot contain nested grouping steps.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new placement hint reaches the existing selectability logic and has no unrelated behavioral effects.

The empty If-Then launcher now supplies the context required to reject For-each and nested If-then selections, and the new tests use production-equivalent action identifiers and step ordering.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx | Marks the empty-block launcher as inside the If-Then so grouping-action restrictions are applied. |
| packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts | Exports existing selectability logic and reason constants to support focused tests without changing runtime decisions. |
| packages/frontend/src/components/FlowStepConfigurationModal/hooks/__tests__/useIsAppSelectable.test.ts | Adds representative unit coverage for grouping actions and delay selection across block placements. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Empty If-Then add button] -->|inside-if-then-block| B[Configuration modal context]
  B --> C[useIsAppSelectable]
  C --> D[Disable For-each]
  C --> E[Disable nested If-Then]
  C --> F[Allow supported actions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(editor): disable for-each inside an ..."](https://github.com/opengovsg/plumber/commit/a175746645c61315c1cbc51939329556fc2b6140) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61298649)</sub>

**Context used:**

- Linear — [Allow If-Then anywhere in a pipe](https://linear.app/ogp/issue/PLU-743/allow-if-then-anywhere-in-a-pipe)

<!-- /greptile_comment -->