### PR TITLE
PLU-743: [IF-THEN-THEN-V2-26] Make spacing consistent in if-then and for-each blocks

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -24,7 +24,12 @@ import { getForEachBlockPreviewParts } from '../../helpers/getConditionBlockPrev
 import useDeleteStepConfirmation from '../../hooks/useDeleteStepConfirmation'
 import { HoverAddStepButton } from '../IfThen/HoverAddStepButton'
 import IfThen from '../IfThen/IfThen'
-import { blockActionButtonStyles, conditionBlockStyles } from '../IfThen/styles'
+import {
+  blockActionButtonStyles,
+  CONDITION_BLOCK_BODY_PB,
+  conditionBlockStyles,
+  EMPTY_CONDITION_BLOCK_BODY_PB,
+} from '../IfThen/styles'
 
 interface ForEachProps {
   groupedSteps: IStep[][]
@@ -153,7 +158,14 @@ export default function ForEach(props: ForEachProps) {
         }
       />
 
-      <Flex {...conditionBlockStyles.body}>
+      <Flex
+        {...conditionBlockStyles.body}
+        pb={
+          hasNoActionSteps
+            ? EMPTY_CONDITION_BLOCK_BODY_PB
+            : CONDITION_BLOCK_BODY_PB
+        }
+      >
         {hasNoActionSteps ? (
           <HoverAddStepButton
             isDisabled={readOnly}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -38,14 +38,13 @@ import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPr
 
 import { AddAfterBlockButton } from './AddAfterBlockButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
-import { blockActionButtonStyles, conditionBlockStyles } from './styles'
+import {
+  blockActionButtonStyles,
+  CONDITION_BLOCK_BODY_PB,
+  conditionBlockStyles,
+  EMPTY_CONDITION_BLOCK_BODY_PB,
+} from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
-
-/**
- * 3 + 4, from `conditionBlockStyles.body`'s usual padding and the height
- * HoverAddStepButton reserves for a last step's strip.
- */
-const EMPTY_BLOCK_BODY_PB = 7
 
 interface IfThenProps {
   block: IfThenBlock
@@ -289,9 +288,11 @@ export default function IfThen({
 
             <Flex
               {...conditionBlockStyles.body}
-              // An empty block reserves no trailing hover-+ strip, so its
-              // padding stands in for one and both blocks' bottoms align.
-              pb={isEmptyBlock ? EMPTY_BLOCK_BODY_PB : 3}
+              pb={
+                isEmptyBlock
+                  ? EMPTY_CONDITION_BLOCK_BODY_PB
+                  : CONDITION_BLOCK_BODY_PB
+              }
             >
               {isEmptyBlock ? (
                 <HoverAddStepButton

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -41,6 +41,12 @@ import { HoverAddStepButton } from './HoverAddStepButton'
 import { blockActionButtonStyles, conditionBlockStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 
+/**
+ * 3 + 4, from `conditionBlockStyles.body`'s usual padding and the height
+ * HoverAddStepButton reserves for a last step's strip.
+ */
+const EMPTY_BLOCK_BODY_PB = 7
+
 interface IfThenProps {
   block: IfThenBlock
   // Whether this block is the last item in the flow, which drives the
@@ -281,7 +287,12 @@ export default function IfThen({
               }
             />
 
-            <Flex {...conditionBlockStyles.body} pb={isEmptyBlock ? 2 : 3}>
+            <Flex
+              {...conditionBlockStyles.body}
+              // An empty block reserves no trailing hover-+ strip, so its
+              // padding stands in for one and both blocks' bottoms align.
+              pb={isEmptyBlock ? EMPTY_BLOCK_BODY_PB : 3}
+            >
               {isEmptyBlock ? (
                 <HoverAddStepButton
                   isDisabled={readOnly}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -95,16 +95,25 @@ export const conditionBlockStyles = {
     minH: 12,
     w: '100%',
   },
+  // Every consumer sets its own `pb`, so none is declared here.
   body: {
     alignItems: 'stretch',
     bg: 'white',
     direction: 'column' as FlexProps['direction'],
     px: 3,
     pt: 4,
-    pb: 0,
     w: '100%',
   },
 }
+
+/** Sits below the trailing hover-+ strip a block's last step reserves. */
+export const CONDITION_BLOCK_BODY_PB = 3
+
+/**
+ * An empty block reserves no such strip, so its padding stands in for one and
+ * every condition block's bottom lines up. The 4 is the strip's own height.
+ */
+export const EMPTY_CONDITION_BLOCK_BODY_PB = CONDITION_BLOCK_BODY_PB + 4
 
 export const hoverAddStepButtonStyles = {
   container: {


### PR DESCRIPTION
# Problem

The spacing in If-Then and For-each blocks were inconsistent

# Fix

More CSS and styling.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes bottom spacing for empty and populated If-Then and For-Each blocks.

- Centralizes the condition-block body padding values in shared style constants.
- Applies larger padding to empty blocks to compensate for the trailing add-step strip reserved by populated blocks.
- Removes the obsolete default padding now that every body-style consumer selects padding explicitly.

Greptile automatically discovered a related ticket that helped explain the purpose of this PR: If-Then is being redesigned as a condition wrapping a group of steps that can appear throughout a pipe.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both condition-block consumers apply the shared padding explicitly and the resulting resting spacing is consistent.

No actionable failures remain; the empty and populated layouts each reserve equivalent bottom space, and removing the shared default does not affect an unhandled consumer.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx | Selects shared empty or populated body padding based on whether the For-Each block contains action steps. |
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx | Replaces inline padding values with the shared condition-block spacing constants. |
| packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts | Centralizes empty and populated block padding values and removes the superseded body default. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(editor): align the empty REPEAT bloc..."](https://github.com/opengovsg/plumber/commit/5f70db42da686e5f0cadf56565db4def2b80c64b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61298672)</sub>

**Context used:**

- Linear — [Allow If-Then anywhere in a pipe](https://linear.app/ogp/issue/PLU-743/allow-if-then-anywhere-in-a-pipe)

<!-- /greptile_comment -->