### PR TITLE
chore(backend): fix all non-Tiles models + finish getDataOutMetadata pattern

### DIFF
--- a/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
@@ -321,7 +321,7 @@ function buildPaymentContentMetadata(
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const data = executionStep.dataOut
 
   if (!data || !data.fields) {

--- a/packages/backend/src/apps/gathersg/actions/create-case/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/get-data-out-metadata.ts
@@ -4,7 +4,7 @@ import { responseSchema } from './schema'
 
 async function getDataOutMetadata(
   step: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = step
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -55,7 +55,7 @@ function resolveAttachments(
 
 async function getDataOutMetadata(
   step: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = step
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
@@ -9,7 +9,7 @@ import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
 
   if (!rawDataOut) {

--- a/packages/backend/src/apps/lettersg/actions/create-letter/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/get-data-out-metadata.ts
@@ -6,7 +6,7 @@ import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
   step: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = step
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/get-data-out-metadata.ts
@@ -2,7 +2,7 @@ import type { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/m365-excel/actions/get-cell-values/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-cell-values/get-data-out-metadata.ts
@@ -4,7 +4,7 @@ import type { DataOut } from './data-out'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
@@ -4,7 +4,7 @@ import { dataOutSchema } from './schemas'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -4,7 +4,7 @@ import { dataOutSchema } from './schemas'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/get-data-out-metadata.ts
@@ -4,7 +4,7 @@ import { dataOutSchema } from './schemas'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/apps/pair/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/pair/common/get-data-out-metadata.ts
@@ -8,7 +8,7 @@ import { sanitizeOutputFieldName } from './schema'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut } = executionStep
   if (!dataOut) {
     return null

--- a/packages/backend/src/apps/tiles/actions/create-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/get-data-out-metadata.ts
@@ -9,7 +9,7 @@ import { CreateRowOutput } from '../../types'
  */
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut } = executionStep
   if (!dataOut?.row || typeof dataOut.row !== 'object') {
     return null

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -6,7 +6,7 @@ import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
 
   if (!rawDataOut) {

--- a/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
@@ -9,7 +9,7 @@ import { FindSingleRowOutput } from '../../types'
  */
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut } = executionStep
   if (!dataOut?.row || typeof dataOut.row !== 'object') {
     return null

--- a/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
@@ -9,7 +9,7 @@ import { UpdateRowOutput } from '../../types'
  */
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut } = executionStep
   if (!dataOut?.row || typeof dataOut.row !== 'object') {
     return null

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -22,7 +22,7 @@ const isBackwardCompatibilityColumnId = (id: string, numColumns: number) => {
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
-): Promise<IDataOutMetadata> {
+): Promise<IDataOutMetadata | null> {
   const { dataOut: rawDataOut } = executionStep
   if (!rawDataOut) {
     return null

--- a/packages/backend/src/models/base.ts
+++ b/packages/backend/src/models/base.ts
@@ -7,7 +7,7 @@ import ExtendedQueryBuilder from './query-builder'
 class Base extends Model {
   createdAt!: string
   updatedAt!: string
-  deletedAt: string
+  deletedAt!: string | null
 
   QueryBuilderType!: ExtendedQueryBuilder<this>
   static QueryBuilder = ExtendedQueryBuilder

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -14,11 +14,11 @@ import User from './user'
 class Connection extends Base {
   id!: string
   key!: string
-  data: string
+  data!: string
   formattedData?: IJSONObject
-  userId!: string
-  verified: boolean
-  draft: boolean
+  userId!: string | null
+  verified!: boolean
+  draft!: boolean
   count?: number
   flowCount?: number
   flow?: Flow
@@ -120,7 +120,7 @@ class Connection extends Base {
   static duplicate = async (
     connectionId: string,
     trx?: Transaction,
-  ): Promise<Connection> => {
+  ): Promise<Connection | undefined> => {
     const connection = await this.query(trx).findOne({ id: connectionId })
 
     if (!connection) {

--- a/packages/backend/src/models/email-suppression-entry.ts
+++ b/packages/backend/src/models/email-suppression-entry.ts
@@ -38,10 +38,10 @@ export type SuppressionReason = 'BOUNCE' | 'COMPLAINT'
 class EmailSuppressionEntry extends Base {
   email!: string
   reason!: SuppressionReason
-  reasonDetail?: string
-  sesMessageId?: string
+  reasonDetail?: string | null
+  sesMessageId?: string | null
   whitelistCount!: number
-  lastWhitelistedAt?: string
+  lastWhitelistedAt?: string | null
 
   static tableName = 'email_suppression'
 

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -14,13 +14,13 @@ class ExecutionStep extends Base {
   stepId!: string
   dataIn!: IJSONObject
   dataOut!: IJSONObject
-  errorDetails: IJSONObject
-  status: 'success' | 'failure'
-  appKey: string
-  jobId: string
-  step: Step
-  metadata: IExecutionStepMetadata
-  key: string
+  errorDetails!: IJSONObject
+  status!: 'success' | 'failure'
+  appKey!: string
+  jobId?: string
+  step!: Step
+  metadata!: IExecutionStepMetadata
+  key!: string
   execution?: Execution
 
   static tableName = 'execution_steps'

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -6,11 +6,11 @@ type ExecutionStatus = 'success' | 'failure' | null
 class Execution extends Base {
   id!: string
   flowId!: string
-  testRun: boolean
-  internalId: string
-  flow: Flow
-  executionSteps: ExecutionStep[]
-  status: ExecutionStatus
+  testRun!: boolean
+  internalId?: string | null
+  flow!: Flow
+  executionSteps!: ExecutionStep[]
+  status!: ExecutionStatus
 
   static tableName = 'executions'
 

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -23,7 +23,7 @@ class FlowCollaborator extends Base {
 
   // Virtual field for GraphQL compatibility - populated by custom resolver
   // Email is guaranteed to be available when user relation is loaded
-  email: string
+  email!: string
 
   static tableName = 'flow_collaborators'
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -19,7 +19,7 @@ class FlowConnections extends Base {
   connection?: Connection
   table?: TableMetadata
   user?: User
-  metadata: Record<string, any>
+  metadata!: Record<string, any>
   flow?: Flow
 
   static tableName = 'flow_connections'
@@ -213,9 +213,15 @@ class FlowConnections extends Base {
    */
   getConnection(): Connection | TableMetadata {
     if (this.connectionType === 'connection') {
+      if (!this.connection) {
+        throw new Error('Connection relation was not loaded')
+      }
       return this.connection
     }
     if (this.connectionType === 'table') {
+      if (!this.table) {
+        throw new Error('Table relation was not loaded')
+      }
       return this.table
     }
     throw new Error('Connection type is not valid')

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -19,14 +19,14 @@ class Flow extends Base {
   id!: string
   name!: string
   userId!: string
-  active: boolean
-  steps: Step[]
-  publishedAt: string
-  remoteWebhookId: string
+  active!: boolean
+  steps!: Step[]
+  publishedAt?: string | null
+  remoteWebhookId!: string
   executions?: Execution[]
-  testExecutionId: string
+  testExecutionId?: string | null
   testExecution?: Execution
-  user: User
+  user!: User
   collaborators?: FlowCollaborator[]
   updatedBy?: string
 
@@ -37,7 +37,7 @@ class Flow extends Base {
   /**
    * Null means to use default config.
    */
-  config: IFlowConfig | null
+  config!: IFlowConfig | null
 
   static tableName = 'flows'
 
@@ -222,9 +222,13 @@ class Flow extends Base {
   }
 
   async getTriggerStep(): Promise<Step> {
-    return await this.$relatedQuery('steps').findOne({
+    const triggerStep = await this.$relatedQuery('steps').findOne({
       type: 'trigger',
     })
+    if (!triggerStep) {
+      throw new Error(`Flow ${this.id} has no trigger step`)
+    }
+    return triggerStep
   }
 
   async containsFileProcessingActions(): Promise<boolean> {

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -28,15 +28,15 @@ class Step extends Base {
   appKey?: string
   type!: IStep['type']
   connectionId?: string
-  status: 'incomplete' | 'completed'
+  status!: 'incomplete' | 'completed'
   position!: number
-  parameters: IJSONObject
+  parameters!: IJSONObject
   connection?: Connection
-  flow: Flow
-  executionSteps: ExecutionStep[]
-  config: IStepConfig
+  flow!: Flow
+  executionSteps!: ExecutionStep[]
+  config!: IStepConfig
   updatedBy?: string
-  version: number
+  version!: number
 
   static tableName = 'steps'
 
@@ -103,6 +103,7 @@ class Step extends Base {
 
   get webhookUrl() {
     if (
+      !this.appKey ||
       !['webhook', 'formsg', 'gathersg'].includes(this.appKey) ||
       this.type === 'action'
     ) {
@@ -152,7 +153,10 @@ class Step extends Base {
       query.andWhere('execution_id', executionId)
     }
     if (additionalFilter) {
-      additionalFilter(query)
+      // Objection's query builder generics can't express the exact shape of
+      // `query` after chaining orderBy/limit/where/first(), so this is a
+      // trusted-caller escape hatch rather than a real null/undefined case.
+      additionalFilter(query as unknown as RelatedQueryBuilder<ExecutionStep>)
     }
     if (iteration) {
       query.andWhere(
@@ -224,7 +228,9 @@ class Step extends Base {
       return null
     }
 
-    const command = apps[appKey].triggers.find((trigger) => trigger.key === key)
+    const command = apps[appKey].triggers?.find(
+      (trigger) => trigger.key === key,
+    )
 
     return command
   }
@@ -235,7 +241,7 @@ class Step extends Base {
       return null
     }
 
-    const command = apps[appKey].actions.find((action) => action.key === key)
+    const command = apps[appKey].actions?.find((action) => action.key === key)
 
     return command
   }
@@ -320,6 +326,9 @@ class Step extends Base {
    * This approach allows zero-downtime migrations without database updates.
    */
   async $afterFind(): Promise<void> {
+    if (!this.appKey) {
+      return
+    }
     const app = apps[this.appKey]
     if (app?.stepTransformer && this.key && this.parameters) {
       this.parameters = app.stepTransformer.transformStepParameters(

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -6,9 +6,9 @@ import TableMetadata from './table-metadata'
 class TableColumnMetadata extends Base {
   id!: string
   tableId!: string
-  name: string
-  position: number
-  config: ITableColumnConfig
+  name!: string
+  position!: number
+  config!: ITableColumnConfig
   table!: TableMetadata
 
   static tableName = 'table_column_metadata'

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -13,9 +13,9 @@ interface ViewOnlyPassword {
 
 class TableMetadata extends Base {
   id!: string
-  name: string
+  name!: string
   collaborators!: User[]
-  columns: TableColumnMetadata[]
+  columns!: TableColumnMetadata[]
   viewOnlyKey?: string | null
   viewOnlyPassword?: ViewOnlyPassword | null
 
@@ -24,7 +24,7 @@ class TableMetadata extends Base {
    */
   role?: ITableCollabRole
   lastAccessedAt?: Date
-  db: 'pg' | 'ddb'
+  db!: 'pg' | 'ddb'
 
   static tableName = 'table_metadata'
 
@@ -107,8 +107,9 @@ class TableMetadata extends Base {
 
     const mappedData: Record<string, string> = {}
     for (const [key, value] of Object.entries(data)) {
-      if (columnMap.get(key)) {
-        mappedData[columnMap.get(key)] = value
+      const columnName = columnMap.get(key)
+      if (columnName) {
+        mappedData[columnName] = value
       }
     }
     return mappedData

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,6 +1,7 @@
 import { IFlowCollabRole, ITableCollabRole } from '@plumber/types'
 
 import crypto from 'crypto'
+import type { Knex } from 'knex'
 import {
   AnyQueryBuilder,
   ModelOptions,
@@ -32,7 +33,7 @@ class User extends Base {
   id!: string
   email!: string
   otpHash?: string
-  otpAttempts: number
+  otpAttempts!: number
   otpSentAt?: Date
   connections?: Connection[]
   flows?: Flow[]
@@ -153,11 +154,14 @@ class User extends Base {
       .modifyGraph('flow', (flowQuery: any) => {
         // this.applyFlowRoleSelection(flowQuery, userId)
         flowQuery
-          .leftJoin('flow_collaborators as fc', function () {
-            this.on('fc.flow_id', 'flows.id')
-              .andOnNull('fc.deleted_at')
-              .andOnVal('fc.user_id', userId)
-          })
+          .leftJoin(
+            'flow_collaborators as fc',
+            function (this: Knex.JoinClause) {
+              this.on('fc.flow_id', 'flows.id')
+                .andOnNull('fc.deleted_at')
+                .andOnVal('fc.user_id', userId)
+            },
+          )
           .select('flows.*', Flow.raw(ROLE_STMT, [userId]))
       })
   }

--- a/packages/backend/tsconfig.strict.json
+++ b/packages/backend/tsconfig.strict.json
@@ -233,6 +233,24 @@
     "src/types/interfaces/json-object.ts",
     "src/types/luxon-extensions.ts",
     "src/types/step.ts",
-    "src/workers/helpers/job-queue-timing.ts"
+    "src/workers/helpers/job-queue-timing.ts",
+    "src/db/storage/archived_templates/attendance-taking.ts",
+    "src/db/storage/archived_templates/schedule-reminders.ts",
+    "src/db/storage/archived_templates/update-mailing-lists.ts",
+    "src/db/storage/attendance-taking-v2.ts",
+    "src/db/storage/for-each-reminder.ts",
+    "src/db/storage/get-live-updates-through-telegram.ts",
+    "src/db/storage/route-support-enquiries-with-pair.ts",
+    "src/db/storage/route-support-enquiries.ts",
+    "src/db/storage/send-a-copy-of-form-response.ts",
+    "src/db/storage/send-follow-ups.ts",
+    "src/db/storage/track-feedback.ts",
+    "src/db/storage/update-mailing-lists-v2.ts",
+    "src/helpers/delay-as-milliseconds.ts",
+    "src/helpers/email-validator.ts",
+    "src/helpers/pagination.ts",
+    "src/models/base.ts",
+    "src/routes/api/chat/schema.ts",
+    "src/types/app-info.ts"
   ]
 }


### PR DESCRIPTION
## Stack Context

Ninth PR in the backend strict-mode rollout (stacked on #2147). Fixes all 13 non-Tiles `models/*.ts` files — the foundational data models — plus finishes the `getDataOutMetadata` null-widening pattern across 16 more apps.

## What?

- **`getDataOutMetadata` null-widening**: 16 more implementations across m365-excel, gathersg, lettersg, pair, tiles, toolbox, formsg follow the same `return null` pattern already fixed for postman/scheduler in #2145 — same mechanical fix (`Promise<IDataOutMetadata | null>`).
- **`models/base.ts`**: `deletedAt` widened to `string | null` (the exact case identified during the original grilling session for ADR-0001) — genuinely nullable per the soft-delete migration.
- **`models/connection.ts`**: `userId` widened to `string | null` — confirmed via 8 existing call sites across the codebase that already do `connection.userId !== null` checks, so the model's `userId!: string` was already a known lie the rest of the code worked around. Also fixed `Connection.duplicate`'s return type (it can return `undefined`; the one caller already handles that).
- **`models/step.ts`**: fixed `apps[appKey].triggers?.find(...)`/`.actions?.find(...)` (both optional per `IApp`), an `$afterFind` guard for a possibly-undefined `appKey` before indexing, and a documented `as unknown as` cast for `additionalFilter`'s Objection query-builder generic (a real type-checker limitation across chained `.first()`/`.where()`, not a null-safety bypass).
- **`models/flow.ts`**: `getTriggerStep` now throws instead of silently returning `undefined` typed as `Step` — all 4 existing call sites already assumed a definite result.
- **`models/flow-connections.ts`**: `getConnection()` throws if the relevant relation wasn't loaded, instead of returning `undefined` typed as `Connection | TableMetadata`.
- The rest (`execution.ts`, `execution-step.ts`, `flow-collaborators.ts`, `table-column-metadata.ts`, `table-metadata.ts`, `user.ts`): mechanical `strictPropertyInitialization` fixes, checked against each column's actual migration (`.notNullable()`/`.nullable()`) rather than guessed — `!` for Objection-hydrated fields, `| null` only where the DB genuinely allows it.
- `models/tiles/*` (DynamoDB/Postgres table operations, ~18 errors) deliberately **not** touched — ElectroDB/Objection generic-type issues distinct enough to deserve their own focused round.

## Why?

None of these model files can be added to `tsconfig.strict.json`'s `include` list yet — `models/step.ts` imports `@/apps` (the full app registry), so anything reaching it transitively pulls in every unfixed app. Fixed and verified them anyway (each confirmed clean via a scoped `tsc` probe) since they're necessary prerequisite work for the eventual apps+models mega-round, and landing them incrementally beats one giant future PR.

**Caught and reverted a real regression** via the usual before/after full non-strict `typecheck` diff: my first pass widened several relation fields (`Step.flow`, `Flow.steps`, `Flow.user`, `Execution.flow`/`executionSteps`, `ExecutionStep.step`, `TableColumnMetadata.table`) from required to optional, reasoning that Objection relations are only populated when graph-fetched. That broke structural compatibility with `@plumber/types`' `IStep`/`IFlow`/`IExecution`/`IUser` interfaces, which declare these as required — these Model classes are duck-typed against those interfaces throughout the app-plugin code. Reverted to match the existing established pattern (`!`, required) for relations, and separately reverted three column fields (`Flow.remoteWebhookId`, `ExecutionStep.errorDetails`/`appKey`/`key`) that I'd also over-widened to nullable — the DB migrations show them as genuinely nullable, but `@plumber/types` declares them required and non-null, so fixing that mismatch is deferred to a future round focused on those shared interfaces specifically, rather than risking another wide-blast-radius change here.
