### PR TITLE
chore(backend): fix formsg/gathersg/m365-excel strict-mode errors

### DIFF
--- a/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
@@ -17,8 +17,8 @@ import { ParsedMrfWorkflowStep } from './types'
 function buildQuestionMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
   const question: IDataOutMetadatum = {
     type: 'text',
-    label: fieldData.order ? `Question ${fieldData.order}` : null,
-    order: fieldData.order ? (fieldData.order as number) : null,
+    label: fieldData.order ? `Question ${fieldData.order}` : undefined,
+    order: fieldData.order ? (fieldData.order as number) : undefined,
     isCollapsedByDefault: true,
   }
 
@@ -35,7 +35,7 @@ function buildQuestionMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
 
 function buildAnswerMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
   const answer: IDataOutMetadatum = {
-    order: fieldData.order ? (fieldData.order as number) + 0.1 : null,
+    order: fieldData.order ? (fieldData.order as number) + 0.1 : undefined,
   }
 
   switch (fieldData.fieldType) {
@@ -61,7 +61,7 @@ function buildAnswerMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
       answer['type'] = 'text'
       answer['label'] = fieldData.order
         ? `${fieldData.order}. ${fieldData.question}`
-        : null
+        : undefined
   }
 
   return answer
@@ -111,7 +111,7 @@ function buildAnswerArrayForCheckbox(
   return {
     type: 'array',
     label: `${order}. ${question}`,
-    order: order ? (order as number) + 0.1 : null,
+    order: order ? (order as number) + 0.1 : undefined,
   }
 }
 
@@ -177,7 +177,7 @@ function buildAnswerArrayForTable(
       nestedAnswerArray.push({
         type: 'text',
         label,
-        order: order ? (order as number) + 0.1 : null,
+        order: order ? (order as number) + 0.1 : undefined,
         // NOTE: we hide the option if it is empty
         // mock data will have dummy strings in the answerArray
         // actual submissions should contain real data, otherwise the cells should be hidden
@@ -208,7 +208,7 @@ function buildTableMetadatum(fieldData: IJSONObject): IDataOutMetadata {
     label: fieldData.question
       ? `${fieldData.order}. ${fieldData.question}`
       : `Response ${fieldData.order}`,
-    order: fieldData.order ? (fieldData.order as number) + 0.1 : null,
+    order: fieldData.order ? (fieldData.order as number) + 0.1 : undefined,
     type: 'table',
     displayedValue: `${rowsFound} row${rowsFound != 1 ? 's' : ''}`,
     value: tableObject,

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -67,6 +67,9 @@ async function getDataOutMetadata(
   }
 
   const { data: dataOut } = parsedDataOut.data
+  if (!dataOut) {
+    return null
+  }
 
   const metadata = {
     data: {

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -9,11 +9,11 @@ import { getLastHitGraphApiType, GraphApiType } from '../graph-api-type'
 import { tryParseGraphApiError } from '../parse-graph-api-error'
 
 type ThrowingHandler = (
-  ...args: Parameters<IApp['requestErrorHandler']>
+  ...args: Parameters<NonNullable<IApp['requestErrorHandler']>>
 ) => never
 
 type MaybeThrowingHandler = (
-  ...args: Parameters<IApp['requestErrorHandler']>
+  ...args: Parameters<NonNullable<IApp['requestErrorHandler']>>
 ) => never | void
 
 const handleIntermittentError: MaybeThrowingHandler = ($, error) => {
@@ -44,8 +44,8 @@ const handle404: ThrowingHandler = ($, error) => {
   logger.error('Received HTTP 404 from MS Graph', {
     event: 'm365-http-404-invalid-version',
     tenant: $.auth?.data?.tenantKey as string,
-    baseUrl: error.response.config.baseURL,
-    url: error.response.config.url,
+    baseUrl: error.response.config?.baseURL,
+    url: error.response.config?.url,
     flowId: $.flow?.id,
     stepId: $.step?.id,
     executionId: $.execution?.id,
@@ -74,7 +74,8 @@ const handle429: ThrowingHandler = ($, error) => {
   //
   // Since they apply per-file, we delay only the group when retrying.
   if (
-    getLastHitGraphApiType(error.response.config.url) === GraphApiType.Excel
+    getLastHitGraphApiType(error.response.config?.url ?? '') ===
+    GraphApiType.Excel
   ) {
     throw new RetriableError({
       error: 'Retrying HTTP 429 from Excel endpoint',
@@ -88,8 +89,8 @@ const handle429: ThrowingHandler = ($, error) => {
   logger.error('Received HTTP 429 from MS Graph', {
     event: 'm365-http-429',
     tenant: $.auth?.data?.tenantKey as string,
-    baseUrl: error.response.config.baseURL,
-    url: error.response.config.url,
+    baseUrl: error.response.config?.baseURL,
+    url: error.response.config?.url,
     flowId: $.flow?.id,
     stepId: $.step?.id,
     executionId: $.execution?.id,
@@ -113,8 +114,8 @@ const handle500and502and503: ThrowingHandler = function ($, error) {
   logger.warn(`Received HTTP ${status} from MS Graph`, {
     event: `m365-http-${status}`,
     tenant: $.auth?.data?.tenantKey as string,
-    baseUrl: error.response.config.baseURL,
-    url: error.response.config.url,
+    baseUrl: error.response.config?.baseURL,
+    url: error.response.config?.url,
     flowId: $.flow?.id,
     stepId: $.step?.id,
     executionId: $.execution?.id,
@@ -154,8 +155,8 @@ const handle504: ThrowingHandler = function ($, error) {
   logger.warn('Received HTTP 504 from MS Graph', {
     event: 'm365-http-504',
     tenant: $.auth?.data?.tenantKey as string,
-    baseUrl: error.response.config.baseURL,
-    url: error.response.config.url,
+    baseUrl: error.response.config?.baseURL,
+    url: error.response.config?.url,
     flowId: $.flow?.id,
     stepId: $.step?.id,
     executionId: $.execution?.id,
@@ -186,8 +187,8 @@ const handle509: ThrowingHandler = function ($, error) {
   logger.error('Received HTTP 509 from MS Graph', {
     event: 'm365-http-509',
     tenant: $.auth?.data?.tenantKey as string,
-    baseUrl: error.response.config.baseURL,
-    url: error.response.config.url,
+    baseUrl: error.response.config?.baseURL,
+    url: error.response.config?.url,
     flowId: $.flow?.id,
     stepId: $.step?.id,
     executionId: $.execution?.id,


### PR DESCRIPTION
## Stack Context

Tenth PR in the backend strict-mode rollout (stacked on #2149). Fixes three more app files for strict mode — not yet added to `tsconfig.strict.json`, same reasoning as the models round (#2149): they still transitively reach the unfixed `apps/` cluster.

## What?

- **`formsg/common/get-data-out-metadata.ts`**: `IDataOutMetadatum.label`/`.order` are optional (`undefined`), not nullable (`null`) — several ternaries used `: null` as the "not set" branch. Swapped to `: undefined` to match the actual type.
- **`gathersg/actions/get-case-details/get-data-out-metadata.ts`**: the Zod schema's `data` field is itself `.nullish()` (the whole case-data object can be absent), but the code destructured and used it without checking. Added the missing guard.
- **`m365-excel/common/interceptors/request-error-handler.ts`**: `HttpError.response.config` is optional (per ADR-0001) — added `?.` at every access. Also the `ThrowingHandler`/`MaybeThrowingHandler` type aliases needed `NonNullable<IApp['requestErrorHandler']>` (same fix as #2146/#2147, `requestErrorHandler` is an optional interface member).

## Why?

Same rationale as #2149: these fixes are correct and individually verified via scoped `tsc` probes, but can't be added to `tsconfig.strict.json` yet since even a single fixed file, once used as a probe root, still pulls in the rest of the unfixed `apps/` tree transitively (confirmed by testing each one — same ~260 pre-existing errors resurface). Landing the fix now rather than batching it into the eventual mega-PR.

Verified via the same before/after full non-strict `typecheck` diff (zero regressions) plus the existing `get-data-out-metadata-mrf.test.ts` suite.
