### PR TITLE
chore(backend): fix custom-api http-request.ts strict-mode errors

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -3,6 +3,7 @@ import { IGlobalVariable, IRawAction } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
+import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
 import Step from '@/models/step'
 
@@ -140,6 +141,10 @@ async function run($: IGlobalVariable) {
       )
     }
 
+    if (!(err instanceof Error)) {
+      throw err
+    }
+
     if (err.message === RECURSIVE_WEBHOOK_ERROR) {
       throw new StepError(
         RECURSIVE_WEBHOOK_ERROR,
@@ -160,23 +165,25 @@ async function run($: IGlobalVariable) {
       )
     }
 
+    const httpError = err instanceof HttpError ? err : undefined
+
     if (err.message === `timeout of ${timeout}ms exceeded`) {
       throw new StepError(
         `HTTP request exceeded timeout of ${timeout / 1000}s`,
         'The request took too long to respond.',
-        err,
+        httpError,
       )
     }
 
     // remaining errors are http errors to be caught
     throw new StepError(
       `Status code: ${
-        err.response
-          ? `${err.response.status} (${err.response.statusText})`
+        httpError?.response
+          ? `${httpError.response.status} (${httpError.response.statusText})`
           : err.message
       } `,
       'Check your custom app based on the status code and retry again.',
-      err,
+      httpError,
     )
   }
 }


### PR DESCRIPTION
## Stack Context

Eleventh PR in the backend strict-mode rollout (stacked on #2150). Fixes `custom-api/actions/http-request/index.ts`'s error-handling catch block — not yet gated into `tsconfig.strict.json`, same reasoning as #2149/#2150.

## What?

The catch block handles three distinct error shapes without distinguishing them: `ZodError` (parameter validation), plain `Error` (thrown by pre-flight checks like `check-urls.ts`'s recursive-webhook/invalid-URL/disallowed-IP guards, before any HTTP call happens), and `HttpError` (wrapped by `$.http`'s interceptor once a real request fails). Added narrowing at each boundary:
- `if (!(err instanceof Error)) throw err` before any `.message` access.
- `const httpError = err instanceof HttpError ? err : undefined` before the `.response` access in the fallback branch, matching the `instanceof HttpError` idiom already used in ~15 other apps.

## Why?

`StepError`'s third constructor argument is typed `HttpError | undefined`; the code was passing `err` (typed `unknown` in a `catch` block) directly. Verified via the existing 70-test `http-request.test.ts` + `http-request-interceptors.test.ts` suite that this preserves exact behavior for the pre-flight-check errors (recursive webhook, disallowed IP, invalid URL/protocol) and the timeout/HTTP-status fallback paths.
