### PR TITLE
chore(backend): widen IStep/IConnection/IFlow types, fix compute-parameters.ts

### DIFF
--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -109,12 +109,13 @@ function findAndSubstituteVariables(
       })
       const data = executionStep?.dataOut
       const stepIsInForEach =
-        forEachStepPosition > -1 &&
-        stepPositions?.[stepId] >= forEachStepPosition
+        forEachStepPosition !== undefined &&
+        stepPositions?.[stepId] !== undefined &&
+        stepPositions[stepId] >= forEachStepPosition
 
       const keyPath = keyPaths.join('.') // for lodash get to work
       let dataValue = get(data, keyPath)
-      if (stepIsInForEach) {
+      if (stepIsInForEach && executionStep && data && forEachContext) {
         dataValue = computeForEachParameters({
           data,
           keyPath,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -41,7 +41,7 @@ export interface IConnection {
   key: string
   data: string
   formattedData?: IJSONObject
-  userId: string
+  userId: string | null
   verified: boolean
   count?: number
   flowCount?: number
@@ -199,8 +199,8 @@ export interface IStep {
   flowId: string
   key?: string
   appKey?: string
-  iconUrl: string
-  webhookUrl: string
+  iconUrl: string | null
+  webhookUrl: string | null
   type: 'action' | 'trigger'
   connectionId?: string
   status: string
@@ -279,7 +279,7 @@ export interface IFlow {
   createdAt: string
   updatedAt: string
   remoteWebhookId: string
-  lastInternalId: () => Promise<string>
+  lastInternalId: () => Promise<string | null | undefined>
   config: IFlowConfig | null
   pendingTransfer?: IFlowTransfer
   template?: ITemplate


### PR DESCRIPTION
## Stack Context

Twelfth PR in the backend strict-mode rollout (stacked on #2151). Fixes `helpers/compute-parameters.ts` and, along the way, four more `@plumber/types` interface fields that were stricter than the actual Model implementations they're meant to describe.

## What?

- **`@plumber/types`**: widened four fields to match what the real Model code actually returns:
  - `IStep.iconUrl`/`.webhookUrl`: `string` → `string | null` — `Step`'s own getters (`get iconUrl()`, `get webhookUrl()`) already return `null` in several branches (no `appKey`, action-type step, etc.).
  - `IConnection.userId`: `string` → `string | null` — same field fixed on the `Connection` model in #2149, evidenced by 8 existing call sites already doing `connection.userId !== null` checks.
  - `IFlow.lastInternalId`: `() => Promise<string>` → `() => Promise<string | null | undefined>` — `Flow.lastInternalId()` returns `null` when there's no prior execution.
- **`helpers/compute-parameters.ts`**: `forEachContext`'s destructured fields are all optional (defaults to `{}` when the context itself is absent) but were used without checking; added the missing guards before computing `stepIsInForEach` and before calling `computeForEachParameters` (which requires non-optional `data`/`executionStep`/`forEachContext`).

## Why?

Each widening was found by starting from `compute-parameters.ts`'s real errors and following the type-checker's own "why doesn't `ExecutionStep[]` satisfy `IExecutionStep[]`" trail down through nested structural mismatches — each one a genuine gap between what `@plumber/types` promised and what the Model layer (already fixed in #2149) actually does. Verified each widening individually via a full before/after non-strict `typecheck` diff before moving to the next (all clean, zero regressions) — same discipline as the rest of this rollout, just applied to a chain of four fixes instead of one.

`helpers/compute-parameters.ts` itself isn't yet addable to `tsconfig.strict.json` (still transitively reaches the unfixed `apps/` cluster via `models/step.ts`), same as #2149-#2151.
