### PR TITLE
chore(backend): fix postman email flow + doesFileProcessing strict-mode errors

### DIFF
--- a/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
+++ b/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
@@ -51,7 +51,7 @@ const action: IRawAction = {
     },
   ],
   doesFileProcessing: (step: Step) => {
-    return step.parameters.file && step.parameters.file !== ''
+    return Boolean(step.parameters.file && step.parameters.file !== '')
   },
 
   async run(_) {

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -90,9 +90,9 @@ const action: IRawAction = {
   },
 
   doesFileProcessing: (step: Step) => {
-    return (
+    return Boolean(
       step.parameters.attachments &&
-      (step.parameters.attachments as IJSONArray).length > 0
+        (step.parameters.attachments as IJSONArray).length > 0,
     )
   },
 
@@ -141,6 +141,10 @@ function getSendEmailParams(
     ? parsed.data.useConfiguredEmails ?? false
     : false
 
+  if (!$.user) {
+    throw new Error('Test run is missing the triggering user')
+  }
+
   return {
     subject,
     body,
@@ -156,6 +160,10 @@ async function sendEmail(
   $: IGlobalVariable,
   testRunMetadata?: TestRunStepMetadata,
 ) {
+  if (!$.user) {
+    throw new Error('Flow is missing an owner')
+  }
+
   const {
     subject,
     body,
@@ -208,15 +216,18 @@ async function sendEmail(
   const prevDataOutParseResult = dataOutSchema.safeParse(
     lastExecutionStep?.dataOut,
   )
-  const isPartialRetry =
+  const isPartialRetry = Boolean(
     prevDataOutParseResult.success &&
-    lastExecutionStep.errorDetails &&
-    // Don't do partial retry in test runs! always send to all recipients
-    !$.execution.testRun
+      lastExecutionStep?.errorDetails &&
+      // Don't do partial retry in test runs! always send to all recipients
+      !$.execution.testRun,
+  )
 
-  if (isPartialRetry) {
+  if (isPartialRetry && prevDataOutParseResult.success) {
     const { status, recipient } = prevDataOutParseResult.data
-    recipientsToSend = recipient.filter((_, i) => status[i] !== 'ACCEPTED')
+    recipientsToSend = recipient.filter(
+      (_: string, i: number) => status[i] !== 'ACCEPTED',
+    )
   }
 
   // Resolve the transport once, on the configured attachments and the actual
@@ -241,7 +252,7 @@ async function sendEmail(
     $,
     attachmentsList: result.data.attachments,
     isPartialRetry,
-    lastExecutionStep,
+    lastExecutionStep: lastExecutionStep ?? null,
     extensionPolicy,
   })
 
@@ -267,7 +278,7 @@ async function sendEmail(
   /**
    * Patch the status of the recipients that were sent in the previous execution
    */
-  if (isPartialRetry) {
+  if (isPartialRetry && prevDataOutParseResult.success) {
     const prevDataOut = prevDataOutParseResult.data
     const updatedStatus = prevDataOut.status.map((oldStatus, i) => {
       const correspondingRecipient = prevDataOut.recipient[i]
@@ -342,11 +353,13 @@ async function sendEmail(
     hasInvalidAttachments &&
     !isPartialRetry &&
     !$.execution.testRun &&
-    !isRetryWithoutAttachments
+    !isRetryWithoutAttachments &&
+    submissionId
   ) {
     await sendInvalidAttachmentsEmail({
       ...defaultSendEmailParams,
       ...invalidAttachmentParams,
+      submissionId,
     })
 
     logger.warn({

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -79,7 +79,7 @@ interface PostmanPromiseFulfilled {
 interface PostmanPromiseRejected {
   status: PostmanEmailSendStatus
   recipient: string
-  error: HttpError
+  error: unknown
 }
 
 async function sendViaPostman(
@@ -96,7 +96,7 @@ async function sendViaPostman(
     `${email.senderName} <${appConfig.postman.fromAddress}>`,
   )
   requestData.append('disable_tracking', 'true')
-  if (email.ccList?.length > 0) {
+  if ((email.ccList?.length ?? 0) > 0) {
     requestData.append('cc', JSON.stringify(email.ccList))
   }
 
@@ -169,6 +169,9 @@ async function sendViaSes(
   // attachments for) every recipient.
   sharedRawMessage: Buffer | undefined,
 ): Promise<PostmanPromiseFulfilled> {
+  if (!appConfig.ses.fromAddress) {
+    throw new Error('SES_FROM_ADDRESS environment variable needs to be set!')
+  }
   const client = getSesClient()
   // Address sent to SES: display name is RFC 5322-quoted when it contains
   // specials (e.g. a comma) so the header isn't malformed.
@@ -297,7 +300,7 @@ export async function sendTransactionalEmails(
 ): Promise<{
   dataOut: PostmanEmailDataOut
   errorStatus?: PostmanEmailSendStatus
-  error?: HttpError
+  error?: unknown
 }> {
   // Pre-send suppression check (SES path only). CC addresses are included so a
   // blacklisted CC can be dropped from the SES call rather than re-sent to
@@ -341,6 +344,10 @@ export async function sendTransactionalEmails(
     )
     if (totalAttachmentBytes > SES_MAX_TOTAL_ATTACHMENT_SIZE) {
       attachmentBuildError = new AttachmentSizeExceededError()
+    } else if (!appConfig.ses.fromAddress) {
+      attachmentBuildError = new Error(
+        'SES_FROM_ADDRESS environment variable needs to be set!',
+      )
     } else {
       try {
         sharedRawMessage = await buildRawEmail({
@@ -423,7 +430,7 @@ export async function sendTransactionalEmails(
   const results = await Promise.allSettled(promises)
   const status: PostmanEmailSendStatus[] = []
   const recipient: string[] = []
-  let params: Omit<PostmanEmailDataOut, 'status' | 'recipient'>
+  let params: Omit<PostmanEmailDataOut, 'status' | 'recipient'> | undefined
   const errors: PostmanPromiseRejected[] = []
 
   // Merge suppressed entries and send results back into input order so

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -19,9 +19,11 @@ type PostmanApiErrorData = {
 // Until this is fixed, we will retry these requests on behalf of the user
 const POSTMAN_RETRIABLE_HTTP_CODES = [500, 502, 504, 520, 524]
 
-export function getPostmanErrorStatus(
-  error: HttpError,
-): PostmanEmailSendStatus {
+export function getPostmanErrorStatus(error: unknown): PostmanEmailSendStatus {
+  if (!(error instanceof HttpError)) {
+    return 'ERROR'
+  }
+
   const postmanErrorData: PostmanApiErrorData = error.response?.data ?? {}
   const { code: errorCode, message: errorMessage } = postmanErrorData
   // catch common postman error codes and provide solution
@@ -40,7 +42,10 @@ export function getPostmanErrorStatus(
     case 'attachment_limit':
       return 'ATTACHMENT-SIZE-EXCEEDED'
     default:
-      if (POSTMAN_RETRIABLE_HTTP_CODES.includes(error.response?.status)) {
+      if (
+        error.response?.status !== undefined &&
+        POSTMAN_RETRIABLE_HTTP_CODES.includes(error.response.status)
+      ) {
         return 'INTERMITTENT-ERROR'
       }
       // return original error if not caught
@@ -89,7 +94,7 @@ export function getSesErrorStatus(error: unknown): PostmanEmailSendStatus {
   }
 
   // Server errors — 500+ are transient, worth retrying
-  if (httpStatus >= 500) {
+  if (httpStatus !== undefined && httpStatus >= 500) {
     return 'INTERMITTENT-ERROR'
   }
 
@@ -143,8 +148,8 @@ export function throwPostmanStepError({
   isRetryWithoutAttachments,
 }: {
   $: IGlobalVariable
-  status: PostmanEmailSendStatus
-  error: HttpError
+  status?: PostmanEmailSendStatus
+  error?: unknown
   isPartialSuccess: boolean
   blacklistedRecipients: string[]
   invalidAttachments: string[]
@@ -156,9 +161,17 @@ export function throwPostmanStepError({
     // should not show attachments list if we are retrying without attachments
     showAttachmentsList: !isRetryWithoutAttachments,
   })
+  // Only some error paths (e.g. AttachmentSizeExceededError) produce a real
+  // HttpError; StepError/RetriableError's `error`/`.details` still want a best
+  // effort message either way.
+  const httpError = error instanceof HttpError ? error : undefined
+  const errorMessage = error instanceof Error ? error.message : undefined
 
   switch (status) {
     case 'BLACKLISTED': {
+      if (!$.user) {
+        throw new Error('Flow is missing an owner')
+      }
       let name = 'Blacklisted recipient email'
       const formLink = createRequestBlacklistFormLink({
         userEmail: $.user.email,
@@ -202,12 +215,12 @@ export function throwPostmanStepError({
           },
         })
       }
-      throw new StepError(name, solution, error)
+      throw new StepError(name, solution, httpError)
     }
     case 'RATE-LIMITED':
       // this will be auto-retried later on
       throw new RetriableError({
-        error: error.details ?? error.message,
+        error: httpError?.details ?? errorMessage ?? 'Unknown error',
         delayInMs: 'default',
         delayType: 'queue',
       })
@@ -215,17 +228,17 @@ export function throwPostmanStepError({
       throw new StepError(
         'Password-protected attachment(s)',
         `Check that the attachment(s) are not password-protected.`,
-        error,
+        httpError,
       )
     case 'ATTACHMENT-SIZE-EXCEEDED':
       throw new StepError(
         'Total attachment size exceeded',
         'Check that the attachments do not exceed 20MB in total.',
-        error,
+        httpError,
       )
     case 'INTERMITTENT-ERROR':
       throw new RetriableError({
-        error: error.details ?? error.message,
+        error: httpError?.details ?? errorMessage ?? 'Unknown error',
         delayInMs: 'default',
         delayType: 'step',
       })
@@ -233,9 +246,9 @@ export function throwPostmanStepError({
     default:
       // socket hang up is a Cloudflare/Postman-specific issue; only retry
       // if the error came from the Postman path (not SES).
-      if (error?.message === 'socket hang up') {
+      if (errorMessage === 'socket hang up') {
         throw new RetriableError({
-          error: `Retrying ${error.message}`,
+          error: `Retrying ${errorMessage}`,
           delayInMs: 'default',
           delayType: 'step',
         })
@@ -253,7 +266,7 @@ export function throwPostmanStepError({
         // throw StepError for test runs so that user cannot publish the pipe
         // until the error is fixed
         if ($.execution.testRun) {
-          throw new StepError(name, solution, error)
+          throw new StepError(name, solution, httpError)
         }
 
         throw new PartialStepError({
@@ -265,7 +278,7 @@ export function throwPostmanStepError({
       throw new StepError(
         'Something went wrong',
         'Please contact plumber@open.gov.sg for assistance.',
-        error,
+        httpError,
       )
   }
 }

--- a/packages/backend/src/helpers/actions/does-action-process-files.ts
+++ b/packages/backend/src/helpers/actions/does-action-process-files.ts
@@ -2,10 +2,10 @@ import apps from '@/apps'
 import Step from '@/models/step'
 
 export function doesActionProcessFiles(step: Step): boolean {
-  if (!apps[step.appKey]) {
+  if (!step.appKey || !apps[step.appKey]) {
     return false
   }
-  const action = apps[step.appKey].actions.find((a) => a.key === step.key)
+  const action = apps[step.appKey].actions?.find((a) => a.key === step.key)
   if (!action || !action.doesFileProcessing) {
     return false
   }


### PR DESCRIPTION
## Stack Context

Thirteenth PR in the backend strict-mode rollout (stacked on #2152). Fixes the Postman transactional-email sending flow (3 files, 30+ errors), plus `aisay`'s and the shared `doesActionProcessFiles`'s `doesFileProcessing` implementations.

## What?

- **`aisay/actions/use-generalised-model/index.ts`, `postman/actions/send-transactional-email/index.ts`**: `doesFileProcessing`'s implementations returned `step.parameters.x && ...` directly — under strict mode this infers as `boolean | "" | 0 | null`, not `boolean`. Wrapped in `Boolean(...)`.
- **`helpers/actions/does-action-process-files.ts`**: guarded `step.appKey` (optional) before indexing the apps registry, and `.actions` (optional) before `.find()`.
- **`postman/common/throw-errors.ts`, `postman/common/email-helper.ts`, `postman/actions/send-transactional-email/index.ts`**: the bulk of this PR. `getPostmanErrorStatus`/`getSesErrorStatus`/`throwPostmanStepError`'s `error` parameter is genuinely `unknown` at the call site (could be an `HttpError`, a plain `AttachmentSizeExceededError`, or anything else `Promise.allSettled` catches) — widened all three to accept `unknown` and narrow internally (`instanceof HttpError` for `.details`/`.response`, `instanceof Error` for `.message`) instead of asserting `HttpError`. Also fixed a lost-narrowing bug from wrapping a Zod `.safeParse()` check in `Boolean(...)` (see below), and a `let params` that's genuinely possibly-unassigned if every recipient fails.

## Why?

**Caught and fixed a real regression** via the test suite (not just the typecheck diff): my first pass at the `error` parameter filtered it to `e instanceof HttpError ? e : undefined`, which is wrong — `AttachmentSizeExceededError` isn't an `HttpError`, so filtering dropped the "an error occurred" signal `throwPostmanStepError`'s gating check depends on, and the whole size-exceeded test started passing silently instead of throwing. Fixed by keeping `error: unknown` end-to-end and narrowing only where a specific field (`.details`, `.response`) is actually read, restoring the original "any caught value signals an error" behavior while still being type-honest.

Also caught a separate lost-narrowing bug while fixing types: wrapping `prevDataOutParseResult.success && ...` in `Boolean(...)` to satisfy a `boolean`-typed `isPartialRetry` variable broke the type narrowing at the two `if (isPartialRetry) { ...prevDataOutParseResult.data... }` call sites further down (TS can no longer trace back through the boolean variable to know `.success` was true there). Fixed by re-checking `prevDataOutParseResult.success` directly at each use site.

Verified via the same full non-strict `typecheck` diff (zero regressions) plus the existing 33-test `send-transactional-email.test.ts` suite, which caught the regression above before it shipped.
