### PR TITLE
chore(backend): fix telegram-bot get-chat-ids.ts strict-mode errors

### DIFF
--- a/packages/backend/src/apps/telegram-bot/dynamic-data/get-chat-ids.ts
+++ b/packages/backend/src/apps/telegram-bot/dynamic-data/get-chat-ids.ts
@@ -19,8 +19,8 @@ type ChatInfo = {
   id: number
 }
 
-function extractChatFromUpdate(update: TelegramUpdate): ChatInfo {
-  const messageObject: HasTelegramChat =
+function extractChatFromUpdate(update: TelegramUpdate): ChatInfo | null {
+  const messageObject: HasTelegramChat | undefined =
     update.message ||
     update.my_chat_member ||
     update.channel_post ||
@@ -41,7 +41,7 @@ function extractChatFromUpdate(update: TelegramUpdate): ChatInfo {
     return null
   }
   const name = `${title || username} (${type})`
-  return { title: name || username, id }
+  return { title: name, id }
 }
 
 const dynamicData: IDynamicData = {
@@ -80,7 +80,9 @@ const dynamicData: IDynamicData = {
     } catch (e) {
       return {
         data: [],
-        error: e.message,
+        error: {
+          message: e instanceof Error ? e.message : String(e),
+        },
       }
     }
   },

--- a/packages/backend/tsconfig.strict.json
+++ b/packages/backend/tsconfig.strict.json
@@ -136,6 +136,7 @@
     "src/apps/telegram-bot/common/force-ipv4.ts",
     "src/apps/telegram-bot/common/interceptor/rate-limit.ts",
     "src/apps/telegram-bot/common/markdown-v1.ts",
+    "src/apps/telegram-bot/dynamic-data/get-chat-ids.ts",
     "src/apps/telegram-bot/dynamic-data/types.ts",
     "src/apps/telegram-bot/index.d.ts",
     "src/apps/tiles/actions/find-multiple-rows/schema.ts",


### PR DESCRIPTION
## Stack Context

Fifteenth PR in the backend strict-mode rollout (stacked on #2155).

## What?

- **`telegram-bot/dynamic-data/get-chat-ids.ts`**: fixes 6 strict-mode errors and adds the file to `tsconfig.strict.json`'s `include` list (it's a clean leaf — its whole import closure is already strict-clean).
  - `extractChatFromUpdate` genuinely returns `null` in 3 places; widened its return type to `ChatInfo | null`.
  - The `messageObject` local (an `||` chain over 6 optional `TelegramUpdate` fields) can be `undefined` if none are set; widened to `HasTelegramChat | undefined`.
  - `return { title: name || username, id }`: `name` is always a non-empty string (template literal), so `name || username` was dead fallback logic reading `username: string | undefined`. Simplified to `title: name`.
  - `catch (e)`: `e` is `unknown` under `useUnknownInCatchVariables`. Narrowed via `e instanceof Error`, and shaped the result as `{ message: ... }` to match `DynamicDataOutput.error: IJSONObject` (a raw string doesn't satisfy that type — matches the pattern used in `databricks/dynamic-data/list-table-columns.ts`).

## Why?

Straightforward leaf fix — the function already had defensive `null`-returning branches; the fixes just make the type signatures reflect that instead of asserting `ChatInfo`/`HasTelegramChat`/`string` outright.

Verified via an isolated `tsc` probe (zero errors), a full non-strict `typecheck` diff (zero regressions), `tsc -p tsconfig.strict.json` (passes with the file added to `include`), and the `apps/telegram-bot` test suite (22 tests, all passing).
