### PR TITLE
chore(backend): fix m365-excel strict-mode errors

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -24,8 +24,9 @@ function buildRowUpdateArgs(
   try {
     return constructMsGraphValuesArrayForRowWrite(...args)
   } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
     throw new StepError(
-      `Error creating table row: ${err.message}`,
+      `Error creating table row: ${errorMessage}`,
       'Double check that your step is configured correctly',
     )
   }
@@ -136,9 +137,13 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     if ($.execution.testRun) {
       // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user.email, $)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -88,9 +88,13 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user.email, $)
     }
 
     const parametersParseResult = lookupParametersSchema.safeParse(

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -31,7 +31,7 @@ const action: IRawAction = {
   arguments: [
     // We're doing an update based on results of our getTableRow action, so just
     // re-use its arguments.
-    ...getTableRowAction['arguments'],
+    ...(getTableRowAction['arguments'] ?? []),
     {
       key: 'columnsToUpdate' as const,
       label: 'Row data',
@@ -88,9 +88,13 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user.email, $)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/auth/get-system-added-connections.ts
+++ b/packages/backend/src/apps/m365-excel/auth/get-system-added-connections.ts
@@ -16,7 +16,7 @@ function getCurrentTenantKeys(connections: Connection[]): ReadonlySet<string> {
         (connection) =>
           connection.formattedData?.tenantKey as string | undefined | null,
       )
-      .filter((key) => !!key),
+      .filter((key): key is string => !!key),
   )
 }
 

--- a/packages/backend/src/apps/m365-excel/auth/is-still-verified.ts
+++ b/packages/backend/src/apps/m365-excel/auth/is-still-verified.ts
@@ -12,7 +12,10 @@ const isStillVerified: NonNullable<IAuth['isStillVerified']> = async function (
   if (!tenantKey || !isM365TenantKey(tenantKey)) {
     return false
   }
-  return (await getEligibleTenantKeys($.user?.email)).has(tenantKey)
+  if (!$.user) {
+    throw new Error('Connection is missing an owner')
+  }
+  return (await getEligibleTenantKeys($.user.email)).has(tenantKey)
 }
 
 export default isStillVerified

--- a/packages/backend/src/apps/m365-excel/auth/register-connection.ts
+++ b/packages/backend/src/apps/m365-excel/auth/register-connection.ts
@@ -13,8 +13,12 @@ const registerConnection: NonNullable<IAuth['registerConnection']> =
       return
     }
 
+    if (!$.user) {
+      throw new Error('Connection is missing an owner')
+    }
+
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
-    await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email)
+    await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user.email)
 
     const folderId = await createPlumberFolder(authData.tenantKey, $)
     $.auth.set({

--- a/packages/backend/src/apps/m365-excel/auth/verify-connection-registration.ts
+++ b/packages/backend/src/apps/m365-excel/auth/verify-connection-registration.ts
@@ -7,6 +7,10 @@ const verifyConnectionRegistration: NonNullable<
 > = async function ($) {
   const authData = $.auth.data as AuthData
 
+  if (!$.user) {
+    throw new Error('Connection is missing an owner')
+  }
+
   if (authData.folderId) {
     return {
       registrationVerified: true,

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -1,3 +1,5 @@
+import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
+
 // Needed to break circular import between auth.getSystemAddedConnections and
 // main app definition
 export const APP_KEY = 'm365-excel'
@@ -13,7 +15,7 @@ export const TEST_STEP_MAX_COLUMNS = 100
 
 export const MAX_LOOKUP_CONDITIONS = 3
 
-export const LOOKUP_CONDITIONS_SUBFIELDS = [
+export const LOOKUP_CONDITIONS_SUBFIELDS: IFieldMultiRowMultiColSubField[] = [
   {
     placeholder: 'Lookup column',
     key: 'lookupColumn',

--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -8,9 +8,10 @@ import { tryParseGraphApiError } from './parse-graph-api-error'
 async function checkForExistingFolder(
   $: IGlobalVariable,
   tenant: M365TenantInfo,
+  userEmail: string,
 ): Promise<string> {
   const filterQueryParams = new URLSearchParams({
-    filter: `name eq '${$.user.email}'`,
+    filter: `name eq '${userEmail}'`,
     select: 'id',
   }).toString()
 
@@ -30,9 +31,10 @@ export async function createPlumberFolder(
   tenantKey: string,
   $: IGlobalVariable,
 ): Promise<string> {
-  if (!$.user.email) {
+  if (!$.user?.email) {
     throw new Error('User email unavailable')
   }
+  const userEmail = $.user.email
 
   const tenant = getM365TenantInfo(tenantKey)
 
@@ -42,7 +44,7 @@ export async function createPlumberFolder(
     const createFolderResult = await $.http.post<{ id: string }>(
       '/v1.0/sites/:sharePointSiteId/drive/root/children',
       {
-        name: $.user.email,
+        name: userEmail,
         folder: {},
       },
       {
@@ -60,7 +62,7 @@ export async function createPlumberFolder(
       throw error
     }
 
-    folderId = await checkForExistingFolder($, tenant)
+    folderId = await checkForExistingFolder($, tenant, userEmail)
   }
 
   if (!folderId) {
@@ -73,7 +75,7 @@ export async function createPlumberFolder(
     await $.http.post(
       '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
       {
-        recipients: [{ email: $.user.email }],
+        recipients: [{ email: userEmail }],
         requireSignIn: true,
         sendInvitation: false,
         roles: ['sp.full control'],

--- a/packages/backend/src/apps/m365-excel/common/get-transfer-details.ts
+++ b/packages/backend/src/apps/m365-excel/common/get-transfer-details.ts
@@ -54,7 +54,9 @@ async function getTransferDetails(
       connectionName: results.data.name,
     }
   } catch (error) {
-    const errorCode = get(error, 'details.error.code', '')
+    // lodash.get can't infer a path's type through `unknown`, so it falls
+    // back to the default's literal type ('') instead of `string`.
+    const errorCode = get(error, 'details.error.code', '') as string
     logger.warn('Error with M365 excel before pipe transfer', {
       event: 'm365-excel-pipe-transfer',
       errorCode,

--- a/packages/backend/src/apps/m365-excel/common/oauth/token-cache.ts
+++ b/packages/backend/src/apps/m365-excel/common/oauth/token-cache.ts
@@ -34,7 +34,7 @@ export async function getAccessToken(
   }
   const cachedToken = cachedTokens[tenantKey]
 
-  if (Date.now() < cachedToken.token?.expiryTimestamp) {
+  if (cachedToken.token && Date.now() < cachedToken.token.expiryTimestamp) {
     return cachedToken.token.value
   }
 
@@ -43,7 +43,7 @@ export async function getAccessToken(
     // If multiple requests await this callback, then the 1st request would
     // have grabbed a new token before resolving. This check makes later
     // requests avoid grabbing a token again.
-    if (Date.now() < cachedToken.token?.expiryTimestamp) {
+    if (cachedToken.token && Date.now() < cachedToken.token.expiryTimestamp) {
       return
     }
 
@@ -51,5 +51,9 @@ export async function getAccessToken(
     cachedToken.token = await makeAccessTokenRequest(tenantKey, httpClient)
   })
 
-  return cachedTokens[tenantKey].token.value
+  const token = cachedTokens[tenantKey].token
+  if (!token) {
+    throw new Error(`Failed to obtain M365 access token for ${tenantKey}`)
+  }
+  return token.value
 }

--- a/packages/backend/src/apps/m365-excel/common/workbook-session/index.ts
+++ b/packages/backend/src/apps/m365-excel/common/workbook-session/index.ts
@@ -66,13 +66,17 @@ export default class WorkbookSession {
     $: IGlobalVariable,
     fileId: string,
   ): Promise<WorkbookSession> {
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     const authData = extractAuthDataWithPlumberFolder($)
 
     // We _always_ check against the server in case file sensitivity has changed
     // or it has been moved. This guards against things likes delayed actions
     // working on files whose sensitivity has been upgraded during the delay
     // period.
-    await validateCanAccessFile($.user?.email, authData, fileId, $.http)
+    await validateCanAccessFile($.user.email, authData, fileId, $.http)
 
     const tenant = getM365TenantInfo(authData.tenantKey)
     let sessionId = await getSessionIdFromRedis(tenant, fileId)

--- a/packages/backend/src/apps/m365-excel/common/workbook-session/redis.ts
+++ b/packages/backend/src/apps/m365-excel/common/workbook-session/redis.ts
@@ -35,11 +35,16 @@ export async function getSessionIdFromRedis(
 ): Promise<string | null> {
   const key = `${makeRedisKeyPrefix(tenant, fileId)}session:id`
 
-  const [[getErr, sessionId], [expireErr]] = await redisAppDataClient
+  const results = await redisAppDataClient
     .multi()
     .get(key)
     .expire(key, SESSION_ID_EXPIRY_SECONDS)
     .exec()
+
+  if (!results) {
+    throw new Error('Redis transaction was aborted')
+  }
+  const [[getErr, sessionId], [expireErr]] = results
 
   if (getErr) {
     throw getErr

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-table-columns/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-table-columns/index.ts
@@ -34,8 +34,12 @@ const dynamicData: IDynamicData = {
     // browsing through files, so directly invoke access validation.
     // FIXME (ogp-weeloong): move to a central file metadata cache to remove
     // need for this check
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     await validateCanAccessFile(
-      $.user?.email,
+      $.user.email,
       authData,
       fileId as string,
       $.http,

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-tables/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-tables/index.ts
@@ -34,8 +34,12 @@ const dynamicData: IDynamicData = {
     // browsing through files, so directly invoke access validation.
     // FIXME (ogp-weeloong): move to a central file metadata cache to remove
     // need for this check
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     await validateCanAccessFile(
-      $.user?.email,
+      $.user.email,
       authData,
       fileId as string,
       $.http,

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-worksheets/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-worksheets/index.ts
@@ -34,8 +34,12 @@ const dynamicData: IDynamicData = {
     // browsing through files, so directly invoke access validation.
     // FIXME (ogp-weeloong): move to a central file metadata cache to remove
     // need for this check
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     await validateCanAccessFile(
-      $.user?.email,
+      $.user.email,
       authData,
       fileId as string,
       $.http,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -507,7 +507,7 @@ export interface IFieldMultiSelect extends IBaseField {
   variableTypes?: TDataOutMetadatumType[]
 }
 
-type IFieldMultiRowMultiColSubField = IField & {
+export type IFieldMultiRowMultiColSubField = IField & {
   customStyle?: Record<string, string | number>
 }
 
@@ -1230,7 +1230,7 @@ export interface IRequest extends Request {
 
 export interface IVerifyConnectionRegistrationOutput {
   registrationVerified: boolean
-  message: string
+  message: string | null
 }
 
 export interface ITestConnectionOutput


### PR DESCRIPTION
## Stack Context

Seventeenth PR in the backend strict-mode rollout (stacked on #2158).

## What?

- **`$.user` guards**: `create-table-row`, `get-table-row`, `update-table-row` actions, `list-tables`/`list-worksheets`/`list-table-columns` dynamic-data, `workbook-session/index.ts` (`WorkbookSession.acquire`), `is-still-verified.ts`, `register-connection.ts`, `verify-connection-registration.ts` all read `$.user.email` without a guard. Added the standard `if (!$.user) throw new Error(...)` guard (same pattern as pair/postman) — verified each call site always builds `$` with a `user` (traced back to `graphql/queries/test-connection.ts`, `graphql/mutations/register-connection.ts`, `graphql/queries/get-dynamic-data.ts`, all of which always pass one).
- **`create-plumber-folder.ts`**: same `$.user` issue, but the helper `checkForExistingFolder` takes its own `$` param so the guard couldn't narrow across the function boundary. Threaded `userEmail: string` through as an explicit parameter instead.
- **`common/oauth/token-cache.ts`**: `Date.now() < cachedToken.token?.expiryTimestamp` short-circuits through optional chaining to `undefined` when there's no cached token yet; restructured to an explicit `cachedToken.token &&` guard, and added a should-never-happen throw after the mutex-guarded refresh (the type says the token could still be `null`, but the refresh always sets it).
- **`common/workbook-session/redis.ts`**: `ioredis`'s `.multi().exec()` returns `null` if the transaction aborts (e.g. a watched key changed); added an explicit guard before destructuring the result tuple.
- **`common/get-transfer-details.ts`**: `lodash.get(error, 'details.error.code', '')` can't infer a path's type through `error: unknown`, so it fell back to the default's literal type (`''`) for the whole expression, making a later `errorCode === 'itemNotFound'` comparison a type error (no overlap between `''` and `'itemNotFound'`). Cast to `string` with a comment — a real inference limitation of `lodash.get`+`unknown`, not a bypassed null check.
- **`auth/get-system-added-connections.ts`**: `.filter((key) => !!key)` doesn't narrow `(string | null | undefined)[]` — switched to a type predicate (`(key): key is string => !!key`).
- **`common/constants.ts`**: `LOOKUP_CONDITIONS_SUBFIELDS` (used by `get-table-row`/`get-table-rows`) had no explicit type, so TS inferred a combined `customStyle` shape across its two array elements with `minWidth?: undefined`, which doesn't satisfy `Record<string, string | number>`. Exported `IFieldMultiRowMultiColSubField` from `@plumber/types` (previously module-private) and annotated the array with it so each element type-checks against the right union member directly.
- **`types/index.d.ts`**: widened `IVerifyConnectionRegistrationOutput.message` from `string` to `string | null` — its one real implementation (`m365-excel/auth/verify-connection-registration.ts`) genuinely returns `null` on the unverified path, and the GraphQL schema's `message` field is already nullable.
- **`update-table-row/index.ts`**: `...getTableRowAction['arguments']` spreads `IRawAction['arguments']`, which is optional (`?: IField[]`) even though this specific action literal always sets it; added `?? []` rather than asserting non-null.

## Why?

Same apps+models entanglement as round 14 — none of this is added to `tsconfig.strict.json` yet.

Verified via an isolated `tsc` probe (all 17 files clean, cluster error count down from 133 to 107), a full non-strict `typecheck` diff (zero regressions — including for the two shared-type widenings), the full `apps/m365-excel` test suite (113 tests, all passing), and lint (clean).
