### PR TITLE
chore(backend): fix gathersg strict-mode errors

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -175,8 +175,10 @@ const action: IRawAction = {
       if (error instanceof HttpError) {
         throwGatherSGStepError(error)
       }
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
       throw new StepError(
-        `An error occurred: '${error.message}'`,
+        `An error occurred: '${errorMessage}'`,
         'Please check that you have configured your step correctly',
       )
     }

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -1,5 +1,6 @@
 import { IRawAction } from '@plumber/types'
 
+import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 
@@ -43,7 +44,7 @@ const action: IRawAction = {
         throw new StepError(
           `Invalid case uuid: ${caseUuid}`,
           'Please check that you have configured your step correctly',
-          error,
+          error instanceof HttpError ? error : undefined,
         )
       }
 
@@ -80,8 +81,10 @@ const action: IRawAction = {
         `Failed to get case details for case ${$.step.parameters.caseUuid}:`,
         error,
       )
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
       throw new StepError(
-        `An error occurred: '${error.message}'`,
+        `An error occurred: '${errorMessage}'`,
         'Please check that you have configured your step correctly',
       )
     }

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -79,8 +79,10 @@ const action: IRawAction = {
         throwGatherSGStepError(error)
       }
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
       throw new StepError(
-        `An error occurred: '${error.message}'`,
+        `An error occurred: '${errorMessage}'`,
         'Please check that you have configured your step correctly',
       )
     }

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -150,8 +150,10 @@ const action: IRawAction = {
         throwGatherSGStepError(error)
       }
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
       throw new StepError(
-        `An error occurred: '${error.message}'`,
+        `An error occurred: '${errorMessage}'`,
         'Please check that you have configured your step correctly',
       )
     }

--- a/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
+++ b/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
@@ -104,6 +104,11 @@ export async function decryptResponse(
   $: IGlobalVariable,
 ): Promise<{ verified: boolean; internalId: string | null }> {
   try {
+    if (!$.request) {
+      logger.error('No trigger item provided')
+      return { verified: false, internalId: null }
+    }
+
     const { app, data, encryptedData, signature, timestamp } = $.request.body
     const { encryptionKey } = $.step.parameters
 

--- a/packages/backend/src/apps/gathersg/auth/verify-api-key.ts
+++ b/packages/backend/src/apps/gathersg/auth/verify-api-key.ts
@@ -1,5 +1,7 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import HttpError from '@/errors/http'
+
 export async function verifyApiKey($: IGlobalVariable): Promise<void> {
   try {
     await $.http.post('/cases/search', {
@@ -7,11 +9,11 @@ export async function verifyApiKey($: IGlobalVariable): Promise<void> {
       size: 0,
     })
   } catch (err) {
-    if (err.response?.status === 401) {
+    if (err instanceof HttpError && err.response?.status === 401) {
       throw new Error(
         'API key is invalid, please ensure you have copied the correct API key',
       )
-    } else if (err.response?.status === 403) {
+    } else if (err instanceof HttpError && err.response?.status === 403) {
       throw new Error(
         'Please check that you have the correct permissions to access the Ownself Gather API e.g. view, update or tag cases',
       )

--- a/packages/backend/src/apps/gathersg/common/attachment.ts
+++ b/packages/backend/src/apps/gathersg/common/attachment.ts
@@ -2,6 +2,7 @@ import { IGlobalVariable, IJSONValue } from '@plumber/types'
 
 import { z } from 'zod'
 
+import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import { COMMON_S3_BUCKET, MAX_FILE_SIZE, putObject } from '@/helpers/s3'
@@ -90,7 +91,7 @@ async function downloadAndStoreAttachmentInS3(
     throw new StepError(
       `Failed to process attachment ${attachmentUuid} for case ${caseUuid}`,
       'Please check that your case attachments are accessible and try again.',
-      error,
+      error instanceof HttpError ? error : undefined,
     )
   }
 }

--- a/packages/backend/src/apps/gathersg/common/case-fields-schema.ts
+++ b/packages/backend/src/apps/gathersg/common/case-fields-schema.ts
@@ -67,7 +67,7 @@ const transformCaseFields = (params: CaseField[], context: z.RefinementCtx) => {
       }
       result[field] = emailResult.data
     } else {
-      result[field] = value
+      result[field] = value ?? null
     }
   }
   return result

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -156,9 +156,14 @@ const dynamicData: IDynamicData = {
         }
       }
 
+      const message = error instanceof Error ? error.message : undefined
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String(error.code)
+          : undefined
       return {
         data: [],
-        error: error?.message || error?.code || 'Unknown error',
+        error: { message: message || code || 'Unknown error' },
       }
     }
   },

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-statuses.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-statuses.ts
@@ -31,9 +31,14 @@ const dynamicData: IDynamicData = {
         })),
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : undefined
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String(error.code)
+          : undefined
       return {
         data: [],
-        error: error?.message || error?.code || 'Unknown error',
+        error: { message: message || code || 'Unknown error' },
       }
     }
   },

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-types.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-types.ts
@@ -61,9 +61,14 @@ const dynamicData: IDynamicData = {
 
       return { data: caseTypes }
     } catch (error) {
+      const message = error instanceof Error ? error.message : undefined
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String(error.code)
+          : undefined
       return {
         data: [],
-        error: error?.message || error?.code || 'Unknown error',
+        error: { message: message || code || 'Unknown error' },
       }
     }
   },

--- a/packages/backend/src/apps/gathersg/queue/index.ts
+++ b/packages/backend/src/apps/gathersg/queue/index.ts
@@ -12,6 +12,10 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async ({
 }) => {
   const step = await Step.query().findById(stepId).throwIfNotFound()
 
+  if (!step.connectionId) {
+    return undefined
+  }
+
   return {
     id: step.connectionId,
   }


### PR DESCRIPTION
## Stack Context

Eighteenth PR in the backend strict-mode rollout (stacked on #2159).

## What?

- **`dynamic-data/get-case-types.ts`, `get-case-statuses.ts`, `get-case-fields.ts`**: same `catch (error) { ...error?.message || error?.code...}` pattern as round 15's telegram-bot fix — `error` is `unknown`, and `DynamicDataOutput.error` wants `IJSONObject`, not a raw string. Narrowed via `instanceof Error` for `.message`, an `'code' in error` check for `.code`, and wrapped the result as `{ message: ... }`.
- **`actions/create-case`, `tag-or-untag-case`, `update-case`, `get-case-details`, `common/attachment.ts`**: narrowed caught `unknown` errors via `instanceof Error`/`instanceof HttpError` before reading `.message` or passing to `StepError`'s `error?: HttpError` param.
- **`auth/verify-api-key.ts`**: `err.response?.status` on an unknown catch var; narrowed via `instanceof HttpError`.
- **`auth/decrypt-response.ts`**: `$.request` is optional on `IGlobalVariable`; added the same `if (!$.request) return { verified: false, internalId: null }` guard formsg's `decryptFormResponse` already uses (this is also a webhook `verifyWebhook` implementation) — behaviourally identical since an unguarded `$.request.body` access would already throw into the same catch-all that returns the same result.
- **`common/case-fields-schema.ts`**: the fallback branch assigned `value: string | null | undefined` (from Zod's `.nullish()`) directly into a `Record<string, string | number | null>`; added `?? null` so a genuinely-missing value coalesces the same way the `'null'` fieldType branch already does.
- **`queue/index.ts`**: `getGroupConfigForJob` returned `{ id: step.connectionId }` where `connectionId` is `string | undefined` (a step's connection is optional); the interface wants `{id: string, ...} | undefined`, so returning `{id: undefined}` is exactly the wrong shape. Returns `undefined` outright when there's no connection.

## Why?

Same apps+models entanglement as round 14 — not added to `tsconfig.strict.json`.

Verified via an isolated `tsc` probe (all of gathersg clean, cluster count down from 107 to 88), a full non-strict `typecheck` diff (zero regressions), the full `apps/gathersg` test suite (115 tests, all passing), and lint (clean).
