### PR TITLE
chore(backend): fix scheduler trigger strict-mode errors

### DIFF
--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -41,7 +41,6 @@ const trigger: IRawTrigger = {
       type: 'dropdown' as const,
       description: TIME_OF_DAY_DESCRIPTION,
       required: true,
-      value: null,
       variables: false,
       showOptionValue: false,
       options: TIME_OF_DAY_OPTIONS,
@@ -58,6 +57,9 @@ const trigger: IRawTrigger = {
   },
 
   async run($) {
+    if (!this.getInterval) {
+      throw new Error('Trigger is missing getInterval')
+    }
     const nextCronDateTime = getNextCronDateTime(
       this.getInterval($.step.parameters),
     )

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -43,6 +43,9 @@ const trigger: IRawTrigger = {
   },
 
   async run($) {
+    if (!this.getInterval) {
+      throw new Error('Trigger is missing getInterval')
+    }
     const nextCronDateTime = getNextCronDateTime(
       this.getInterval($.step.parameters),
     )

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -23,7 +23,6 @@ const trigger: IRawTrigger = {
       type: 'dropdown' as const,
       description: 'What day of the month should this workflow start?',
       required: true,
-      value: null,
       variables: false,
       showOptionValue: false,
       options: [
@@ -159,7 +158,6 @@ const trigger: IRawTrigger = {
       type: 'dropdown' as const,
       description: TIME_OF_DAY_DESCRIPTION,
       required: true,
-      value: null,
       variables: false,
       showOptionValue: false,
       options: TIME_OF_DAY_OPTIONS,
@@ -177,6 +175,9 @@ const trigger: IRawTrigger = {
   },
 
   async run($) {
+    if (!this.getInterval) {
+      throw new Error('Trigger is missing getInterval')
+    }
     const nextCronDateTime = getNextCronDateTime(
       this.getInterval($.step.parameters),
     )

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -23,7 +23,6 @@ const trigger: IRawTrigger = {
       type: 'dropdown' as const,
       description: 'What day of the week should this workflow start?',
       required: true,
-      value: null,
       variables: false,
       showOptionValue: false,
       options: [
@@ -63,7 +62,6 @@ const trigger: IRawTrigger = {
       type: 'dropdown' as const,
       description: TIME_OF_DAY_DESCRIPTION,
       required: true,
-      value: null,
       variables: false,
       showOptionValue: false,
       options: TIME_OF_DAY_OPTIONS,
@@ -81,6 +79,9 @@ const trigger: IRawTrigger = {
   },
 
   async run($) {
+    if (!this.getInterval) {
+      throw new Error('Trigger is missing getInterval')
+    }
     const nextCronDateTime = getNextCronDateTime(
       this.getInterval($.step.parameters),
     )


### PR DESCRIPTION
## Stack Context

Nineteenth PR in the backend strict-mode rollout (stacked on #2160).

## What?

- **`triggers/every-day`, `every-hour`, `every-week`, `every-month`**: removed the `value: null` placeholder from dropdown arg definitions (same fix as round 16's auth fields — `IField.value` is optional, not nullable). Guarded `this.getInterval(...)` with a throw before calling it: `IRawTrigger.getInterval` is declared optional in the shared type (other triggers don't implement it), but each of these 4 literals always defines its own, so `this.getInterval` inside `run()` needed a should-never-happen check rather than an assertion.

## Why?

Same apps+models entanglement as round 14 — not added to `tsconfig.strict.json`.

Verified via an isolated `tsc` probe (all 4 files clean, cluster count down from 88 to 79), a full non-strict `typecheck` diff (zero regressions), the `apps/scheduler` test suite (8 tests, all passing), and lint (clean).
