### PR TITLE
chore(backend): fix remaining formsg strict-mode errors

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
@@ -35,7 +35,7 @@ export async function decryptFormAttachmentsV3OrV4(
   const decryptedAttachments: DecryptedAttachments = {}
 
   const filenames = formFields.reduce((acc, field) => {
-    if (field.fieldType === 'attachment') {
+    if (field.fieldType === 'attachment' && field.answer) {
       acc[field._id] = field.answer
     }
     return acc

--- a/packages/backend/src/apps/formsg/auth/helpers/compute-submission-time.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/compute-submission-time.ts
@@ -19,7 +19,7 @@ interface FormsgPayload {
  * This funciton returns the submission time based on whether it's an MRF or SRF form.
  */
 export function computeSubmissionTime(data: FormsgPayload): string {
-  const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
+  const workflowContent = data.workflowContent
 
   // If not MRF, just return submission creation time
   if (

--- a/packages/backend/src/apps/formsg/common/webhook-settings.ts
+++ b/packages/backend/src/apps/formsg/common/webhook-settings.ts
@@ -59,7 +59,7 @@ export function getFormDetailsFromGlobalVariable($: IGlobalVariable) {
 
 export async function registerWebhookUrl(
   $: IGlobalVariable,
-): ReturnType<IAuth['registerConnection']> {
+): ReturnType<NonNullable<IAuth['registerConnection']>> {
   const { userEmail, webhookUrl, formId, env } =
     getFormDetailsFromGlobalVariable($)
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
@@ -17,6 +17,9 @@ async function deleteAllStepsInMrfBranch(
   trx: Transaction,
 ) {
   const mrfStep = allSteps.find((step) => step.id === mrfStepId)
+  if (!mrfStep) {
+    throw new Error(`MRF step ${mrfStepId} not found in flow's steps`)
+  }
   const nextMrfStep = allSteps.find(
     (step) =>
       step.position > mrfStep.position &&
@@ -94,11 +97,13 @@ export async function createMrfSteps(
 
     // Delete steps that no longer exist in actions
     const stepsToDelete = existingMrfSteps.filter((step) => {
+      // lodash.get can't resolve a path's type through IJSONObject, so it
+      // falls back to a type far broader than the string this actually is.
       const formWorkflowStepId = get(
         step.parameters,
         'mrf.formWorkflowStepId',
         null,
-      )
+      ) as string | null
       return !formWorkflowStepId || !actionStepIds.has(formWorkflowStepId)
     })
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/fetch-form-schema.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/fetch-form-schema.ts
@@ -22,11 +22,14 @@ export async function fetchFormSchema(
       $.auth.data?.formId,
       e,
     )
-    if (e.response?.status === 404) {
-      if (e.response.data?.isPageFound) {
-        // form is valid but not public
-        throw new Error('Ensure form is public')
-      }
+    // Not narrowed to HttpError: some tests reject with a plain
+    // axios-response-shaped object rather than a real HttpError instance.
+    const response = (
+      e as { response?: { status?: number; data?: { isPageFound?: boolean } } }
+    )?.response
+    if (response?.status === 404 && response.data?.isPageFound) {
+      // form is valid but not public
+      throw new Error('Ensure form is public')
     }
     throw new Error('Unable to fetch form. Form might not exist.')
   }

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -107,6 +107,11 @@ function generateVerifiedSubmitterInfoData(
   $: IGlobalVariable,
 ): Record<string, Record<string, string>> {
   const filteredNric = filterNric($, MOCK_NRIC)
+  if (filteredNric === null) {
+    // NRIC filter is set to "Remove" - matches real decryption's behaviour of
+    // omitting the field entirely.
+    return {}
+  }
   switch (authType) {
     case 'SGID': // deprecated
     case 'SGID_MyInfo': // deprecated
@@ -189,7 +194,7 @@ function generateMockPaymentData(products: Partial<PaymentProduct>[]) {
       payer: 'payer@open.gov.sg',
       url: 'https://form.gov.sg/api/v3/payments/abcde/12345/invoice/download',
       paymentIntent: 'pi_12345',
-      amount: (firstProduct.amount_cents / 100).toFixed(2),
+      amount: ((firstProduct.amount_cents ?? 0) / 100).toFixed(2),
       productService: firstProduct.name,
       dateTime: new Date().toISOString(),
       transactionFee: '0.05',
@@ -277,6 +282,9 @@ function patchMockData(
       }
 
       if (mockData.responses[formFields[i]._id].fieldType === 'email') {
+        if (!$.user) {
+          throw new Error('Test run is missing the triggering user')
+        }
         mockData.responses[formFields[i]._id].answer = $.user.email
       }
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
@@ -11,7 +11,7 @@ import {
 export function parseWorkflowData(
   $: IGlobalVariable,
   formSchema: FormSchema,
-): ParsedMrfWorkflow | null {
+): ParsedMrfWorkflow {
   const result = mrfWorkflowDataSchema.safeParse(formSchema.form.workflow)
   if (!result.success) {
     throw new StepError(

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -115,10 +115,10 @@ const trigger: IRawTrigger = {
     if (
       formSchema.form.responseMode === 'multirespondent' &&
       // if the workflow is not set up, we treat it as a single respondent form
-      formSchema.form.workflow?.length > 0
+      (formSchema.form.workflow?.length ?? 0) > 0
     ) {
       // Create MRF steps for multirespondent forms
-      const mrfWorkflowData = await parseWorkflowData($, formSchema)
+      const mrfWorkflowData = parseWorkflowData($, formSchema)
       try {
         await createMrfSteps($, mrfWorkflowData)
       } catch (error) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1046,7 +1046,7 @@ export interface IActionOutput {
 }
 
 export interface IActionItem {
-  raw: IJSONObject
+  raw: IJSONObject | null
   meta?: IExecutionStepMetadata
 }
 
@@ -1230,7 +1230,7 @@ export interface IRequest extends Request {
 
 export interface IVerifyConnectionRegistrationOutput {
   registrationVerified: boolean
-  message: string | null
+  message: string | null | undefined
 }
 
 export interface ITestConnectionOutput


### PR DESCRIPTION
## Stack Context

Twentieth PR in the backend strict-mode rollout (stacked on #2161). Completes the formsg portion of the apps+models cluster started in round 14 (#2155).

## What?

- **`fetch-form-schema.ts`**: caught `unknown` error read `.response?.status`/`.response.data?.isPageFound`. First attempt narrowed via `instanceof HttpError`, but reverted to a duck-typed shape check after it broke a test (see Why).
- **`webhook-settings.ts`**: `registerWebhookUrl`'s `ReturnType<IAuth['registerConnection']>` hit the same optional-method `ReturnType` issue as round 14's `decrypt-form-response.ts` — fixed with `NonNullable<...>`. `verifyWebhookUrl`'s local `message` variable can stay `undefined` if neither branch of the if/else-if assigns it.
- **`decrypt-form-attachments-v3-or-v4.ts`**: `field.answer` is `string | undefined` per FormSG SDK's discriminated `FormField` type (the `fieldType === 'attachment'` check doesn't narrow it); guarded before assigning into a `Record<string, string>`.
- **`helpers/compute-submission-time.ts`**: removed a redundant explicit type annotation that widened `data.workflowContent` from optional to required.
- **`triggers/new-submission/create-mrf-steps.ts`**: `Array.find()` result used without a null check for `mrfStep` (should-never-happen, added a throw); `lodash.get(step.parameters, ..., null)` can't resolve a path's type through `IJSONObject`, so it infers a type far broader than the actual `string`, needing a cast.
- **`triggers/new-submission/get-mock-data.ts`**: `filterNric` returning `null` (NRIC filter set to "Remove") wasn't handled in the MyInfo mock-data generator — now mirrors real decryption's behaviour of omitting the field; guarded `$.user` before reading `.email` in the same should-never-happen style as other test-run code; defaulted `firstProduct.amount_cents` to `0` since the ternary's fallback branch loses its literal narrowing.
- **`triggers/new-submission/get-workflow-data.ts`**: `parseWorkflowData` was typed `ParsedMrfWorkflow | null` but never actually returns `null` (it throws on invalid data) — narrowed the return type to match reality instead of adding a dead null-check at the one call site.
- **`triggers/new-submission/index.ts`**: `formSchema.form.workflow?.length > 0` treated the optional-chained `undefined` as unconditionally comparable; added `?? 0`.
- **`types/index.d.ts`**: widened `IActionItem.raw` to `IJSONObject | null` — `raw: null` is already relied on unchecked in `helpers/global-variable.ts`'s default `actionOutput` and used 3x in `mrf-submission/index.ts`. Widened `IVerifyConnectionRegistrationOutput.message` to `string | null | undefined` — its two real implementations (m365-excel returns `null`, formsg returns `undefined`) disagree on the "no message" sentinel.

## Why?

**Caught two regressions via the test suite before committing.** First: narrowing `fetch-form-schema.ts`'s catch via `instanceof HttpError` broke `verify-credentials.test.ts`'s "should throw an error if form is not public" test, which rejects with a plain `{response: {status, data}}` object rather than a real `HttpError` — reverted to a duck-typed shape check, since the original code's actual behavior worked against any object shaped like an HTTP error response, not just nominal `HttpError` instances. Second: coercing `webhook-settings.ts`'s `message` to `?? null` broke `webhook-settings.test.ts`'s "should return false if webhook url is not set" test, which expects `message: undefined` via `toEqual` (which treats `undefined` specially but not `null`) — fixed by widening the shared type to accept both conventions instead of forcing one implementation to match the other's.

Verified via an isolated `tsc` probe (formsg cluster fully clean, cluster count down from 79 to 58 — the full apps/models cluster's formsg portion is now done), a full non-strict `typecheck` diff (zero regressions across both fix iterations), the full `apps/formsg` (303 tests) and `apps/m365-excel` (113 tests, re-checked after the second shared-type change) suites, and lint (clean).
