### PR TITLE
chore(backend): fix remaining small-app strict-mode errors

### DIFF
--- a/packages/backend/src/apps/custom-api/common/check-urls.ts
+++ b/packages/backend/src/apps/custom-api/common/check-urls.ts
@@ -12,6 +12,10 @@ import {
 import { isIpAllowed } from './ip-resolver'
 
 const checkUrls: TBeforeRequest = async ($, requestConfig) => {
+  if (!requestConfig.baseURL) {
+    throw new Error(INVALID_URL_ERROR)
+  }
+
   // Prohibit calling ourselves to prevent self-DoS.
   if (requestConfig.baseURL.toLowerCase().endsWith('plumber.gov.sg')) {
     throw new Error(RECURSIVE_WEBHOOK_ERROR)

--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -142,7 +142,8 @@ const createRowAction: IRawAction = {
         testRun: $.execution?.testRun,
         error: e,
       })
-      throw new StepError('Failed to create row', e.message)
+      const errorMessage = e instanceof Error ? e.message : String(e)
+      throw new StepError('Failed to create row', errorMessage)
     } finally {
       await endSession()
     }

--- a/packages/backend/src/apps/databricks/auth/create-client.ts
+++ b/packages/backend/src/apps/databricks/auth/create-client.ts
@@ -43,7 +43,7 @@ export const createSession = async (
     token,
   } satisfies ConnectionOptions
 
-  let connectedClient: IDBSQLClient
+  let connectedClient: IDBSQLClient | undefined
   try {
     connectedClient = await client.connect(connectOptions)
     const session = await connectedClient.openSession({
@@ -53,7 +53,7 @@ export const createSession = async (
     const endSession = async () => {
       try {
         await session.close()
-        await connectedClient.close()
+        await connectedClient?.close()
       } catch (e) {
         logger.warn('Unable to close session', e)
       }

--- a/packages/backend/src/apps/databricks/auth/is-still-verified.ts
+++ b/packages/backend/src/apps/databricks/auth/is-still-verified.ts
@@ -5,6 +5,10 @@ import Connection from '@/models/connection'
 import { checkSchemaExists } from './check-schema-exists'
 
 const isStillVerified = async ($: IGlobalVariable) => {
+  if (!$.auth.connectionId) {
+    return false
+  }
+
   const databricksConnection = await Connection.query().findById(
     $.auth.connectionId,
   )

--- a/packages/backend/src/apps/databricks/dynamic-data/create-table.ts
+++ b/packages/backend/src/apps/databricks/dynamic-data/create-table.ts
@@ -21,6 +21,10 @@ const dynamicData: IDynamicAction = {
   key: 'databricks-createTable',
   type: 'action',
   async run($: IGlobalVariable): Promise<IJSONObject> {
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+
     const parametersParseResult = createTableSchema.safeParse({
       ...$.step.parameters,
       userEmail: $.user.email,

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/transform-data.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/transform-data.ts
@@ -82,8 +82,9 @@ export const transformData: TransformSpec['transformData'] = async (
       throw error
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error)
     throw new StepError(
-      `Error processing dates: '${error.message}'`,
+      `Error processing dates: '${errorMessage}'`,
       'Ensure that you have selected the correct date format, and that time periods to add / subtract are valid numbers.',
     )
   }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -58,8 +58,10 @@ export const spec = {
         throw error
       }
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
       throw new StepError(
-        `Error with the original value: '${error.message}'`,
+        `Error with the original value: '${errorMessage}'`,
         'Ensure that you have selected the correct date format for your original value.',
       )
     }

--- a/packages/backend/src/apps/lettersg/auth/verify-api-key.ts
+++ b/packages/backend/src/apps/lettersg/auth/verify-api-key.ts
@@ -1,10 +1,12 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import HttpError from '@/errors/http'
+
 export async function verifyApiKey($: IGlobalVariable): Promise<void> {
   try {
     await $.http.get('/v1/templates?limit=1')
   } catch (err) {
-    if (err.response.status === 401) {
+    if (err instanceof HttpError && err.response?.status === 401) {
       throw new Error(
         'API key is invalid, please ensure you have copied the correct API key',
       )

--- a/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
@@ -37,7 +37,9 @@ const dynamicData: IDynamicData = {
     } catch (error) {
       return {
         data: [],
-        error: error.message,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+        },
       }
     }
   },

--- a/packages/backend/src/apps/lettersg/dynamic-data/get-template-ids.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/get-template-ids.ts
@@ -29,7 +29,9 @@ const dynamicData: IDynamicData = {
     } catch (error) {
       return {
         data: [],
-        error: error.message,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+        },
       }
     }
   },

--- a/packages/backend/src/apps/paysg/common/schemas/payment.ts
+++ b/packages/backend/src/apps/paysg/common/schemas/payment.ts
@@ -17,7 +17,7 @@ export const schema = z
   .transform((data) => ({
     id: data.id,
     paymentUrl: data.payment_url,
-    stripePaymentIntentId: data.stripe_payment_intent_id,
+    stripePaymentIntentId: data.stripe_payment_intent_id ?? null,
     paymentQrCodeUrl: data.payment_qr_code_url,
     amountInDollars: (data.amount_in_cents / 100).toFixed(2),
     amountInCents: data.amount_in_cents,

--- a/packages/backend/src/apps/postman-sms/auth/is-still-verified.ts
+++ b/packages/backend/src/apps/postman-sms/auth/is-still-verified.ts
@@ -4,9 +4,9 @@ import HttpError from '@/errors/http'
 
 import { authDataSchema } from './schema'
 
-const isStillVerified: IUserAddedConnectionAuth['isStillVerified'] = async (
-  $: IGlobalVariable,
-) => {
+const isStillVerified: NonNullable<
+  IUserAddedConnectionAuth['isStillVerified']
+> = async ($: IGlobalVariable) => {
   const { campaignId } = authDataSchema.parse($.auth.data)
 
   try {

--- a/packages/backend/src/apps/postman-sms/queue/index.ts
+++ b/packages/backend/src/apps/postman-sms/queue/index.ts
@@ -8,6 +8,10 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async ({
 }) => {
   const step = await Step.query().findById(stepId).throwIfNotFound()
 
+  if (!step.connectionId) {
+    return undefined
+  }
+
   return {
     // Each connection ID should, _in theory_, represent a different campaign.
     //

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -1,5 +1,6 @@
 import { IRawAction } from '@plumber/types'
 
+import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 
@@ -95,6 +96,9 @@ const action: IRawAction = {
         raw: response.data,
       })
     } catch (err) {
+      if (!(err instanceof HttpError)) {
+        throw err
+      }
       await throwSendMessageError(err, $.step, $.execution.testRun)
     }
   },

--- a/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
+++ b/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
@@ -106,7 +106,10 @@ function handleHttpError(
   }
 
   // Handle retriable status codes
-  if (RETRIABLE_STATUS_CODES.includes(executionError.response?.status)) {
+  if (
+    executionError.response?.status !== undefined &&
+    RETRIABLE_STATUS_CODES.includes(executionError.response.status)
+  ) {
     throw new RetriableError({
       error: errorDetails,
       delayInMs: 'default',


### PR DESCRIPTION
## Stack Context

Twenty-first PR in the backend strict-mode rollout (stacked on #2162). Clears every non-Tiles file in the apps+models cluster started in round 14 (#2155) — only Tiles remains before that whole cluster can be gated into `tsconfig.strict.json` at once.

## What?

- **`custom-api/common/check-urls.ts`**: `requestConfig.baseURL` is optional on axios's config type; added a guard before use (an interceptor with no base URL can't make a request anyway).
- **`databricks/actions/create-row.ts`, `auth/is-still-verified.ts`, `dynamic-data/create-table.ts`**: unknown-error narrowing, an `$.auth.connectionId` guard (returns `false` — can't verify a connection that doesn't exist), and the standard `$.user` guard.
- **`databricks/auth/create-client.ts`**: `connectedClient` was `let connectedClient: IDBSQLClient` with no initializer, read via a truthy check in the catch block — TS's definite-assignment analysis flags this even though `let x: T` is genuinely `undefined` at runtime until assigned. Retyped as `IDBSQLClient | undefined`; the same variable is also read from inside a nested closure (`endSession`), where TS narrowing doesn't cross the function boundary — switched that read to optional chaining.
- **`formatter`'s `add-subtract-date-time`/`convert-date-time`, `lettersg`'s `verify-api-key`/`get-template-fields`/`get-template-ids`, `postman-sms/auth/is-still-verified.ts`**: unknown-error narrowing (`instanceof Error`/`instanceof HttpError`), plus the `DynamicDataOutput.error: IJSONObject` wrapping fix from round 15/18 for lettersg's two dynamic-data files.
- **`postman-sms/auth/is-still-verified.ts`**: typed its own const via the interface's *optional* method signature (`IUserAddedConnectionAuth['isStillVerified']`, which includes `| undefined`) even though the const itself always has a value; switched to `NonNullable<...>`.
- **`postman-sms/queue/index.ts`**: same `getGroupConfigForJob` fix as round 18's gathersg — returns `undefined` instead of `{id: undefined}` when a step has no connection.
- **`telegram-bot/actions/send-message/index.ts`**: `throwSendMessageError` requires a real `HttpError`; added an `instanceof` guard at the one call site instead of loosening that function's already-`HttpError`-only internals (it unconditionally reads `.response.status` etc, so it never handled non-`HttpError` cases anyway).
- **`helpers/actions/handle-failed-step-and-throw.ts`**: `RETRIABLE_STATUS_CODES.includes(x)` where `x: number | undefined`; added an explicit `!== undefined` check.
- **`paysg/common/schemas/payment.ts`**: the response-schema transform passed a `.nullish()` Zod field straight through, producing `string | null | undefined` where `IJSONObject` only allows `string | null`; added `?? null` (this one file backs both `get-payment` and `create-payment`'s actions).

## Why?

Same apps+models entanglement as round 14 — not added to `tsconfig.strict.json` yet (Tiles is the last piece).

Verified via an isolated `tsc` probe (every non-Tiles file in the cluster now clean — remaining count is 100% Tiles), a full non-strict `typecheck` diff (zero regressions), the full test suites for every touched app (319 tests, all passing, including paysg's shared-schema change), and lint (clean).
