### PR TITLE
chore(backend): fix apps/tiles strict-mode errors

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/queue.test.ts
+++ b/packages/backend/src/apps/tiles/__tests__/queue.test.ts
@@ -42,7 +42,7 @@ describe('Queue config', () => {
     })
   })
 
-  it('sets group ID to null', async () => {
+  it('sets group ID to undefined', async () => {
     mocks.stepQueryResult.mockResolvedValueOnce({
       parameters: {
         tableId: 'mock-table-id',
@@ -55,7 +55,7 @@ describe('Queue config', () => {
       stepId: 'test-step-id',
       executionId: 'test-step-id',
     })
-    expect(groupConfig).toEqual(null)
+    expect(groupConfig).toEqual(undefined)
   })
 
   it('sets group concurrency to 1', () => {

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -108,7 +108,10 @@ const action: IRawAction = {
       )
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+    await TableCollaborator.hasAccess($.user.id, tableId, 'editor', $)
 
     /**
      * convert array to object

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -104,7 +104,10 @@ const action: IRawAction = {
       )
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+    await TableCollaborator.hasAccess($.user.id, tableId, 'editor', $)
 
     // Check that filters are valid
     try {
@@ -125,7 +128,7 @@ const action: IRawAction = {
     }
     // Retrieve the manual scan limit override, converting it to a number.
     // If the conversion results in NaN, we set scanLimit to undefined.
-    const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
+    const scanLimitRaw = +(step.config?.adminOverride?.tileScanLimit ?? NaN)
     const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
 
     const tableOperations = getTableOperations(table.db)

--- a/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
@@ -26,7 +26,10 @@ async function getDataOutMetadata(
       order: 1,
     },
   }
-  const rowData = (dataOut as FindSingleRowOutput).row
+  const rowData = (dataOut as unknown as FindSingleRowOutput).row
+  if (!rowData) {
+    return null
+  }
   const columnNameMetadata = await generateColumnNameMetadata(rowData)
 
   return { ...metadata, ...columnNameMetadata }

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -98,7 +98,10 @@ const action: IRawAction = {
       )
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+    await TableCollaborator.hasAccess($.user.id, tableId, 'editor', $)
 
     // Check that filters are valid
     try {
@@ -119,7 +122,7 @@ const action: IRawAction = {
     }
     // Retrieve the manual scan limit override, converting it to a number.
     // If the conversion results in NaN, we set scanLimit to undefined.
-    const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
+    const scanLimitRaw = +(step.config?.adminOverride?.tileScanLimit ?? NaN)
     const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
 
     const tableOperations = getTableOperations(table.db)
@@ -158,6 +161,13 @@ const action: IRawAction = {
       rowId: rowIdToUse,
       columnIds: table.columns.map((c) => c.id),
     })
+
+    if (!rowToReturn) {
+      throw new StepError(
+        'Row not found',
+        'Row may have been deleted. Please try again.',
+      )
+    }
 
     $.setActionItem({
       raw: {

--- a/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
@@ -26,7 +26,10 @@ async function getDataOutMetadata(
       order: 1,
     },
   }
-  const rowData = (dataOut as UpdateRowOutput).row
+  const rowData = (dataOut as unknown as UpdateRowOutput).row
+  if (!rowData) {
+    return null
+  }
   const columnNameMetadata = await generateColumnNameMetadata(rowData)
 
   return { ...metadata, ...columnNameMetadata }

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -153,7 +153,10 @@ const action: IRawAction = {
 
     const columnIds = table.columns.map((c) => c.id)
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+    if (!$.user) {
+      throw new Error('Flow is missing an owner')
+    }
+    await TableCollaborator.hasAccess($.user.id, tableId, 'editor', $)
 
     /**
      * Row ID is empty, this could be because the previous get single row action

--- a/packages/backend/src/apps/tiles/common/constants.ts
+++ b/packages/backend/src/apps/tiles/common/constants.ts
@@ -1,4 +1,7 @@
-import { IFieldVisibilityCondition } from '@plumber/types'
+import {
+  IFieldMultiRowMultiColSubField,
+  IFieldVisibilityCondition,
+} from '@plumber/types'
 
 import { TableRowFilterOperator } from '@/models/tiles/types'
 
@@ -8,7 +11,7 @@ export const DYNAMODB_DEFAULT_PAGINATION_CURSOR = 'start' as const
 
 export const FIND_MULTIPLE_ROWS_LIMIT = 500
 
-export const LOOKUP_CONDITIONS_SUBFIELDS = [
+export const LOOKUP_CONDITIONS_SUBFIELDS: IFieldMultiRowMultiColSubField[] = [
   {
     placeholder: 'Column',
     key: 'columnId',

--- a/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
@@ -21,7 +21,9 @@ const dynamicData: IDynamicData = {
     }
 
     try {
-      const currentUser = await User.query().findById($.user.id)
+      const currentUser = await User.query()
+        .findById($.user.id)
+        .throwIfNotFound()
       const tile = await currentUser
         .$relatedQuery('tables')
         .findById($.step.parameters.tableId as string)
@@ -41,16 +43,14 @@ const dynamicData: IDynamicData = {
         })),
       }
     } catch (err) {
-      logger.error(
-        err.data.message ?? 'Tiles dynamic data: list columns error',
-        {
-          userId: $.user?.id,
-          tableId: $.step.parameters.tableId,
-          flowId: $.flow?.id,
-          stepId: $.step?.id,
-        },
-      )
-      throw new Error(err.data.message ?? 'Unable to fetch columns')
+      const errorMessage = err instanceof Error ? err.message : undefined
+      logger.error(errorMessage ?? 'Tiles dynamic data: list columns error', {
+        userId: $.user?.id,
+        tableId: $.step.parameters.tableId,
+        flowId: $.flow?.id,
+        stepId: $.step?.id,
+      })
+      throw new Error(errorMessage ?? 'Unable to fetch columns')
     }
   },
 }

--- a/packages/backend/src/apps/tiles/dynamic-data/list-tables.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-tables.ts
@@ -16,7 +16,9 @@ const dynamicData: IDynamicData = {
       throw new Error('No user found')
     }
     try {
-      const currentUser = await User.query().findById($.user.id)
+      const currentUser = await User.query()
+        .findById($.user.id)
+        .throwIfNotFound()
       const tiles = await currentUser
         .$relatedQuery('tables')
         .whereIn('role', ['owner', 'editor'])

--- a/packages/backend/src/apps/tiles/queue/index.ts
+++ b/packages/backend/src/apps/tiles/queue/index.ts
@@ -20,7 +20,7 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
   const step = await Step.query().findById(jobData.stepId).throwIfNotFound()
   const tableId = step.parameters['tableId'] as string
 
-  if (QUEUED_ACTIONS.has(step.key)) {
+  if (step.key && QUEUED_ACTIONS.has(step.key)) {
     return {
       id: `${tableId}-${step.key}`,
     }
@@ -28,7 +28,7 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
 
   // All other Tile actions are not grouped and do not need to be rate limited
   // as the write operations are fast and less expensive.
-  return null
+  return undefined
 }
 
 const queueSettings = {

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -3,7 +3,7 @@ import { IJSONObject } from '@plumber/types'
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 import { TableRowOutput } from '@/models/tiles/types'
 
-export interface FindSingleRowOutput extends IJSONObject {
+export interface FindSingleRowOutput {
   rowsFound: number
   rowId?: string
   row?: Record<string, string | number>
@@ -15,7 +15,7 @@ export type TileColumnMetadata = {
   value: string
 }
 
-export interface FindMultipleRowsOutput extends IJSONObject {
+export interface FindMultipleRowsOutput {
   rowsFound: number
   data?: {
     rows: TableRowOutput[]
@@ -29,7 +29,7 @@ export interface CreateRowOutput extends IJSONObject {
   row: Record<string, string | number>
 }
 
-export interface UpdateRowOutput extends IJSONObject {
+export interface UpdateRowOutput {
   rowId?: string
   row?: Record<string, string | number>
   updated: boolean


### PR DESCRIPTION
## Stack Context

Twenty-second PR in the backend strict-mode rollout (stacked on #2163). Clears every `apps/tiles/*` file in the cluster started in round 14 (#2155) — only `models/tiles/*` (~18 errors, ElectroDB/Objection generics, its own specialized round) remains before the whole apps+models cluster can be gated into `tsconfig.strict.json` at once.

## What?

- **`types/index.ts`**: `FindSingleRowOutput`, `FindMultipleRowsOutput`, `UpdateRowOutput` all `extends IJSONObject` with optional fields (`rowId?`, `row?`, `data?`) — optional properties are internally `T | undefined`, and `IJSONObject`'s `[x: string]: IJSONValue` index signature doesn't allow `undefined`, so declaring the interface this way always fails (TS2411), regardless of how it's used. Dropped `extends IJSONObject` from these three (kept it on `CreateRowOutput`, whose fields are all required). Compatibility with `$.setActionItem({ raw: IJSONObject })` still holds at every call site because TS's structural check for a *fresh object literal* against an index-signature type is looser than the check for a *named interface* against one — verified this empirically rather than assuming it.
- **`common/constants.ts`**: same `LOOKUP_CONDITIONS_SUBFIELDS` fix as round 17's m365-excel — exported `IFieldMultiRowMultiColSubField` annotation instead of letting TS infer a too-narrow combined `customStyle` shape.
- **`actions/create-row`, `find-single-row`, `find-multiple-rows`, `update-row`**: added the standard `$.user` guard before `TableCollaborator.hasAccess($.user.id, ...)` (all 4 actions had the same unguarded `$.user?.id`). `find-single-row`/`find-multiple-rows` also needed a `?? NaN` fallback for a unary-`+` scan-limit override read through two optional-chains, and `find-single-row` added a should-never-happen guard for `getRawRowById` returning `null` for a row we just found moments ago.
- **`actions/find-single-row/get-data-out-metadata.ts`, `update-row/get-data-out-metadata.ts`**: `dataOut as FindSingleRowOutput`/`as UpdateRowOutput` broke once those types stopped extending `IJSONObject` (the cast source and target no longer "sufficiently overlap"); went through `as unknown as X` instead, plus an explicit `row` null-check before calling `generateColumnNameMetadata` (its param is required, but `.row` is optional on both types).
- **`dynamic-data/list-columns.ts`, `list-tables.ts`**: `User.query().findById(...)` returns `User | undefined`; added `.throwIfNotFound()`. `list-columns.ts`'s catch block read `err.data.message` off an untyped catch var — since Objection's `NotFoundError` sets `.data.message` to the same string it passes to `Error`'s own constructor, switched to `err instanceof Error ? err.message : undefined`, which is equivalent and properly typed.
- **`queue/index.ts`**: `QUEUED_ACTIONS.has(step.key)` where `step.key` is optional; added a truthiness check first. Returned `undefined` instead of `null` for "no group" (see Why).

## Why?

**Caught and fixed a real test/type mismatch.** `queue.test.ts`'s "sets group ID to null" test asserted `toEqual(null)`, but the interface's actual type (BullMQ Pro's `JobsProOptions['group']`) is `{...} | undefined` — no `null` in the union. Traced the one real consumer (`queues/action.ts`'s `...(groupConfig ? { group: groupConfig } : {})`) and confirmed it treats `null` and `undefined` identically via a truthy check, so switching the implementation to return `undefined` and updating the test to match is a type-correctness fix with zero behavior change, not a loosened assertion.

Verified via an isolated `tsc` probe (every `apps/tiles/*` file clean — remaining cluster errors are 100% `models/tiles/*`), a full non-strict `typecheck` diff (zero regressions across two iterations), the `apps/tiles` test suite (3 tests, all passing after the queue-test fix), and lint (clean).
