### PR TITLE
chore(backend): fix global-variable.ts + remaining strays, complete apps/models

### DIFF
--- a/packages/backend/src/apps/aisay/actions/use-specific-model/index.ts
+++ b/packages/backend/src/apps/aisay/actions/use-specific-model/index.ts
@@ -34,7 +34,7 @@ const action: IRawAction = {
     },
   ],
   doesFileProcessing: (step: Step) => {
-    return step.parameters.file && step.parameters.file !== ''
+    return Boolean(step.parameters.file && step.parameters.file !== '')
   },
   async run(_) {
     throwAisayDeprecationError()

--- a/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-create-step.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/infra/handle-create-step.ts
@@ -90,6 +90,12 @@ export async function fixupEndStepOnCreateStep({
     const preBlockStep = preInsertSteps.find(
       (step) => step.id === previousBlockId,
     )
+    if (!preBlockStep) {
+      rejectEndStepWrite('previous-block-not-found', {
+        previousBlockId,
+        flowId,
+      })
+    }
     const derivedEndStep = deriveIfThenV1EndStep(preInsertSteps, preBlockStep)
     if (previousStep.id !== derivedEndStep.id) {
       rejectEndStepWrite('previous-step-not-block-end', {

--- a/packages/backend/src/apps/toolbox/common/validate-end-step.ts
+++ b/packages/backend/src/apps/toolbox/common/validate-end-step.ts
@@ -376,11 +376,14 @@ export async function deriveV1EndStepDroppingBlankMembers(
   const refetchedSteps = (
     await flow.$relatedQuery('steps', trx).orderBy('position', 'asc')
   ).filter((step) => !excludeStepIds.has(step.id))
+  const refetchedIfThenStep = refetchedSteps.find(
+    (step) => step.id === ifThenStep.id,
+  )
+  if (!refetchedIfThenStep) {
+    throw new Error(`If-then step ${ifThenStep.id} not found after refetch`)
+  }
   return {
-    endStep: deriveIfThenV1EndStep(
-      refetchedSteps,
-      refetchedSteps.find((step) => step.id === ifThenStep.id),
-    ),
+    endStep: deriveIfThenV1EndStep(refetchedSteps, refetchedIfThenStep),
     cleaned: true,
   }
 }
@@ -427,6 +430,9 @@ export async function upgradeIfThenV1BlocksIfEnabled(
     const liveIfThenStep = currentSteps.find(
       (step) => step.id === ifThenStep.id,
     )
+    if (!liveIfThenStep) {
+      throw new Error(`If-then step ${ifThenStep.id} not found in flow steps`)
+    }
     const { endStep, cleaned } = await deriveV1EndStepDroppingBlankMembers(
       trx,
       flow,

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -44,7 +44,6 @@ const globalVariable = async (
     metadata,
   } = options
 
-  const isTrigger = step?.isTrigger
   const nextStep = await step?.getNextStep()
 
   // http is attached below via mutation, since createHttpClient captures $ by
@@ -61,7 +60,7 @@ const globalVariable = async (
             },
           })
 
-          $.auth.data = connection.formattedData
+          $.auth.data = connection.formattedData ?? {}
         }
 
         return null
@@ -110,7 +109,7 @@ const globalVariable = async (
       }
       return (
         await step?.getLastExecutionStep({
-          executionId: options?.sameExecution ? execution.id : undefined,
+          executionId: options?.sameExecution ? execution?.id : undefined,
           testRunOnly: options?.testRunOnly,
           additionalFilter: options?.additionalFilter,
           iteration: options?.iteration,
@@ -153,7 +152,7 @@ const globalVariable = async (
     $,
     baseURL: app.apiBaseUrl,
     beforeRequest: app.beforeRequest ?? [],
-    requestErrorHandler: app.requestErrorHandler ?? null,
+    requestErrorHandler: app.requestErrorHandler,
   })
 
   if (flow) {
@@ -161,29 +160,32 @@ const globalVariable = async (
     $.webhookUrl = webhookUrl
   }
 
-  if (isTrigger && (await step.getTriggerCommand()).type === 'webhook') {
-    $.flow.setRemoteWebhookId = async (remoteWebhookId) => {
-      await flow.$query().patchAndFetch({
-        remoteWebhookId,
-      })
+  if (flow && step?.isTrigger) {
+    const triggerCommand = await step.getTriggerCommand()
+    if (triggerCommand?.type === 'webhook') {
+      $.flow.setRemoteWebhookId = async (remoteWebhookId) => {
+        await flow.$query().patchAndFetch({
+          remoteWebhookId,
+        })
 
-      $.flow.remoteWebhookId = remoteWebhookId
+        $.flow.remoteWebhookId = remoteWebhookId
+      }
+
+      $.flow.remoteWebhookId = flow.remoteWebhookId
     }
-
-    $.flow.remoteWebhookId = flow.remoteWebhookId
   }
 
   // Fetch and cache last internal ids for isAlreadyProcessed
-  let lastInternalIds: string[] | undefined
+  let lastInternalIds: (string | null | undefined)[] | undefined
 
   const isAlreadyProcessed = async (internalId: string): Promise<boolean> => {
-    if (testRun || (flow && step.isAction)) {
+    if (testRun || (flow && step?.isAction)) {
       return false
     }
     if (!lastInternalIds) {
       lastInternalIds = await flow?.lastInternalIds(500)
     }
-    return lastInternalIds?.includes(internalId)
+    return lastInternalIds?.includes(internalId) ?? false
   }
 
   return $

--- a/packages/backend/src/models/app.ts
+++ b/packages/backend/src/models/app.ts
@@ -46,7 +46,8 @@ class App {
       const app = await this.findOneByKey(appKey)
       return (
         app.triggers?.find((trigger) => trigger.key === key) ||
-        app.actions?.find((action) => action.key === key)
+        app.actions?.find((action) => action.key === key) ||
+        null
       )
     } catch {
       logger.error({
@@ -60,11 +61,11 @@ class App {
   }
 
   static getAllAppsWithFunctions = memoize(async () => {
-    return await this.findAll(null, false)
+    return await this.findAll(undefined, false)
   })
 
   static getAllAppsWithConnections = memoize(async () => {
-    const allApps = await this.findAll(null, false)
+    const allApps = await this.findAll(undefined, false)
     return allApps.filter((app) => app.auth)
   })
 }

--- a/packages/backend/tsconfig.strict.json
+++ b/packages/backend/tsconfig.strict.json
@@ -320,6 +320,11 @@
     "src/apps/databricks/auth/is-still-verified.ts",
     "src/apps/databricks/auth/create-client.ts",
     "src/apps/databricks/actions/create-row.ts",
-    "src/apps/formsg/auth/decrypt-form-response.ts"
+    "src/apps/formsg/auth/decrypt-form-response.ts",
+    "src/apps/aisay/actions/use-specific-model/index.ts",
+    "src/apps/toolbox/actions/if-then/infra/handle-create-step.ts",
+    "src/apps/toolbox/common/validate-end-step.ts",
+    "src/helpers/global-variable.ts",
+    "src/models/app.ts"
   ]
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1141,7 +1141,7 @@ export type IHttpClientParams = {
   $: IGlobalVariable
   baseURL?: string
   beforeRequest: TBeforeRequest[]
-  requestErrorHandler: TRequestErrorHandler
+  requestErrorHandler?: TRequestErrorHandler
 }
 
 export type IGlobalVariable = {


### PR DESCRIPTION
## Stack Context

Twenty-fourth PR in the backend strict-mode rollout (stacked on #2165). Fixes the last 5 production files outside the round-14 cluster and, combined with round 23, **completes strict-mode coverage for all of `apps/` and `models/` production code** (everything except `.test.ts`/`.itest.ts` files, which are a separate body of work).

## What?

- **`apps/aisay/actions/use-specific-model/index.ts`**: same `doesFileProcessing` `Boolean(...)` fix as round 13's `use-generalised-model` — this is aisay's other action, never touched before now.
- **`apps/toolbox/actions/if-then/infra/handle-create-step.ts`, `common/validate-end-step.ts`**: three `Array.find()` results used without a null guard, where the file's own docs already state "throws on any violation" as the intended contract. Added explicit should-never-happen throws (one reusing the existing `rejectEndStepWrite`, two plain `throw new Error`) instead of letting the possibly-`undefined` values flow into functions that require the real type.
- **`models/app.ts`**: `app.triggers?.find(...) || app.actions?.find(...)` collapses to `undefined` when both fail, but the function's declared return type is `... | null`; added `|| null`. `findAll(null, false)` passed `null` where the parameter is `name?: string` (accepts `undefined`, not `null`) — switched both call sites to `findAll(undefined, false)`.
- **`helpers/global-variable.ts`**: the function that constructs `$` for every single flow execution — previously exempted from strict checking entirely via a whole-object `as unknown as IGlobalVariable` cast at the end of its literal, so none of its *internal* logic had ever been strict-checked even though everything importing `$`'s type had been. Fixes:
  - `$.auth.data = connection.formattedData` needed a `?? {}` fallback (`Connection.formattedData` is optional).
  - `getLastExecutionStep`'s ternary read `execution.id` (non-optional) after a guard that only checked `execution?.id`'s truthiness — switched to `execution?.id` directly, which is correct regardless of narrowing.
  - The webhook-registration branch chained `step?.isTrigger && (await step.getTriggerCommand()).type === 'webhook'` — the `await` in the middle invalidated the property-based narrowing of `step` established by the optional-chain check earlier in the same `&&` expression. Restructured into a plain `if (flow && step?.isTrigger)` guard followed by capturing `getTriggerCommand()`'s result before checking `.type`, which keeps `step` narrowed across the `await` (nothing else happens between the guard and the call).
  - `isAlreadyProcessed`'s cached `lastInternalIds` was typed `string[] | undefined` but `Flow.lastInternalIds()` returns `(string | null | undefined)[]` (a row's `internalId` column is nullable) — widened the local type instead of asserting non-null, since a `null`/`undefined` entry simply never matches a real ID in the `.includes()` check either way.
  - `IHttpClientParams.requestErrorHandler` was typed required, but its only caller here always potentially passes `undefined`, and the implementation (`http-client/index.ts`) already null-checks it internally (`if (!requestErrorHandler) {...}`) — widened the shared type to optional instead of the previous `?? null`, which didn't even satisfy the required type.

## Why?

**Verified this genuinely closes out `apps/` and `models/`, not just my file list.** Probed with `src/apps/**/*` and `src/models/**/*` added wholesale on top of the now-gated `tsconfig.strict.json` (same technique as round 23) — every one of the 653 remaining errors is in a `__tests__`/`.test.ts` file; zero are in production code. `global-variable.ts` in particular had never been individually strict-checked despite being the single most load-bearing file in flow execution (every action/trigger's `$` comes from it), so fixing it here — rather than leaving it permanently exempted by its own cast — closes a real gap, not just a formality.

Given that centrality, verified beyond the isolated probe: a full non-strict `typecheck` diff (zero regressions) and the **entire backend unit test suite** (2426 tests passing; the one failing suite, `graphql-instance.test.ts`, fails on the pre-existing GraphQL codegen module-resolution gap in this dev environment — unrelated to this change, and already documented as a known local-environment limitation, not a real bug).
