### PR TITLE
chore(backend): fix 19 missed apps/models .itest.ts files (round 26)

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.critical.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.critical.itest.ts
@@ -1,4 +1,4 @@
-import { IGlobalVariable } from '@plumber/types'
+import { IGlobalVariable, IJSONObject } from '@plumber/types'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -47,7 +47,7 @@ describe('mrf-submission action gating rules (integration)', () => {
   beforeEach(async () => {
     context = await generateMockContext()
     await generateMockFlow(context, FLOW_ID)
-    flow = await Flow.query().findById(FLOW_ID)
+    flow = (await Flow.query().findById(FLOW_ID))!
     triggerStep = await generateMockStep(
       context,
       'newSubmission',
@@ -122,12 +122,12 @@ describe('mrf-submission action gating rules (integration)', () => {
         executionId: execution.id,
         stepId: triggerStep.id,
         status: 'failure',
-        dataOut: null,
+        dataOut: null as unknown as IJSONObject,
         appKey: 'formsg',
       })
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: { command: 'pause-execution' },
@@ -184,7 +184,7 @@ describe('mrf-submission action gating rules (integration)', () => {
         executionId: execution.id,
         stepId: failedStep.id,
         status: 'failure',
-        dataOut: null,
+        dataOut: null as unknown as IJSONObject,
         appKey: 'postman',
       })
       await ExecutionStep.query().insert({
@@ -202,7 +202,7 @@ describe('mrf-submission action gating rules (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStepB, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: { command: 'pause-execution' },
@@ -220,7 +220,7 @@ describe('mrf-submission action gating rules (integration)', () => {
       // No execution step for the trigger at all
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: { command: 'pause-execution' },
@@ -322,7 +322,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toBeUndefined()
+      expect(await action.run!($)).toBeUndefined()
     })
 
     it('should continue when the block ran to its end', async () => {
@@ -331,7 +331,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toBeUndefined()
+      expect(await action.run!($)).toBeUndefined()
     })
 
     it('should pause execution while a TRUE block is still running', async () => {
@@ -339,7 +339,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toEqual({
+      expect(await action.run!($)).toEqual({
         nextStep: { command: 'pause-execution' },
       })
     })
@@ -347,7 +347,7 @@ describe('mrf-submission action gating rules (integration)', () => {
     it('should pause execution before the if-then itself has run', async () => {
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toEqual({
+      expect(await action.run!($)).toEqual({
         nextStep: { command: 'pause-execution' },
       })
     })
@@ -363,7 +363,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toEqual({
+      expect(await action.run!($)).toEqual({
         nextStep: { command: 'pause-execution' },
       })
     })
@@ -391,11 +391,11 @@ describe('mrf-submission action gating rules (integration)', () => {
       })
 
       const $ = createGlobalVariable(
-        await Step.query().findById(mrfStep3.id),
+        (await Step.query().findById(mrfStep3.id))!,
         execution,
       )
 
-      expect(await action.run($)).toBeUndefined()
+      expect(await action.run!($)).toBeUndefined()
     })
   })
 
@@ -468,7 +468,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toEqual({
+      expect(await action.run!($)).toEqual({
         nextStep: { command: 'pause-execution' },
       })
     })
@@ -484,7 +484,7 @@ describe('mrf-submission action gating rules (integration)', () => {
 
       const $ = createGlobalVariable(mrfStep3, execution)
 
-      expect(await action.run($)).toBeUndefined()
+      expect(await action.run!($)).toBeUndefined()
     })
   })
 })

--- a/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/actions/mrf-submission.itest.ts
@@ -30,7 +30,7 @@ describe('mrf-submission action (integration)', () => {
   beforeEach(async () => {
     context = await generateMockContext()
     await generateMockFlow(context, FLOW_ID)
-    flow = await Flow.query().findById(FLOW_ID)
+    flow = (await Flow.query().findById(FLOW_ID))!
     triggerStep = await generateMockStep(
       context,
       'newSubmission',
@@ -110,7 +110,7 @@ describe('mrf-submission action (integration)', () => {
       // But no execution step for the MRF action step itself
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: { command: 'pause-execution' },
@@ -150,7 +150,7 @@ describe('mrf-submission action (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toBeUndefined()
     })
@@ -189,7 +189,7 @@ describe('mrf-submission action (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toBeUndefined()
     })
@@ -234,7 +234,7 @@ describe('mrf-submission action (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: {
@@ -279,7 +279,7 @@ describe('mrf-submission action (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStep, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       expect(result).toEqual({
         nextStep: { command: 'stop-execution' },
@@ -341,7 +341,7 @@ describe('mrf-submission action (integration)', () => {
       })
 
       const $ = createGlobalVariable(mrfStep3, execution)
-      const result = await action.run($)
+      const result = await action.run!($)
 
       // Should continue normally because mrfStep2 (the real previous step) succeeded
       // If the rejection branch step were incorrectly picked as the previous step,

--- a/packages/backend/src/apps/formsg/__tests__/triggers/remove-mrf-steps.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/remove-mrf-steps.itest.ts
@@ -51,7 +51,7 @@ describe('removeMrfSteps', () => {
     await removeMrfSteps(FLOW_ID)
 
     const updatedTrigger = await Step.query().findById(trigger.id)
-    expect(updatedTrigger.parameters).toEqual({})
+    expect(updatedTrigger!.parameters).toEqual({})
   })
 
   it('should delete reject branch steps', async () => {

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -131,7 +131,7 @@ describe('getTableRowsAction', () => {
       headerSheetRowIndex: 0,
     })
 
-    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+    await expect(getTableRowsAction.run!($)).rejects.toThrow(StepError)
   })
 
   it('should return foundRows: 0 when no matching rows are found', async () => {
@@ -141,7 +141,7 @@ describe('getTableRowsAction', () => {
       headerSheetRowIndex: 0,
     })
 
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
@@ -156,7 +156,7 @@ describe('getTableRowsAction', () => {
   })
 
   it('should return matching rows when found', async () => {
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
@@ -213,7 +213,7 @@ describe('getTableRowsAction', () => {
       $.step.parameters,
       $.step.version,
     )
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
@@ -261,10 +261,10 @@ describe('getTableRowsAction', () => {
 
   it('should handle invalid parameters', async () => {
     $.step.parameters.fileId = ''
-    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+    await expect(getTableRowsAction.run!($)).rejects.toThrow(StepError)
 
     $.step.parameters.tableId = '!!!'
-    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+    await expect(getTableRowsAction.run!($)).rejects.toThrow(StepError)
   })
 
   it('should handle case-sensitive matching', async () => {
@@ -276,7 +276,7 @@ describe('getTableRowsAction', () => {
       $.step.version,
     )
 
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     // Should not find any matches due to case sensitivity
     expect($.setActionItem).toHaveBeenCalledWith({
@@ -315,7 +315,7 @@ describe('getTableRowsAction', () => {
       $.step.version,
     )
 
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     // Should find the exact case match
     expect($.setActionItem).toHaveBeenCalledWith({
@@ -349,7 +349,7 @@ describe('getTableRowsAction', () => {
       headerSheetRowIndex: 0,
     })
 
-    await getTableRowsAction.run($)
+    await getTableRowsAction.run!($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
@@ -396,7 +396,7 @@ describe('getTableRowsAction', () => {
         { lookupColumn: 'Column4', lookupValue: '3' },
       ]
 
-      await getTableRowsAction.run($)
+      await getTableRowsAction.run!($)
 
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: {
@@ -443,7 +443,7 @@ describe('getTableRowsAction', () => {
         { lookupColumn: 'Column2', lookupValue: 'non-matching' },
       ]
 
-      await getTableRowsAction.run($)
+      await getTableRowsAction.run!($)
 
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: {
@@ -468,7 +468,7 @@ describe('getTableRowsAction', () => {
         { lookupColumn: 'Column2', lookupValue: 'data4' },
       ]
 
-      await getTableRowsAction.run($)
+      await getTableRowsAction.run!($)
 
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: {

--- a/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
@@ -17,7 +17,7 @@ import Context from '@/types/express/context'
 import tiles from '../..'
 import createRowAction from '../../actions/create-row'
 
-describe.each([['ddb'], ['pg']])(
+describe.each([['ddb'], ['pg']] as const)(
   'tiles create row action: %s',
   (databaseType: DatabaseType) => {
     let context: Context
@@ -74,19 +74,19 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should allow owners to create row', async () => {
-      await expect(createRowAction.run($)).resolves.toBeUndefined()
+      await expect(createRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should allow editors to create row', async () => {
       $.user = editor
-      await expect(createRowAction.run($)).resolves.toBeUndefined()
+      await expect(createRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should not allow viewers to create row', async () => {
       $.user = viewer
-      await expect(createRowAction.run($)).rejects.toThrow(StepError)
+      await expect(createRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should throw correct error if Tile deleted', async () => {
@@ -96,7 +96,7 @@ describe.each([['ddb'], ['pg']])(
           deletedAt: new Date().toISOString(),
         })
         .where({ id: $.step.parameters.tableId })
-      await expect(createRowAction.run($)).rejects.toThrow(StepError)
+      await expect(createRowAction.run!($)).rejects.toThrow(StepError)
     })
   },
 )

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -44,7 +44,7 @@ vi.mock('@/models/step', () => ({
   },
 }))
 
-describe.each([['ddb'], ['pg']])(
+describe.each([['ddb'], ['pg']] as const)(
   'findMultipleRowsAction: %s',
   (databaseType: DatabaseType) => {
     let context: Context
@@ -116,19 +116,19 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should allow owners to find multiple rows', async () => {
-      await expect(findMultipleRowsAction.run($)).resolves.toBeUndefined()
+      await expect(findMultipleRowsAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should allow editors to find multiple rows', async () => {
       $.user = editor
-      await expect(findMultipleRowsAction.run($)).resolves.toBeUndefined()
+      await expect(findMultipleRowsAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should not allow viewers to find multiple rows', async () => {
       $.user = viewer
-      await expect(findMultipleRowsAction.run($)).rejects.toThrow(StepError)
+      await expect(findMultipleRowsAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should throw correct error if Tile deleted', async () => {
@@ -143,7 +143,7 @@ describe.each([['ddb'], ['pg']])(
           deletedAt: new Date().toISOString(),
         })
         .where({ table_id: $.step.parameters.tableId })
-      await expect(findMultipleRowsAction.run($)).rejects.toThrow(StepError)
+      await expect(findMultipleRowsAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should call getTableRows with scan limit if exists in step config', async () => {
@@ -156,7 +156,7 @@ describe.each([['ddb'], ['pg']])(
           rows: [],
           stringifiedCursor: undefined,
         })
-      await findMultipleRowsAction.run($)
+      await findMultipleRowsAction.run!($)
       expect(getTableRowsSpy).toHaveBeenCalledWith({
         columnIds: dummyColumnIds,
         tableId: $.step.parameters.tableId,
@@ -182,7 +182,7 @@ describe.each([['ddb'], ['pg']])(
         stringifiedCursor: undefined,
       })
 
-      await findMultipleRowsAction.run($)
+      await findMultipleRowsAction.run!($)
 
       expect($.setActionItem).toHaveBeenCalledWith({
         raw: expect.objectContaining({

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -39,7 +39,7 @@ vi.mock('@/models/step', () => ({
   },
 }))
 
-describe.each([['ddb'], ['pg']])(
+describe.each([['ddb'], ['pg']] as const)(
   'tiles find single row action: %s',
   (databaseType: DatabaseType) => {
     let context: Context
@@ -106,14 +106,14 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should allow owners to find single row', async () => {
-      await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+      await expect(findSingleRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should return an empty columns if no rows are found', async () => {
       const filters = $.step.parameters.filters as TableRowFilter[]
       filters[0].value = 'not a valid value'
-      await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+      await expect(findSingleRowAction.run!($)).resolves.toBeUndefined()
       const emptyRow = dummyColumnIds.reduce((acc, c) => {
         acc[c] = ''
         return acc
@@ -129,13 +129,13 @@ describe.each([['ddb'], ['pg']])(
 
     it('should allow editors to find single row', async () => {
       $.user = editor
-      await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+      await expect(findSingleRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should not allow viewers to find single row', async () => {
       $.user = viewer
-      await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+      await expect(findSingleRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should throw correct error if Tile deleted', async () => {
@@ -150,7 +150,7 @@ describe.each([['ddb'], ['pg']])(
           deletedAt: new Date().toISOString(),
         })
         .where({ table_id: $.step.parameters.tableId })
-      await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+      await expect(findSingleRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should call getTableRows with scan limit if exists in step config', async () => {
@@ -163,7 +163,7 @@ describe.each([['ddb'], ['pg']])(
           rows: [],
           stringifiedCursor: undefined,
         })
-      await findSingleRowAction.run($)
+      await findSingleRowAction.run!($)
       expect(getTableRowsSpy).toHaveBeenCalledWith({
         tableId: $.step.parameters.tableId,
         filters: $.step.parameters.filters,
@@ -183,7 +183,7 @@ describe.each([['ddb'], ['pg']])(
           stringifiedCursor: undefined,
         })
       $.step.parameters.returnLastRow = true
-      await findSingleRowAction.run($)
+      await findSingleRowAction.run!($)
       expect(getTableRowsSpy).toHaveBeenCalledWith({
         tableId: $.step.parameters.tableId,
         filters: $.step.parameters.filters,

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -19,7 +19,7 @@ import Context from '@/types/express/context'
 import tiles from '../..'
 import updateRowAction from '../../actions/update-row'
 
-describe.each([['ddb'], ['pg']])(
+describe.each([['ddb'], ['pg']] as const)(
   'tiles update row action: %s',
   (databaseType: DatabaseType) => {
     let context: Context
@@ -87,24 +87,24 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should allow owners to update row', async () => {
-      await expect(updateRowAction.run($)).resolves.toBeUndefined()
+      await expect(updateRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should allow editors to update row', async () => {
       $.user = editor
-      await expect(updateRowAction.run($)).resolves.toBeUndefined()
+      await expect(updateRowAction.run!($)).resolves.toBeUndefined()
       expect($.setActionItem).toBeCalled()
     })
 
     it('should not allow viewers to update row', async () => {
       $.user = viewer
-      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+      await expect(updateRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should throw error if no tableId', async () => {
       $.step.parameters.tableId = ''
-      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+      await expect(updateRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should throw correct error if Tile deleted', async () => {
@@ -119,12 +119,12 @@ describe.each([['ddb'], ['pg']])(
           deletedAt: new Date().toISOString(),
         })
         .where({ table_id: $.step.parameters.tableId })
-      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+      await expect(updateRowAction.run!($)).rejects.toThrow(StepError)
     })
 
     it('should not fail if row does not exist', async () => {
       $.step.parameters.rowId = '123'
-      await expect(updateRowAction.run($)).resolves.not.toThrow(StepError)
+      await expect(updateRowAction.run!($)).resolves.not.toThrow(StepError)
     })
 
     it('should not update columns that are not in the table', async () => {
@@ -142,7 +142,7 @@ describe.each([['ddb'], ['pg']])(
         { columnId: 'invalid_column', cellValue: '123' },
         { columnId: dummyColumnIds[0], cellValue: '123' },
       ]
-      await updateRowAction.run($)
+      await updateRowAction.run!($)
       expect($.setActionItem).toBeCalledWith({
         raw: {
           rowId: row.rowId,

--- a/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
@@ -362,11 +362,11 @@ describe('dynamodb table row functions', () => {
         columnIds: dummyColumnIds,
       })
       const row = await createTableRow({ tableId: dummyTable.id, data })
-      const rawRow = await getRawRowById({
+      const rawRow = (await getRawRowById({
         tableId: dummyTable.id,
         rowId: row.rowId,
         columnIds: dummyColumnIds,
-      })
+      }))!
       expect(rawRow.data).toEqual(rawRow.data)
     })
 
@@ -375,11 +375,11 @@ describe('dynamodb table row functions', () => {
         columnIds: dummyColumnIds,
       })
       const row = await createTableRow({ tableId: dummyTable.id, data })
-      const rawRow = await getRawRowById({
+      const rawRow = (await getRawRowById({
         tableId: dummyTable.id,
         rowId: row.rowId,
         columnIds: [dummyColumnIds[0]],
-      })
+      }))!
       expect(Object.keys(rawRow.data)).toEqual([dummyColumnIds[0]])
     })
   })
@@ -399,11 +399,11 @@ describe('dynamodb table row functions', () => {
         rowId: row.rowId,
         data: newData,
       })
-      const updatedRow = await getRawRowById({
+      const updatedRow = (await getRawRowById({
         tableId: dummyTable.id,
         rowId: row.rowId,
         columnIds: dummyColumnIds,
-      })
+      }))!
       expect(updatedRow.data).toEqual(newData)
     })
   })
@@ -575,7 +575,7 @@ describe('dynamodb table row functions', () => {
         rowId: row.rowId,
         patchData: { [dummyColumnIds[0]]: '123' },
       })
-      expect(updatedRow.updatedAt).toBeGreaterThan(row.updatedAt)
+      expect(updatedRow.updatedAt).toBeGreaterThan(row.updatedAt!)
     })
   })
 })

--- a/packages/backend/tsconfig.strict.json
+++ b/packages/backend/tsconfig.strict.json
@@ -373,6 +373,25 @@
     "src/models/tiles/pg/__tests__/table-row-query.itest.ts",
     "src/models/tiles/pg/__tests__/table-row-filtering.itest.ts",
     "src/graphql/__tests__/mutations/tiles/table.mock.ts",
-    "src/graphql/__tests__/mutations/flow.mock.ts"
+    "src/graphql/__tests__/mutations/flow.mock.ts",
+    "src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts",
+    "src/apps/tiles/__tests__/actions/create-row.itest.ts",
+    "src/apps/tiles/__tests__/actions/find-single-row.itest.ts",
+    "src/apps/tiles/__tests__/actions/update-row.itest.ts",
+    "src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts",
+    "src/apps/formsg/__tests__/triggers/remove-mrf-steps.itest.ts",
+    "src/apps/formsg/__tests__/triggers/create-mrf-steps.itest.ts",
+    "src/apps/formsg/__tests__/actions/mrf-submission.critical.itest.ts",
+    "src/apps/formsg/__tests__/actions/mrf-submission.itest.ts",
+    "src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts",
+    "src/models/tiles/pg/__tests__/table-functions.itest.ts",
+    "src/models/tiles/pg/__tests__/table-column-functions.itest.ts",
+    "src/models/tiles/pg/__tests__/table-row-update.itest.ts",
+    "src/models/tiles/pg/__tests__/table-row-delete.itest.ts",
+    "src/models/tiles/pg/__tests__/table-row-create.itest.ts",
+    "src/models/__tests__/flow-collaborators.itest.ts",
+    "src/models/__tests__/flow-connections.itest.ts",
+    "src/models/__tests__/table-collaborators.itest.ts",
+    "src/models/__tests__/step.itest.ts"
   ]
 }


### PR DESCRIPTION
## Problem

Twenty-sixth PR in the backend `strict: true` rollout (stacked on #2166 / round 25). Round 25 fixed 48 test files across `apps/` and `models/` and claimed full strict-mode coverage for both directories — but its discovery process didn't surface 19 `.itest.ts` files (integration tests, real Postgres/DynamoDB via testcontainers), which were left ungated with 77 real strict-mode errors between them.

## Solution

Fixed all 19 missed `.itest.ts` files and added them to `tsconfig.strict.json`'s `include` list. 9 files needed real fixes (77 errors); the other 10 were already strict-clean and only needed gating.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible (test-only changes)

**Improvements**:

- **Non-null assertions on optional `action.run`** (majority of fixes) — same established pattern as round 25: each file's subject under test always defines `.run`, so `action.run!($)` is the accepted cast for this known type-checker blind spot in test code.
- **`describe.each([['ddb'], ['pg']])` → `describe.each([['ddb'], ['pg']] as const)`** in the 4 `apps/tiles/__tests__/actions/*.itest.ts` files — without `as const`, the array literal widens to `string[]`, which doesn't satisfy the `(databaseType: DatabaseType) => void` callback signature. `as const` narrows the literals to `DatabaseType` ('pg' | 'ddb'), fixing the mismatch without touching the real type.
- **`ExecutionStep.dataOut: null` in `mrf-submission.critical.itest.ts`** — the model field is typed as non-nullable `IJSONObject`, but the DB `jsonSchema` explicitly allows `['object', 'null']`, and production code (`services/action.ts`, `services/trigger.ts`) already inserts `null` there for failed steps. Investigated widening the shared type but reverted it — the change ripples into `IExecutionStep` (shared `@plumber/types`) and several not-yet-gated files (`gathersg`, `helpers/compute-parameters.ts`), which is a separate, larger fix belonging to a future round touching those areas. Used a local `null as unknown as IJSONObject` cast in the test instead, since it's testing a real, legitimate DB state the type doesn't yet reflect.
- Otherwise straightforward non-null assertions (`.findById()` results, `Step.query()`, `Flow.query()`) on rows the test itself just created — guaranteed present.
- **`tsconfig.strict.json`**: added all 19 files to `include` (370 → 389 entries).

**Bug Fixes**:

- None — exclusively type-level fixes to already-passing tests.

## Tests

- Isolated `tsc` probe across all 19 files: 0 errors.
- Full `tsconfig.strict.json` probe (389 files): 0 errors.
- Full non-strict `npm run typecheck` diff against the pre-round baseline: byte-identical output, 0 regressions.
- Lint: clean across all 9 changed test files.
- **Integration test execution blocked in this dev environment**: `vitest.config.integration.ts`'s global setup unconditionally provisions a local DynamoDB table via the AWS SDK, which fails with `CredentialsProviderError: The SSO session associated with this profile has expired` — this happens before any test file loads, so it blocks running *any* `.itest.ts` file in this sandbox right now, unrelated to this PR's changes. Recommend re-running the full integration suite in CI (or after `aws sso login`) before merging.

**New scripts**: none.
**New dependencies**: none.
**New dev dependencies**: none.
