### PR TITLE
Revert "fix: dev command in root (#2095)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "plumber",
-  "version": "1.81.0",
   "license": "AGPL-3.0",
-  "workspaces": {
-    "packages": [
-      "packages/*"
-    ]
+  "engines": {
+    "npm": ">=11.10.0"
   },
   "packageManager": "npm@11.19.0",
   "scripts": {
@@ -23,6 +20,37 @@
     "test:ui": "vitest --ui",
     "migrate": "npm run -w backend db:migrate",
     "teardown": "npm run -w backend teardown"
+  },
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
+  "overrides": {
+    "axios": "1.18.1",
+    "graphql-rate-limit": {
+      "@graphql-tools/utils": {
+        "graphql": "16.11.0"
+      }
+    },
+    "qs": "6.15.0",
+    "glob": "13.0.6",
+    "minimatch": "10.2.3",
+    "rollup": "4.59.0",
+    "dd-trace": {
+      "@opentelemetry/core": "2.8.0",
+      "path-to-regexp": "0.1.13"
+    },
+    "@opentelemetry/core": {
+      "@opentelemetry/semantic-conventions": "1.37.0"
+    },
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
+    "vite": "6.4.3",
+    "immutable": "4.3.9",
+    "picomatch": "4.0.4",
+    "shell-quote": "1.9.0",
+    "form-data": "4.0.6"
   },
   "devDependencies": {
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",


### PR DESCRIPTION
This reverts commit 7fd6e9cb0580329b8cab0bc45f08bef1d996f06d.

## Problem
wrong resolution on merge - i thought the `overrides` was the old config since we're using `turbo` now



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62020994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/opengovsg/-/pull-requests/opengovsg/plumber/2174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until the local Node and devcontainer setup provisions an npm version satisfying the new strict engine requirement.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackage.json%3A5%0AThe%20new%20%60npm%20%3E%3D11.10.0%60%20requirement%20conflicts%20with%20the%20repository's%20local%20toolchains.%20%60.nvmrc%60%20selects%20Node%2022.19.0%2C%20which%20includes%20npm%2010.9.3%2C%20and%20the%20Node%2022%20devcontainer%20also%20provides%20npm%2010%20without%20upgrading%20it.%20Since%20%60.npmrc%60%20enables%20%60engine-strict%60%2C%20developers%20following%20either%20setup%20cannot%20run%20%60npm%20install%60%20or%20%60npm%20ci%60%20until%20they%20manually%20upgrade%20npm.%20Please%20provision%20npm%2011.19.0%20in%20these%20local%20toolchains%2C%20as%20CI%20and%20Docker%20already%20do.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2174&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Local installs reject npm** <a href="https://github.com/opengovsg/plumber/pull/2174#discussion_r3966519227">▶</a>

<details><summary><h3>Summary</h3></summary>

- Restores explicit dependency pins already represented in the lockfile.
- Requires npm 11.10.0 or newer.
- Leaves the local Node and devcontainer toolchains unable to install dependencies without a manual npm upgrade.
</details>

<!-- /greptile_comment -->