### PR TITLE
chore(backend): fix root cause of graphql/ resolver strict-mode cascade (round 30)

### DIFF
--- a/packages/backend/src/graphql/admin/mutations/pause-group.ts
+++ b/packages/backend/src/graphql/admin/mutations/pause-group.ts
@@ -2,7 +2,7 @@ import { actionQueuesByName } from '@/queues/action'
 
 import type { AdminMutationResolvers } from '../../__generated__/types.generated'
 
-const pauseGroup: AdminMutationResolvers['pauseGroup'] = async (
+const pauseGroup: NonNullable<AdminMutationResolvers['pauseGroup']> = async (
   _parent,
   params,
   _context,

--- a/packages/backend/src/graphql/admin/mutations/resume-group.ts
+++ b/packages/backend/src/graphql/admin/mutations/resume-group.ts
@@ -2,7 +2,7 @@ import { actionQueuesByName } from '@/queues/action'
 
 import type { AdminMutationResolvers } from '../../__generated__/types.generated'
 
-const resumeGroup: AdminMutationResolvers['resumeGroup'] = async (
+const resumeGroup: NonNullable<AdminMutationResolvers['resumeGroup']> = async (
   _parent,
   params,
   _context,

--- a/packages/backend/src/graphql/admin/mutations/set-group-concurrency.ts
+++ b/packages/backend/src/graphql/admin/mutations/set-group-concurrency.ts
@@ -2,32 +2,33 @@ import { actionQueuesByName } from '@/queues/action'
 
 import type { AdminMutationResolvers } from '../../__generated__/types.generated'
 
-const setGroupConcurrency: AdminMutationResolvers['setGroupConcurrency'] =
-  async (_parent, params, _context) => {
-    const {
-      input: { groupId, appKey, concurrency },
-    } = params
+const setGroupConcurrency: NonNullable<
+  AdminMutationResolvers['setGroupConcurrency']
+> = async (_parent, params, _context) => {
+  const {
+    input: { groupId, appKey, concurrency },
+  } = params
 
-    const queueName = `{app-actions-${appKey}}`
-    const queue = actionQueuesByName[queueName]
+  const queueName = `{app-actions-${appKey}}`
+  const queue = actionQueuesByName[queueName]
 
-    if (!queue) {
-      throw new Error(`Queue ${queueName} not found`)
-    }
-
-    if (concurrency == undefined) {
-      // unsets group concurrency
-      await queue.deleteGroupConcurrency(groupId)
-    } else if (typeof concurrency === 'number' && concurrency > 0) {
-      // set group concurrency
-      // actually sets this in the db, e.g.:
-      // key: "bull:{app-actions-tiles}:groups:concurrency"
-      // value: "{"<TILE_ID>-findSingleRow":"<CONCURRENCY>"}"
-      await queue.setGroupConcurrency(groupId, concurrency)
-    }
-
-    const result = await queue.getGroupConcurrency(groupId)
-    return result
+  if (!queue) {
+    throw new Error(`Queue ${queueName} not found`)
   }
+
+  if (concurrency == undefined) {
+    // unsets group concurrency
+    await queue.deleteGroupConcurrency(groupId)
+  } else if (typeof concurrency === 'number' && concurrency > 0) {
+    // set group concurrency
+    // actually sets this in the db, e.g.:
+    // key: "bull:{app-actions-tiles}:groups:concurrency"
+    // value: "{"<TILE_ID>-findSingleRow":"<CONCURRENCY>"}"
+    await queue.setGroupConcurrency(groupId, concurrency)
+  }
+
+  const result = await queue.getGroupConcurrency(groupId)
+  return result
+}
 
 export default setGroupConcurrency

--- a/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
@@ -2,11 +2,9 @@ import Execution from '@/models/execution'
 
 import type { AdminQueryResolvers } from '../../__generated__/types.generated'
 
-const getExecutionOwner: AdminQueryResolvers['getExecutionOwner'] = async (
-  _parent,
-  params,
-  _context,
-) => {
+const getExecutionOwner: NonNullable<
+  AdminQueryResolvers['getExecutionOwner']
+> = async (_parent, params, _context) => {
   const { executionId } = params
 
   const execution = await Execution.query()

--- a/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
@@ -2,7 +2,7 @@ import Flow from '@/models/flow'
 
 import type { AdminQueryResolvers } from '../../__generated__/types.generated'
 
-const getFlowOwner: AdminQueryResolvers['getFlowOwner'] = async (
+const getFlowOwner: NonNullable<AdminQueryResolvers['getFlowOwner']> = async (
   _parent,
   params,
   _context,

--- a/packages/backend/src/graphql/admin/queries/get-paused-groups.ts
+++ b/packages/backend/src/graphql/admin/queries/get-paused-groups.ts
@@ -4,11 +4,9 @@ import { actionQueuesByName } from '@/queues/action'
 
 import type { AdminQueryResolvers } from '../../__generated__/types.generated'
 
-const getPausedGroups: AdminQueryResolvers['getPausedGroups'] = async (
-  _parent,
-  params,
-  _context,
-) => {
+const getPausedGroups: NonNullable<
+  AdminQueryResolvers['getPausedGroups']
+> = async (_parent, params, _context) => {
   const { appKey } = params
   const queueName = `{app-actions-${appKey}}`
   const queue = actionQueuesByName[queueName]

--- a/packages/backend/src/graphql/admin/queries/get-table-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-table-owner.ts
@@ -2,7 +2,7 @@ import TableCollaborator from '@/models/table-collaborators'
 
 import type { AdminQueryResolvers } from '../../__generated__/types.generated'
 
-const getTableOwner: AdminQueryResolvers['getTableOwner'] = async (
+const getTableOwner: NonNullable<AdminQueryResolvers['getTableOwner']> = async (
   _parent,
   params,
   _context,

--- a/packages/backend/src/graphql/admin/queries/search-users-by-email.ts
+++ b/packages/backend/src/graphql/admin/queries/search-users-by-email.ts
@@ -4,11 +4,9 @@ import type { AdminQueryResolvers } from '../../__generated__/types.generated'
 
 const MIN_QUERY_CHARS = 3
 
-const searchUsersByEmail: AdminQueryResolvers['searchUsersByEmail'] = async (
-  _parent,
-  params,
-  _context,
-) => {
+const searchUsersByEmail: NonNullable<
+  AdminQueryResolvers['searchUsersByEmail']
+> = async (_parent, params, _context) => {
   const { query } = params
 
   if (!query || query.trim().length < MIN_QUERY_CHARS) {

--- a/packages/backend/src/graphql/custom-resolvers/execution-step.ts
+++ b/packages/backend/src/graphql/custom-resolvers/execution-step.ts
@@ -4,9 +4,9 @@ import type { Resolvers } from '../__generated__/types.generated'
 
 type ExecutionStepResolver = Resolvers['ExecutionStep']
 
-const dataOutMetadata: ExecutionStepResolver['dataOutMetadata'] = async (
-  parent,
-) => {
+const dataOutMetadata: NonNullable<
+  ExecutionStepResolver['dataOutMetadata']
+> = async (parent) => {
   const {
     appKey,
     key: stepKey,

--- a/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
@@ -2,7 +2,9 @@ import type { Resolvers } from '../__generated__/types.generated'
 
 type FlowCollaboratorResolver = Resolvers['FlowCollaborator']
 
-const email: FlowCollaboratorResolver['email'] = async (parent) => {
+const email: NonNullable<FlowCollaboratorResolver['email']> = async (
+  parent,
+) => {
   // user is eagerly loaded in queries, we should use the loaded relation first
   if (parent?.user?.email) {
     return parent?.user?.email

--- a/packages/backend/src/graphql/custom-resolvers/flow.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow.ts
@@ -10,7 +10,7 @@ import type {
 
 type FlowResolver = Resolvers['Flow']
 
-const template: FlowResolver['template'] = async (parent) => {
+const template: NonNullable<FlowResolver['template']> = async (parent) => {
   const templateId = parent?.config?.templateConfig?.templateId
   if (!templateId) {
     return null
@@ -18,7 +18,9 @@ const template: FlowResolver['template'] = async (parent) => {
   return TEMPLATES.find((template) => template.id === templateId)
 }
 
-const collaborators: FlowResolver['collaborators'] = async (parent) => {
+const collaborators: NonNullable<FlowResolver['collaborators']> = async (
+  parent,
+) => {
   let collaborators = parent?.collaborators
   if (!collaborators) {
     const flowCollaborators = await FlowCollaborator.query()
@@ -44,7 +46,7 @@ const collaborators: FlowResolver['collaborators'] = async (parent) => {
   )
 }
 
-const role: FlowResolver['role'] = async (parent) => {
+const role: NonNullable<FlowResolver['role']> = async (parent) => {
   // Return the computed role from the query
   return (parent as any)?.role || 'viewer'
 }
@@ -54,10 +56,11 @@ const role: FlowResolver['role'] = async (parent) => {
 // however, there may be existing flows that already have errorConfig.notificationFrequency
 // and when returning, may not contain this `notificationRecipients` field
 // to avoid gql errors, we force it to return an empty array
-const notificationRecipients: FlowErrorConfigResolvers['notificationRecipients'] =
-  (parent) => {
-    return parent?.notificationRecipients ?? []
-  }
+const notificationRecipients: NonNullable<
+  FlowErrorConfigResolvers['notificationRecipients']
+> = (parent) => {
+  return parent?.notificationRecipients ?? []
+}
 
 export const FlowErrorConfig: FlowErrorConfigResolvers = {
   notificationRecipients,

--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -4,11 +4,15 @@ import type { Resolvers } from '../__generated__/types.generated'
 
 type TableMetadataResolver = Resolvers['TableMetadata']
 
-const databaseType: TableMetadataResolver['databaseType'] = async (parent) => {
+const databaseType: NonNullable<TableMetadataResolver['databaseType']> = async (
+  parent,
+) => {
   return parent.db
 }
 
-const columns: TableMetadataResolver['columns'] = async (parent) => {
+const columns: NonNullable<TableMetadataResolver['columns']> = async (
+  parent,
+) => {
   const columns = await parent
     .$relatedQuery('columns')
     .orderBy('position', 'asc')
@@ -16,9 +20,9 @@ const columns: TableMetadataResolver['columns'] = async (parent) => {
   return columns
 }
 
-const collaborators: TableMetadataResolver['collaborators'] = async (
-  parent,
-) => {
+const collaborators: NonNullable<
+  TableMetadataResolver['collaborators']
+> = async (parent) => {
   const collaborators = await parent
     .$relatedQuery('collaborators')
     .select('email', 'role')

--- a/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
@@ -12,11 +12,9 @@ import { MutationResolvers } from '../../__generated__/types.generated'
 import { getActionStepsSchema } from './schemas/action-steps-schema'
 import { generateSchema } from './schemas/schema-generator'
 
-const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const createFlowWithSteps: NonNullable<
+  MutationResolvers['createFlowWithSteps']
+> = async (_parent, params, context) => {
   const {
     input: { steps, flowName, aiBuilderConfig },
   } = params

--- a/packages/backend/src/graphql/mutations/ai/update-chat-feedback.ts
+++ b/packages/backend/src/graphql/mutations/ai/update-chat-feedback.ts
@@ -4,11 +4,9 @@ import logger from '@/helpers/logger'
 
 import { MutationResolvers } from '../../__generated__/types.generated'
 
-const updateChatFeedback: MutationResolvers['updateChatFeedback'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const updateChatFeedback: NonNullable<
+  MutationResolvers['updateChatFeedback']
+> = async (_parent, params, context) => {
   const { traceId, feedback, score } = params.input
 
   try {

--- a/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
@@ -47,11 +47,9 @@ async function getAllFailedExecutionSteps(
     .select('id', 'execution_id', 'status', 'job_id')
 }
 
-const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const bulkRetryExecutions: NonNullable<
+  MutationResolvers['bulkRetryExecutions']
+> = async (_parent, params, context) => {
   let latestFailedExecutionSteps = await getAllFailedExecutionSteps(
     context.currentUser.email === appConfig.adminUserEmail
       ? Execution.query()

--- a/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
@@ -47,11 +47,9 @@ async function getAllFailedIterations(context: Context, executionId: string) {
   return failedExecutionSteps
 }
 
-const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const bulkRetryIterations: NonNullable<
+  MutationResolvers['bulkRetryIterations']
+> = async (_parent, params, context) => {
   if (!params.input.executionId) {
     throw new Error('Execution ID is required')
   }

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -7,11 +7,9 @@ import type { MutationResolvers } from '../__generated__/types.generated'
 // Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive
 // Data Scanner
 
-const createConnection: MutationResolvers['createConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const createConnection: NonNullable<
+  MutationResolvers['createConnection']
+> = async (_parent, params, context) => {
   await App.findOneByKey(params.input.key)
 
   const flow = await context.currentUser

--- a/packages/backend/src/graphql/mutations/create-flow-transfer.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-transfer.ts
@@ -5,11 +5,9 @@ import User from '@/models/user'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createFlowTransfer: MutationResolvers['createFlowTransfer'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const createFlowTransfer: NonNullable<
+  MutationResolvers['createFlowTransfer']
+> = async (_parent, params, context) => {
   const { flowId, newOwnerEmail } = params.input
 
   // check if flow belongs to the old owner first

--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -1,6 +1,6 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createFlow: MutationResolvers['createFlow'] = async (
+const createFlow: NonNullable<MutationResolvers['createFlow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -18,7 +18,7 @@ import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createStep: MutationResolvers['createStep'] = async (
+const createStep: NonNullable<MutationResolvers['createStep']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/create-templated-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-templated-flow.ts
@@ -2,11 +2,9 @@ import { createFlowFromTemplate } from '@/helpers/flow-templates'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createTemplatedFlow: MutationResolvers['createTemplatedFlow'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const createTemplatedFlow: NonNullable<
+  MutationResolvers['createTemplatedFlow']
+> = async (_parent, params, context) => {
   return createFlowFromTemplate(params.input.templateId, context.currentUser)
 }
 

--- a/packages/backend/src/graphql/mutations/delete-connection.ts
+++ b/packages/backend/src/graphql/mutations/delete-connection.ts
@@ -2,11 +2,9 @@ import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteConnection: MutationResolvers['deleteConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const deleteConnection: NonNullable<
+  MutationResolvers['deleteConnection']
+> = async (_parent, params, context) => {
   return await FlowConnections.transaction(async (trx) => {
     await context.currentUser
       .$relatedQuery('connections', trx)

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -6,58 +6,59 @@ import User from '@/models/user'
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
-  async (_parent, params, context) => {
-    const { flowId, email } = params.input as {
-      flowId: string
-      email: string
-    }
-
-    const validatedEmail = await validateAndParseEmail(email)
-    if (!validatedEmail) {
-      throw new BadUserInputError('Invalid collaborator email')
-    }
-
-    if (validatedEmail === context.currentUser.email) {
-      throw new BadUserInputError('Cannot remove yourself')
-    }
-
-    // only editor or owner can delete collaborators
-    await FlowCollaborator.hasAccess({
-      userId: context.currentUser.id,
-      flowId,
-      requiredRole: 'editor',
-    })
-
-    const user = await User.query()
-      .findOne({
-        email: validatedEmail,
-      })
-      .throwIfNotFound('No such user found')
-
-    try {
-      await FlowCollaborator.query()
-        .delete()
-        .where({
-          flow_id: flowId,
-          user_id: user.id,
-        })
-        .returning('*')
-        .throwIfNotFound({ message: 'No such collaborator found' })
-    } catch (e) {
-      logger.error({
-        message: 'Failed to delete collaborator',
-        data: {
-          flowId,
-          email,
-        },
-        userId: context.currentUser.id,
-        error: e,
-      })
-      throw new Error(e.message ?? 'Failed to delete collaborator')
-    }
-
-    return true
+const deleteFlowCollaborator: NonNullable<
+  MutationResolvers['deleteFlowCollaborator']
+> = async (_parent, params, context) => {
+  const { flowId, email } = params.input as {
+    flowId: string
+    email: string
   }
+
+  const validatedEmail = await validateAndParseEmail(email)
+  if (!validatedEmail) {
+    throw new BadUserInputError('Invalid collaborator email')
+  }
+
+  if (validatedEmail === context.currentUser.email) {
+    throw new BadUserInputError('Cannot remove yourself')
+  }
+
+  // only editor or owner can delete collaborators
+  await FlowCollaborator.hasAccess({
+    userId: context.currentUser.id,
+    flowId,
+    requiredRole: 'editor',
+  })
+
+  const user = await User.query()
+    .findOne({
+      email: validatedEmail,
+    })
+    .throwIfNotFound('No such user found')
+
+  try {
+    await FlowCollaborator.query()
+      .delete()
+      .where({
+        flow_id: flowId,
+        user_id: user.id,
+      })
+      .returning('*')
+      .throwIfNotFound({ message: 'No such collaborator found' })
+  } catch (e) {
+    logger.error({
+      message: 'Failed to delete collaborator',
+      data: {
+        flowId,
+        email,
+      },
+      userId: context.currentUser.id,
+      error: e,
+    })
+    throw new Error(e.message ?? 'Failed to delete collaborator')
+  }
+
+  return true
+}
 
 export default deleteFlowCollaborator

--- a/packages/backend/src/graphql/mutations/delete-flow-connection.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-connection.ts
@@ -8,11 +8,9 @@ import Step from '@/models/step'
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteFlowConnection: MutationResolvers['deleteFlowConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const deleteFlowConnection: NonNullable<
+  MutationResolvers['deleteFlowConnection']
+> = async (_parent, params, context) => {
   const { flowId, connectionId, connectionType } = params.input as {
     flowId: string
     connectionId: string

--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -2,7 +2,7 @@ import { COMMON_S3_BUCKET, deleteObjects, parseS3Id } from '@/helpers/s3'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteFlow: MutationResolvers['deleteFlow'] = async (
+const deleteFlow: NonNullable<MutationResolvers['deleteFlow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -22,7 +22,7 @@ function getStepsToInvalidate(steps: Step[], deletedIds: Set<string>) {
   return stepsToInvalidate
 }
 
-const deleteStep: MutationResolvers['deleteStep'] = async (
+const deleteStep: NonNullable<MutationResolvers['deleteStep']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
+++ b/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
@@ -9,11 +9,9 @@ import Step from '@/models/step'
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteUploadedFile: MutationResolvers['deleteUploadedFile'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const deleteUploadedFile: NonNullable<
+  MutationResolvers['deleteUploadedFile']
+> = async (_parent, params, context) => {
   const { id, flowUpdatedAt } = params
   if (!validateManualUploadId(id)) {
     throw new Error('Invalid id')

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -13,11 +13,9 @@ import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const duplicateBranch: NonNullable<
+  MutationResolvers['duplicateBranch']
+> = async (_parent, params, context) => {
   const { input } = params
 
   return await Step.transaction(async (trx) => {

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -9,7 +9,7 @@ import Flow from '@/models/flow'
 import { MutationResolvers } from '../__generated__/types.generated'
 
 // transaction does 2 things: update duplicate count for flow + duplicate flow + steps
-const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
+const duplicateFlow: NonNullable<MutationResolvers['duplicateFlow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/dynamic-action.ts
+++ b/packages/backend/src/graphql/mutations/dynamic-action.ts
@@ -6,7 +6,7 @@ import globalVariable from '@/helpers/global-variable'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const dynamicAction: MutationResolvers['dynamicAction'] = async (
+const dynamicAction: NonNullable<MutationResolvers['dynamicAction']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -6,7 +6,7 @@ import testStep from '@/services/test-step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const executeStep: MutationResolvers['executeStep'] = async (
+const executeStep: NonNullable<MutationResolvers['executeStep']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/backend/src/graphql/mutations/generate-auth-url.ts
@@ -8,11 +8,9 @@ import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const generateAuthUrl: MutationResolvers['generateAuthUrl'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const generateAuthUrl: NonNullable<
+  MutationResolvers['generateAuthUrl']
+> = async (_parent, params, context) => {
   const flow = await context.currentUser
     .withAccessibleFlows({ requiredRole: 'editor' })
     .findById(params.input.flowId)

--- a/packages/backend/src/graphql/mutations/generate-presigned-post.ts
+++ b/packages/backend/src/graphql/mutations/generate-presigned-post.ts
@@ -12,67 +12,62 @@ import {
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
-const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
-  async (_parent, params, context) => {
-    const {
-      flow: flowInput,
-      filename,
-      fileType,
-      size,
-      updatedAt,
-    } = params.input
+const generatePresignedPost: NonNullable<
+  MutationResolvers['generatePresignedPost']
+> = async (_parent, params, context) => {
+  const { flow: flowInput, filename, fileType, size, updatedAt } = params.input
 
-    if (size > MAX_FILE_SIZE) {
-      throw new Error(
-        `Size of attachment exceeds ${MAX_FILE_SIZE / (1024 * 1024)}MB`,
-      )
-    }
-    // Block-list gate: accept anything except executables/scripts (mirrors the
-    // SES send-time filter). Extension-based to match how attachments are
-    // actually filtered on send; the reported MIME type is unreliable and only
-    // used for the S3 object's content type. Files with no extension are allowed
-    // (consistent with filterAttachments); every object is malware-scanned.
-    const parts = filename.split('.')
-    const fileExtension =
-      parts.length > 1 ? parts.pop()?.toLowerCase() : undefined
-    if (fileExtension && SES_BLOCKED_EXTENSIONS.includes(fileExtension)) {
-      throw new Error('Unsupported file type')
-    }
-
-    const uuid = randomUUID()
-    const objectKey = `${flowInput.id}/${uuid}/${filename}`
-    if (!validateObjectKey(objectKey)) {
-      throw new Error('File path cannot be longer than 1024 bytes')
-    }
-
-    const flow = await context.currentUser
-      .withAccessibleFlows({ requiredRole: 'editor' })
-      .findOne({ id: flowInput.id })
-
-    if (!flow) {
-      throw new ForbiddenError(
-        'You do not have sufficient permissions for this pipe',
-      )
-    }
-
-    flow.assertNotUpdatedSince(flowInput.updatedAt, context.currentUser.id)
-
-    const presignedPost = await getPresignedPost(
-      COMMON_S3_BUCKET,
-      objectKey,
-      fileType,
-      {
-        flowId: flowInput.id,
-        filename,
-        size: size.toString(),
-        updatedAt,
-      },
+  if (size > MAX_FILE_SIZE) {
+    throw new Error(
+      `Size of attachment exceeds ${MAX_FILE_SIZE / (1024 * 1024)}MB`,
     )
-
-    return {
-      presignedPost: presignedPost as PresignedPost,
-      s3Id: `s3:${COMMON_S3_BUCKET}:${objectKey}`,
-    }
   }
+  // Block-list gate: accept anything except executables/scripts (mirrors the
+  // SES send-time filter). Extension-based to match how attachments are
+  // actually filtered on send; the reported MIME type is unreliable and only
+  // used for the S3 object's content type. Files with no extension are allowed
+  // (consistent with filterAttachments); every object is malware-scanned.
+  const parts = filename.split('.')
+  const fileExtension =
+    parts.length > 1 ? parts.pop()?.toLowerCase() : undefined
+  if (fileExtension && SES_BLOCKED_EXTENSIONS.includes(fileExtension)) {
+    throw new Error('Unsupported file type')
+  }
+
+  const uuid = randomUUID()
+  const objectKey = `${flowInput.id}/${uuid}/${filename}`
+  if (!validateObjectKey(objectKey)) {
+    throw new Error('File path cannot be longer than 1024 bytes')
+  }
+
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findOne({ id: flowInput.id })
+
+  if (!flow) {
+    throw new ForbiddenError(
+      'You do not have sufficient permissions for this pipe',
+    )
+  }
+
+  flow.assertNotUpdatedSince(flowInput.updatedAt, context.currentUser.id)
+
+  const presignedPost = await getPresignedPost(
+    COMMON_S3_BUCKET,
+    objectKey,
+    fileType,
+    {
+      flowId: flowInput.id,
+      filename,
+      size: size.toString(),
+      updatedAt,
+    },
+  )
+
+  return {
+    presignedPost: presignedPost as PresignedPost,
+    s3Id: `s3:${COMMON_S3_BUCKET}:${objectKey}`,
+  }
+}
 
 export default generatePresignedPost

--- a/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
@@ -33,29 +33,30 @@ function readEmploymentsFromCookie(req: Request): PublicOfficerEmployment[] {
   }
 }
 
-const loginWithSelectedSgid: MutationResolvers['loginWithSelectedSgid'] =
-  async (_parent, params, context) => {
-    const employments = readEmploymentsFromCookie(context.req)
-    context.res.clearCookie(SGID_MULTI_HAT_COOKIE_NAME)
+const loginWithSelectedSgid: NonNullable<
+  MutationResolvers['loginWithSelectedSgid']
+> = async (_parent, params, context) => {
+  const employments = readEmploymentsFromCookie(context.req)
+  context.res.clearCookie(SGID_MULTI_HAT_COOKIE_NAME)
 
-    const workEmail = params.input.workEmail
+  const workEmail = params.input.workEmail
 
-    const employment = employments.find(
-      (employment) => employment.workEmail === workEmail,
-    )
+  const employment = employments.find(
+    (employment) => employment.workEmail === workEmail,
+  )
 
-    if (!employment) {
-      throw new Error('Invalid work email')
-    }
-
-    const user = await getOrCreateUser(workEmail)
-    await sendOnboardingEmail(user)
-    await updateLastLogin(user.id)
-    setAuthCookie(context.res, { userId: user.id })
-
-    return {
-      success: true,
-    }
+  if (!employment) {
+    throw new Error('Invalid work email')
   }
+
+  const user = await getOrCreateUser(workEmail)
+  await sendOnboardingEmail(user)
+  await updateLastLogin(user.id)
+  setAuthCookie(context.res, { userId: user.id })
+
+  return {
+    success: true,
+  }
+}
 
 export default loginWithSelectedSgid

--- a/packages/backend/src/graphql/mutations/login-with-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-sgid.ts
@@ -88,7 +88,7 @@ async function parsePocdexData(
  * - Length > 1: Multi-hat user; we need the user to select which work email
  *               to login.
  */
-const loginWithSgid: MutationResolvers['loginWithSgid'] = async (
+const loginWithSgid: NonNullable<MutationResolvers['loginWithSgid']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/login-with-sso.ts
+++ b/packages/backend/src/graphql/mutations/login-with-sso.ts
@@ -10,7 +10,7 @@ import { ssoClient } from '@/helpers/sso-client'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const loginWithSso: MutationResolvers['loginWithSso'] = async (
+const loginWithSso: NonNullable<MutationResolvers['loginWithSso']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/logout.ts
+++ b/packages/backend/src/graphql/mutations/logout.ts
@@ -2,7 +2,7 @@ import { deleteAuthCookie, getParsedAuthCookie } from '@/helpers/auth'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const logout: MutationResolvers['logout'] = async (
+const logout: NonNullable<MutationResolvers['logout']> = async (
   _parent,
   _params,
   context,

--- a/packages/backend/src/graphql/mutations/register-connection.ts
+++ b/packages/backend/src/graphql/mutations/register-connection.ts
@@ -42,11 +42,9 @@ async function makeGlobalVariableForPerFlowRegistration(
   })
 }
 
-const registerConnection: MutationResolvers['registerConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const registerConnection: NonNullable<
+  MutationResolvers['registerConnection']
+> = async (_parent, params, context) => {
   const { connectionId, flowId } = params.input
 
   const flow = await context.currentUser

--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -17,7 +17,10 @@ const OTP_RESEND_TIMEOUT_IN_MS = 1 * 30 * 1000
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const requestOtp: MutationResolvers['requestOtp'] = async (_parent, params) => {
+const requestOtp: NonNullable<MutationResolvers['requestOtp']> = async (
+  _parent,
+  params,
+) => {
   const email = await validateAndParseEmail(params.input.email)
   // validate email
   if (!email) {

--- a/packages/backend/src/graphql/mutations/reset-connection.ts
+++ b/packages/backend/src/graphql/mutations/reset-connection.ts
@@ -1,10 +1,8 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const resetConnection: MutationResolvers['resetConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const resetConnection: NonNullable<
+  MutationResolvers['resetConnection']
+> = async (_parent, params, context) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -6,11 +6,9 @@ import { getActionJob } from '@/queues/action'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const retryExecutionStep: MutationResolvers['retryExecutionStep'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const retryExecutionStep: NonNullable<
+  MutationResolvers['retryExecutionStep']
+> = async (_parent, params, context) => {
   const executionStep = await ExecutionStep.query()
     .findById(params.input.executionStepId)
     .whereNotNull('job_id')

--- a/packages/backend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-partial-step.ts
@@ -6,11 +6,9 @@ import { processAction } from '@/services/action'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const retryPartialStep: MutationResolvers['retryPartialStep'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const retryPartialStep: NonNullable<
+  MutationResolvers['retryPartialStep']
+> = async (_parent, params, context) => {
   const executionStep = await ExecutionStep.query()
     .findById(params.input.executionStepId)
     .withGraphJoined('execution')

--- a/packages/backend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-row.ts
@@ -4,7 +4,7 @@ import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRow: MutationResolvers['createRow'] = async (
+const createRow: NonNullable<MutationResolvers['createRow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-rows.ts
@@ -4,7 +4,7 @@ import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRows: MutationResolvers['createRows'] = async (
+const createRows: NonNullable<MutationResolvers['createRows']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
@@ -5,23 +5,22 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createShareableTableLink: MutationResolvers['createShareableTableLink'] =
-  async (_parent, params, context) => {
-    const tableId = params.tableId
+const createShareableTableLink: NonNullable<
+  MutationResolvers['createShareableTableLink']
+> = async (_parent, params, context) => {
+  const tableId = params.tableId
 
-    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-    const table = await TableMetadata.query()
-      .findById(tableId)
-      .throwIfNotFound()
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
 
-    const newViewOnlyKey = randomUUID()
+  const newViewOnlyKey = randomUUID()
 
-    await table.$query().patch({
-      viewOnlyKey: newViewOnlyKey,
-    })
+  await table.$query().patch({
+    viewOnlyKey: newViewOnlyKey,
+  })
 
-    return newViewOnlyKey
-  }
+  return newViewOnlyKey
+}
 
 export default createShareableTableLink

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -24,7 +24,7 @@ const PLACEHOLDER_ROWS = new Array(5).fill({})
 // DELETE THIS FLAG ONCE IT'S NO LONGER IN USE
 const DATABASE_TYPE_LD_FLAG_KEY = 'tiles-database-type'
 
-const createTable: MutationResolvers['createTable'] = async (
+const createTable: NonNullable<MutationResolvers['createTable']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
@@ -4,7 +4,7 @@ import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteRows: MutationResolvers['deleteRows'] = async (
+const deleteRows: NonNullable<MutationResolvers['deleteRows']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
@@ -6,57 +6,58 @@ import User from '@/models/user'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
-  async (_parent, params, context) => {
-    const { tableId, email } = params.input as {
-      tableId: string
-      email: string
-    }
-
-    const validatedEmail = await validateAndParseEmail(email)
-    if (!validatedEmail) {
-      throw new BadUserInputError('Invalid collaborator email')
-    }
-
-    if (validatedEmail === context.currentUser.email) {
-      throw new BadUserInputError('Cannot remove yourself')
-    }
-
-    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
-
-    const user = await User.query()
-      .findOne({
-        email: validatedEmail,
-      })
-      .throwIfNotFound('No such user found')
-
-    const collaboratorUser = await TableCollaborator.query()
-      .findOne({
-        table_id: tableId,
-        user_id: user.id,
-      })
-      .throwIfNotFound('No such collaborator found')
-
-    if (collaboratorUser.role === 'owner') {
-      throw new BadUserInputError('Cannot remove owner')
-    }
-
-    try {
-      await collaboratorUser.$query().delete()
-    } catch (e) {
-      logger.error({
-        message: 'Failed to delete collaborator',
-        data: {
-          tableId,
-          email,
-        },
-        userId: context.currentUser.id,
-        error: e,
-      })
-      throw new Error('Failed to delete collaborator')
-    }
-
-    return true
+const deleteTableCollaborator: NonNullable<
+  MutationResolvers['deleteTableCollaborator']
+> = async (_parent, params, context) => {
+  const { tableId, email } = params.input as {
+    tableId: string
+    email: string
   }
+
+  const validatedEmail = await validateAndParseEmail(email)
+  if (!validatedEmail) {
+    throw new BadUserInputError('Invalid collaborator email')
+  }
+
+  if (validatedEmail === context.currentUser.email) {
+    throw new BadUserInputError('Cannot remove yourself')
+  }
+
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+
+  const user = await User.query()
+    .findOne({
+      email: validatedEmail,
+    })
+    .throwIfNotFound('No such user found')
+
+  const collaboratorUser = await TableCollaborator.query()
+    .findOne({
+      table_id: tableId,
+      user_id: user.id,
+    })
+    .throwIfNotFound('No such collaborator found')
+
+  if (collaboratorUser.role === 'owner') {
+    throw new BadUserInputError('Cannot remove owner')
+  }
+
+  try {
+    await collaboratorUser.$query().delete()
+  } catch (e) {
+    logger.error({
+      message: 'Failed to delete collaborator',
+      data: {
+        tableId,
+        email,
+      },
+      userId: context.currentUser.id,
+      error: e,
+    })
+    throw new Error('Failed to delete collaborator')
+  }
+
+  return true
+}
 
 export default deleteTableCollaborator

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-shareable-link.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-shareable-link.ts
@@ -3,23 +3,22 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteShareableTableLink: MutationResolvers['deleteShareableTableLink'] =
-  async (_parent, params, context) => {
-    const tableId = params.tableId
+const deleteShareableTableLink: NonNullable<
+  MutationResolvers['deleteShareableTableLink']
+> = async (_parent, params, context) => {
+  const tableId = params.tableId
 
-    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-    const table = await TableMetadata.query()
-      .findById(tableId)
-      .throwIfNotFound()
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
 
-    await table.$query().patch({
-      viewOnlyKey: null,
-      // we also remove passwords when shareable link is disabled
-      viewOnlyPassword: null,
-    })
+  await table.$query().patch({
+    viewOnlyKey: null,
+    // we also remove passwords when shareable link is disabled
+    viewOnlyPassword: null,
+  })
 
-    return true
-  }
+  return true
+}
 
 export default deleteShareableTableLink

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-view-password.ts
@@ -3,22 +3,21 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteTableViewPassword: MutationResolvers['deleteTableViewPassword'] =
-  async (_parent, params, context) => {
-    const { tableId } = params
+const deleteTableViewPassword: NonNullable<
+  MutationResolvers['deleteTableViewPassword']
+> = async (_parent, params, context) => {
+  const { tableId } = params
 
-    // Must be at least editor
-    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+  // Must be at least editor
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-    const table = await TableMetadata.query()
-      .findById(tableId)
-      .throwIfNotFound()
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
 
-    await table.$query().patch({
-      viewOnlyPassword: null,
-    })
+  await table.$query().patch({
+    viewOnlyPassword: null,
+  })
 
-    return true
-  }
+  return true
+}
 
 export default deleteTableViewPassword

--- a/packages/backend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table.ts
@@ -4,7 +4,7 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteTable: MutationResolvers['deleteTable'] = async (
+const deleteTable: NonNullable<MutationResolvers['deleteTable']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
@@ -13,11 +13,9 @@ const setTableViewPasswordSchema = z.object({
   password: z.string().min(8).max(100),
 })
 
-const setTableViewPassword: MutationResolvers['setTableViewPassword'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const setTableViewPassword: NonNullable<
+  MutationResolvers['setTableViewPassword']
+> = async (_parent, params, context) => {
   const result = setTableViewPasswordSchema.safeParse(params.input)
   if (!result.success) {
     throw new BadUserInputError('Ensure password is 8-100 characters long')

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -4,7 +4,7 @@ import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const updateRow: MutationResolvers['updateRow'] = async (
+const updateRow: NonNullable<MutationResolvers['updateRow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -30,7 +30,7 @@ export const updateTableSchema = z.object({
   deletedColumns: z.array(z.string().uuid()).optional(),
 })
 
-const updateTable: MutationResolvers['updateTable'] = async (
+const updateTable: NonNullable<MutationResolvers['updateTable']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
@@ -9,118 +9,111 @@ import User from '@/models/user'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const upsertTableCollaborator: MutationResolvers['upsertTableCollaborator'] =
-  async (_parent, params, context) => {
-    const { tableId, email, role } = params.input as {
-      tableId: string
-      email: string
-      role: ITableCollabRole
-    }
+const upsertTableCollaborator: NonNullable<
+  MutationResolvers['upsertTableCollaborator']
+> = async (_parent, params, context) => {
+  const { tableId, email, role } = params.input as {
+    tableId: string
+    email: string
+    role: ITableCollabRole
+  }
 
-    const validatedEmail = await validateAndParseEmail(email)
-    if (!validatedEmail) {
-      throw new BadUserInputError('Invalid collaborator email')
-    }
+  const validatedEmail = await validateAndParseEmail(email)
+  if (!validatedEmail) {
+    throw new BadUserInputError('Invalid collaborator email')
+  }
 
-    if (context.currentUser.email === validatedEmail) {
-      throw new BadUserInputError('Cannot change own role')
-    }
+  if (context.currentUser.email === validatedEmail) {
+    throw new BadUserInputError('Cannot change own role')
+  }
 
-    let collaboratorUser: User
+  let collaboratorUser: User
 
-    if (role === 'owner') {
-      /**
-       * If transferring ownership, current user must be owner
-       * and new user must exist
-       */
-      await TableCollaborator.hasAccess(
-        context.currentUser.id,
-        tableId,
-        'owner',
+  if (role === 'owner') {
+    /**
+     * If transferring ownership, current user must be owner
+     * and new user must exist
+     */
+    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'owner')
+    collaboratorUser = await User.query().findOne({ email })
+    if (!collaboratorUser) {
+      throw new BadUserInputError(
+        'User not found. You can only transfer to users who have logged in at least once.',
       )
-      collaboratorUser = await User.query().findOne({ email })
-      if (!collaboratorUser) {
-        throw new BadUserInputError(
-          'User not found. You can only transfer to users who have logged in at least once.',
-        )
-      }
-    } else {
-      /**
-       * If mere adding collaborator, current user be editor
-       * and new user will be created if not exists
-       */
-      await TableCollaborator.hasAccess(
-        context.currentUser.id,
-        tableId,
-        'editor',
-      )
-      collaboratorUser = await getOrCreateUser(validatedEmail)
-      if (!collaboratorUser) {
-        throw new BadUserInputError('Error creating user')
-      }
     }
+  } else {
+    /**
+     * If mere adding collaborator, current user be editor
+     * and new user will be created if not exists
+     */
+    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+    collaboratorUser = await getOrCreateUser(validatedEmail)
+    if (!collaboratorUser) {
+      throw new BadUserInputError('Error creating user')
+    }
+  }
 
-    try {
+  try {
+    /**
+     * We check if a table collaborator has been added before (could have been soft deleted)
+     * If it exists, we update the role and undelete it (if it was soft deleted)
+     * If it doesn't exist, we insert a new record
+     */
+    await TableCollaborator.transaction(async (trx) => {
+      const existingCollaborator = await TableCollaborator.query(trx)
+        .findOne({
+          table_id: tableId,
+          user_id: collaboratorUser.id,
+        })
+        .withSoftDeleted()
       /**
-       * We check if a table collaborator has been added before (could have been soft deleted)
-       * If it exists, we update the role and undelete it (if it was soft deleted)
-       * If it doesn't exist, we insert a new record
+       * Upsert collaborator here
        */
-      await TableCollaborator.transaction(async (trx) => {
-        const existingCollaborator = await TableCollaborator.query(trx)
-          .findOne({
-            table_id: tableId,
-            user_id: collaboratorUser.id,
+      if (existingCollaborator) {
+        if (existingCollaborator.role === 'owner') {
+          throw new BadUserInputError('Cannot change owner role')
+        }
+        await existingCollaborator
+          .$query(trx)
+          .patchAndFetch({
+            role,
+            deletedAt: null,
           })
           .withSoftDeleted()
-        /**
-         * Upsert collaborator here
-         */
-        if (existingCollaborator) {
-          if (existingCollaborator.role === 'owner') {
-            throw new BadUserInputError('Cannot change owner role')
-          }
-          await existingCollaborator
-            .$query(trx)
-            .patchAndFetch({
-              role,
-              deletedAt: null,
-            })
-            .withSoftDeleted()
-        } else {
-          await TableCollaborator.query(trx).insert({
-            tableId,
-            userId: collaboratorUser.id,
-            role,
-          })
-        }
-
-        /**
-         * When transferring ownership, we need to make sure the current owner is set to editor
-         */
-        if (role === 'owner') {
-          await TableCollaborator.query(trx)
-            .where({ table_id: tableId, user_id: context.currentUser.id })
-            .update({
-              role: 'editor',
-            })
-        }
-      })
-    } catch (e) {
-      logger.error({
-        message: 'Failed to upsert collaborator',
-        data: {
+      } else {
+        await TableCollaborator.query(trx).insert({
           tableId,
-          email,
+          userId: collaboratorUser.id,
           role,
-        },
-        userId: context.currentUser.id,
-        error: e,
-      })
-      throw new Error(e.message ?? 'Failed to upsert collaborator')
-    }
+        })
+      }
 
-    return true
+      /**
+       * When transferring ownership, we need to make sure the current owner is set to editor
+       */
+      if (role === 'owner') {
+        await TableCollaborator.query(trx)
+          .where({ table_id: tableId, user_id: context.currentUser.id })
+          .update({
+            role: 'editor',
+          })
+      }
+    })
+  } catch (e) {
+    logger.error({
+      message: 'Failed to upsert collaborator',
+      data: {
+        tableId,
+        email,
+        role,
+      },
+      userId: context.currentUser.id,
+      error: e,
+    })
+    throw new Error(e.message ?? 'Failed to upsert collaborator')
   }
+
+  return true
+}
 
 export default upsertTableCollaborator

--- a/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
@@ -6,44 +6,43 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const verifyTableViewPassword: MutationResolvers['verifyTableViewPassword'] =
-  async (_parent, params, context) => {
-    const { tableId, password } = params.input
+const verifyTableViewPassword: NonNullable<
+  MutationResolvers['verifyTableViewPassword']
+> = async (_parent, params, context) => {
+  const { tableId, password } = params.input
 
-    const table = await TableMetadata.query()
-      .findById(tableId)
-      .throwIfNotFound()
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
 
-    /**
-     * We check that shareable link is enabled first
-     */
-    if (!table.viewOnlyKey || !table.viewOnlyPassword) {
-      throw new ForbiddenError("Shareable link or password isn't enabled.")
-    }
-
-    if (
-      // If shareable link view key is not provided
-      !context.tilesViewKey ||
-      // If shareable link view key does not match
-      !timingSafeEqual(
-        Buffer.from(table.viewOnlyKey),
-        Buffer.from(context.tilesViewKey),
-      ) ||
-      // If password is incorrect
-      !verifyTilePassword(
-        password,
-        table.viewOnlyPassword.hash,
-        context.tilesViewKey,
-      )
-    ) {
-      throw new ForbiddenError('Invalid password')
-    }
-    const token = generateViewToken(
-      table.id,
-      table.viewOnlyKey,
-      table.viewOnlyPassword.tokenNonce,
-    )
-    return token
+  /**
+   * We check that shareable link is enabled first
+   */
+  if (!table.viewOnlyKey || !table.viewOnlyPassword) {
+    throw new ForbiddenError("Shareable link or password isn't enabled.")
   }
+
+  if (
+    // If shareable link view key is not provided
+    !context.tilesViewKey ||
+    // If shareable link view key does not match
+    !timingSafeEqual(
+      Buffer.from(table.viewOnlyKey),
+      Buffer.from(context.tilesViewKey),
+    ) ||
+    // If password is incorrect
+    !verifyTilePassword(
+      password,
+      table.viewOnlyPassword.hash,
+      context.tilesViewKey,
+    )
+  ) {
+    throw new ForbiddenError('Invalid password')
+  }
+  const token = generateViewToken(
+    table.id,
+    table.viewOnlyKey,
+    table.viewOnlyPassword.tokenNonce,
+  )
+  return token
+}
 
 export default verifyTableViewPassword

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -6,11 +6,9 @@ import type { MutationResolvers } from '../__generated__/types.generated'
 // Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data
 // Scanner
 
-const updateConnection: MutationResolvers['updateConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const updateConnection: NonNullable<
+  MutationResolvers['updateConnection']
+> = async (_parent, params, context) => {
   const flow = await context.currentUser
     .withAccessibleFlows({ requiredRole: 'editor' })
     .findById(params.input.flowId)

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -37,11 +37,9 @@ const validateFlowSteps = (steps: Step[]) => {
   }
 }
 
-const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const updateFlowStatus: NonNullable<
+  MutationResolvers['updateFlowStatus']
+> = async (_parent, params, context) => {
   const flow = await context.currentUser
     .withAccessibleFlows({ requiredRole: 'editor' })
     .findOne({

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -18,295 +18,296 @@ import type { MutationResolvers } from '../__generated__/types.generated'
  * 2. Approve a flow transfer AND update flow owner id as a single transaction
  */
 
-const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
-  async (_parent, params, context) => {
-    const { id, status } = params.input
+const updateFlowTransferStatus: NonNullable<
+  MutationResolvers['updateFlowTransferStatus']
+> = async (_parent, params, context) => {
+  const { id, status } = params.input
 
-    if (status === 'pending') {
-      throw new Error('No updating of pipe transfer back to pending')
-    }
+  if (status === 'pending') {
+    throw new Error('No updating of pipe transfer back to pending')
+  }
 
-    const flowTransfer = await FlowTransfer.query()
-      .findOne({ id })
-      .withGraphFetched({ newOwner: true })
-      .throwIfNotFound()
+  const flowTransfer = await FlowTransfer.query()
+    .findOne({ id })
+    .withGraphFetched({ newOwner: true })
+    .throwIfNotFound()
 
-    // To prevent possible exploits: for approved/rejected status: check if new owner matches
-    if (
-      (status === 'approved' || status === 'rejected') &&
-      flowTransfer.newOwnerId !== context.currentUser.id
-    ) {
-      throw new Error('Pipe transfer request does not belong to new owner')
-    }
+  // To prevent possible exploits: for approved/rejected status: check if new owner matches
+  if (
+    (status === 'approved' || status === 'rejected') &&
+    flowTransfer.newOwnerId !== context.currentUser.id
+  ) {
+    throw new Error('Pipe transfer request does not belong to new owner')
+  }
 
-    // for cancelled status: check if old owner matches
-    if (
-      status === 'cancelled' &&
-      flowTransfer.oldOwnerId !== context.currentUser.id
-    ) {
-      throw new Error('Pipe transfer request does not belong to old owner')
-    }
+  // for cancelled status: check if old owner matches
+  if (
+    status === 'cancelled' &&
+    flowTransfer.oldOwnerId !== context.currentUser.id
+  ) {
+    throw new Error('Pipe transfer request does not belong to old owner')
+  }
 
-    if (status === 'rejected' || status === 'cancelled') {
-      return await flowTransfer.$query().patchAndFetch({
-        status,
-      })
-    }
+  if (status === 'rejected' || status === 'cancelled') {
+    return await flowTransfer.$query().patchAndFetch({
+      status,
+    })
+  }
 
-    // Approval flow: only fetch flow here instead of doing it above unnecessarily
-    const flow = await Flow.query()
-      .findOne({
-        id: flowTransfer.flowId,
-      })
-      .withGraphFetched({
-        steps: {
-          connection: true,
-        },
-      })
-      .throwIfNotFound('Pipe to be transferred cannot be found')
+  // Approval flow: only fetch flow here instead of doing it above unnecessarily
+  const flow = await Flow.query()
+    .findOne({
+      id: flowTransfer.flowId,
+    })
+    .withGraphFetched({
+      steps: {
+        connection: true,
+      },
+    })
+    .throwIfNotFound('Pipe to be transferred cannot be found')
 
-    /**
-     * This transaction does the following to complete a flow transfer:
-     * - Duplicate all connections in the connections table and nullify the user ids
-     *   (EXCEPT M365-excel: nullify all connections)
-     * - Patch the steps to reference the duplicate connection(s)
-     * - Share all connections and tables to flow_connections (if not already shared)
-     * - Add the new owner as an editor in the table (if not already an editor)
-     * - Update the flow id to the new owner
-     * - Update the flow transfer status to 'approved'
-     */
-    return await FlowTransfer.transaction(async (trx) => {
-      // logging for recovery purposes
-      const connectionIds: string[] = []
-      const tableIds: string[] = []
-      const stepIds: string[] = []
-      flow.steps.forEach((step) => {
-        if (step.connectionId) {
-          stepIds.push(step.id)
-          connectionIds.push(step.connectionId)
-        }
-        if (step.parameters.tableId) {
-          tableIds.push(step.parameters.tableId as string)
-        }
-      })
-
-      logger.info('Flow transfer details', {
-        event: 'flow-transfer-request',
-        flowTransferId: id,
-        flowId: flow.id,
-        connectionIds,
-        tableIds,
-        stepIds,
-      })
-
-      // PRE-TRANSFER WORK
-      // nullify connections for M365-excel
-      // excel connections cannot be shared; the new owner should use their own connection
-      const excelStepIds = flow.steps
-        .filter(
-          (step) => step.appKey === 'm365-excel' && step.connectionId != null,
-        )
-        .map((step) => step.id)
-      const numExcelNullified = await Step.query(trx)
-        .patch({ connection: null, connectionId: null, status: 'incomplete' })
-        .where('flow_id', flow.id)
-        .whereNotNull('connection_id')
-        .andWhere('app_key', 'm365-excel')
-
-      // invalidate the execution steps for the m365-excel actions
-      // so that it does not show as an error in the pipe editor
-      // there is no impact to executions history as they will still be visible
-      await ExecutionStep.query(trx).delete().whereIn('step_id', excelStepIds)
-
-      // sanity check that only the connections belonging to the flow is nullified
-      if (numExcelNullified !== excelStepIds.length) {
-        throw new Error(
-          'Update query went wrong, please contact plumber@open.gov.sg for more support',
-        )
+  /**
+   * This transaction does the following to complete a flow transfer:
+   * - Duplicate all connections in the connections table and nullify the user ids
+   *   (EXCEPT M365-excel: nullify all connections)
+   * - Patch the steps to reference the duplicate connection(s)
+   * - Share all connections and tables to flow_connections (if not already shared)
+   * - Add the new owner as an editor in the table (if not already an editor)
+   * - Update the flow id to the new owner
+   * - Update the flow transfer status to 'approved'
+   */
+  return await FlowTransfer.transaction(async (trx) => {
+    // logging for recovery purposes
+    const connectionIds: string[] = []
+    const tableIds: string[] = []
+    const stepIds: string[] = []
+    flow.steps.forEach((step) => {
+      if (step.connectionId) {
+        stepIds.push(step.id)
+        connectionIds.push(step.connectionId)
       }
+      if (step.parameters.tableId) {
+        tableIds.push(step.parameters.tableId as string)
+      }
+    })
 
-      // HANDLE CONNECTIONS
-      // get the connections and tables to be shared
-      // intentionally exclude m365-excel as the connection has been nullified
-      // and it should retain the user_id in the connections table
-      const connectionDetails = await getConnectionDetails(
-        flow?.steps.filter((step) => step.appKey !== 'm365-excel'),
+    logger.info('Flow transfer details', {
+      event: 'flow-transfer-request',
+      flowTransferId: id,
+      flowId: flow.id,
+      connectionIds,
+      tableIds,
+      stepIds,
+    })
+
+    // PRE-TRANSFER WORK
+    // nullify connections for M365-excel
+    // excel connections cannot be shared; the new owner should use their own connection
+    const excelStepIds = flow.steps
+      .filter(
+        (step) => step.appKey === 'm365-excel' && step.connectionId != null,
       )
-      const sharedConnections = connectionDetails.connection
-      const sharedTables = connectionDetails.table
+      .map((step) => step.id)
+    const numExcelNullified = await Step.query(trx)
+      .patch({ connection: null, connectionId: null, status: 'incomplete' })
+      .where('flow_id', flow.id)
+      .whereNotNull('connection_id')
+      .andWhere('app_key', 'm365-excel')
 
-      if (Object.keys(sharedConnections).length > 0) {
-        // duplicate the connections in the connections table and nullify the IDs
-        await Promise.all(
-          Object.entries(sharedConnections).map(
-            async ([connectionId, metadata]) => {
-              const duplicatedConnection = await Connection.duplicate(
-                connectionId,
+    // invalidate the execution steps for the m365-excel actions
+    // so that it does not show as an error in the pipe editor
+    // there is no impact to executions history as they will still be visible
+    await ExecutionStep.query(trx).delete().whereIn('step_id', excelStepIds)
+
+    // sanity check that only the connections belonging to the flow is nullified
+    if (numExcelNullified !== excelStepIds.length) {
+      throw new Error(
+        'Update query went wrong, please contact plumber@open.gov.sg for more support',
+      )
+    }
+
+    // HANDLE CONNECTIONS
+    // get the connections and tables to be shared
+    // intentionally exclude m365-excel as the connection has been nullified
+    // and it should retain the user_id in the connections table
+    const connectionDetails = await getConnectionDetails(
+      flow?.steps.filter((step) => step.appKey !== 'm365-excel'),
+    )
+    const sharedConnections = connectionDetails.connection
+    const sharedTables = connectionDetails.table
+
+    if (Object.keys(sharedConnections).length > 0) {
+      // duplicate the connections in the connections table and nullify the IDs
+      await Promise.all(
+        Object.entries(sharedConnections).map(
+          async ([connectionId, metadata]) => {
+            const duplicatedConnection = await Connection.duplicate(
+              connectionId,
+              trx,
+            )
+
+            if (duplicatedConnection) {
+              const { id: newConnectionId } = duplicatedConnection
+              const existingFlowConnection = await FlowConnections.query(
                 trx,
-              )
+              ).findOne({
+                flow_id: flow.id,
+                connection_id: connectionId,
+              })
 
-              if (duplicatedConnection) {
-                const { id: newConnectionId } = duplicatedConnection
-                const existingFlowConnection = await FlowConnections.query(
-                  trx,
-                ).findOne({
-                  flow_id: flow.id,
-                  connection_id: connectionId,
-                })
-
-                // update or create flow connection using the duplicated connection
-                if (existingFlowConnection) {
-                  await existingFlowConnection
-                    .$query(trx)
-                    .patchAndFetch({
-                      connectionId: newConnectionId,
-                    })
-                    .where({
-                      flow_id: flow.id,
-                      connection_id: connectionId,
-                    })
-                } else {
-                  await FlowConnections.query(trx).insertAndFetch({
-                    flowId: flow.id,
+              // update or create flow connection using the duplicated connection
+              if (existingFlowConnection) {
+                await existingFlowConnection
+                  .$query(trx)
+                  .patchAndFetch({
                     connectionId: newConnectionId,
-                    addedBy: flow.userId,
-                    connectionType: 'connection',
-                    metadata: metadata,
                   })
-                }
-
-                // patch the steps to reference the duplicate connection(s)
-                await Step.query(trx)
-                  .patch({ connectionId: newConnectionId })
-                  .where('flow_id', flow.id)
-                  .whereNotNull('connection_id')
-                  .where('connection_id', connectionId)
-
-                return {
+                  .where({
+                    flow_id: flow.id,
+                    connection_id: connectionId,
+                  })
+              } else {
+                await FlowConnections.query(trx).insertAndFetch({
                   flowId: flow.id,
                   connectionId: newConnectionId,
                   addedBy: flow.userId,
                   connectionType: 'connection',
                   metadata: metadata,
-                }
+                })
               }
-            },
-          ),
-        )
-      }
 
-      // HANDLE TABLES
-      // table connections are not duplicated as the owner of the table stays the same
-      // the new owner only becomes an editor of the table
-      // if the table needs to be transferred, it should be done from the Tile
-      if (sharedTables.length > 0) {
-        const tableInserts = await Promise.all(
-          sharedTables.map(async (tableId) => {
-            try {
-              // the old owner should have the permissions to add the new owner as an editor of the table
-              await TableCollaborator.hasAccess(
-                flowTransfer.oldOwnerId,
-                tableId,
-                'editor',
+              // patch the steps to reference the duplicate connection(s)
+              await Step.query(trx)
+                .patch({ connectionId: newConnectionId })
+                .where('flow_id', flow.id)
+                .whereNotNull('connection_id')
+                .where('connection_id', connectionId)
+
+              return {
+                flowId: flow.id,
+                connectionId: newConnectionId,
+                addedBy: flow.userId,
+                connectionType: 'connection',
+                metadata: metadata,
+              }
+            }
+          },
+        ),
+      )
+    }
+
+    // HANDLE TABLES
+    // table connections are not duplicated as the owner of the table stays the same
+    // the new owner only becomes an editor of the table
+    // if the table needs to be transferred, it should be done from the Tile
+    if (sharedTables.length > 0) {
+      const tableInserts = await Promise.all(
+        sharedTables.map(async (tableId) => {
+          try {
+            // the old owner should have the permissions to add the new owner as an editor of the table
+            await TableCollaborator.hasAccess(
+              flowTransfer.oldOwnerId,
+              tableId,
+              'editor',
+            )
+
+            // there may be instances where the new pipe owner is already the owner of the table
+            // we catch the error but do nothing`
+            await TableCollaborator.upgradeOrInsertCollaborator({
+              userId: context.currentUser.id, // the new owner
+              tableId,
+              role: 'editor',
+              trx,
+            })
+          } catch (e) {
+            if (e instanceof ForbiddenError) {
+              throw new Error(
+                'Previous owner does not have sufficient permissions to add you as an Editor of the Tile.',
               )
-
-              // there may be instances where the new pipe owner is already the owner of the table
-              // we catch the error but do nothing`
-              await TableCollaborator.upgradeOrInsertCollaborator({
-                userId: context.currentUser.id, // the new owner
-                tableId,
-                role: 'editor',
-                trx,
-              })
-            } catch (e) {
-              if (e instanceof ForbiddenError) {
-                throw new Error(
-                  'Previous owner does not have sufficient permissions to add you as an Editor of the Tile.',
-                )
-              }
-              // do nothing if the new owner of the pipe is already the owner of the tile
-              if (
-                !(e instanceof BadUserInputError) &&
-                e.message !== 'Cannot change owner role'
-              ) {
-                throw new Error(e)
-              }
             }
-
-            // always return the table
-            return {
-              flowId: flow.id,
-              connectionId: tableId,
-              addedBy: flow.userId,
-              connectionType: 'table' as const,
+            // do nothing if the new owner of the pipe is already the owner of the tile
+            if (
+              !(e instanceof BadUserInputError) &&
+              e.message !== 'Cannot change owner role'
+            ) {
+              throw new Error(e)
             }
-          }),
-        )
+          }
 
-        // add all tables to the flow_connections table
-        await FlowConnections.query(trx)
-          .insert(tableInserts)
-          .onConflict(['flow_id', 'connection_id'])
-          .ignore()
-      }
+          // always return the table
+          return {
+            flowId: flow.id,
+            connectionId: tableId,
+            addedBy: flow.userId,
+            connectionType: 'table' as const,
+          }
+        }),
+      )
 
-      // HANDLE FLOW COLLABORATORS
-      // - check if the current owner was once a collaborator
-      // - update the role if they were a collaborator
-      // - otherwise, create a new record
-      const existingCollaborator = await FlowCollaborator.query(trx)
-        .findOne({
-          flow_id: flow.id,
-          user_id: flow.userId,
-        })
-        .withSoftDeleted()
+      // add all tables to the flow_connections table
+      await FlowConnections.query(trx)
+        .insert(tableInserts)
+        .onConflict(['flow_id', 'connection_id'])
+        .ignore()
+    }
 
-      if (!existingCollaborator) {
-        await FlowCollaborator.query(trx).insert({
-          flowId: flow.id,
-          userId: flow.userId,
-          role: 'editor',
-          updatedBy: context.currentUser.id,
-        })
-      } else {
-        await existingCollaborator.$query(trx).patchAndFetch({
-          role: 'editor',
-          deletedAt: null,
-          updatedBy: context.currentUser.id,
-        })
-      }
-
-      // remove the new owner from the flow collaborators
-      const isNewOwnerCollaborator = await FlowCollaborator.query(trx).findOne({
+    // HANDLE FLOW COLLABORATORS
+    // - check if the current owner was once a collaborator
+    // - update the role if they were a collaborator
+    // - otherwise, create a new record
+    const existingCollaborator = await FlowCollaborator.query(trx)
+      .findOne({
         flow_id: flow.id,
-        user_id: context.currentUser.id,
+        user_id: flow.userId,
       })
+      .withSoftDeleted()
 
-      if (isNewOwnerCollaborator) {
-        await FlowCollaborator.deleteCollaborator({
-          userId: context.currentUser.id,
-          flowId: flow.id,
-          trx,
-        })
-      }
-
-      // make the current owner a collaborator in the flow
-      await FlowCollaborator.upsertCollaborator({
-        userId: flow.userId,
+    if (!existingCollaborator) {
+      await FlowCollaborator.query(trx).insert({
         flowId: flow.id,
+        userId: flow.userId,
         role: 'editor',
         updatedBy: context.currentUser.id,
+      })
+    } else {
+      await existingCollaborator.$query(trx).patchAndFetch({
+        role: 'editor',
+        deletedAt: null,
+        updatedBy: context.currentUser.id,
+      })
+    }
+
+    // remove the new owner from the flow collaborators
+    const isNewOwnerCollaborator = await FlowCollaborator.query(trx).findOne({
+      flow_id: flow.id,
+      user_id: context.currentUser.id,
+    })
+
+    if (isNewOwnerCollaborator) {
+      await FlowCollaborator.deleteCollaborator({
+        userId: context.currentUser.id,
+        flowId: flow.id,
         trx,
       })
+    }
 
-      // update the flow owner id
-      await flow.$query(trx).patchAndFetch({ userId: context.currentUser.id })
-
-      // FINALLY, MARK THE FLOW TRANSFER AS APPROVED AND COMPLETED
-      return await flowTransfer.$query(trx).patchAndFetch({
-        status,
-      })
+    // make the current owner a collaborator in the flow
+    await FlowCollaborator.upsertCollaborator({
+      userId: flow.userId,
+      flowId: flow.id,
+      role: 'editor',
+      updatedBy: context.currentUser.id,
+      trx,
     })
-  }
+
+    // update the flow owner id
+    await flow.$query(trx).patchAndFetch({ userId: context.currentUser.id })
+
+    // FINALLY, MARK THE FLOW TRANSFER AS APPROVED AND COMPLETED
+    return await flowTransfer.$query(trx).patchAndFetch({
+      status,
+    })
+  })
+}
 
 export default updateFlowTransferStatus

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -1,6 +1,6 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateFlow: MutationResolvers['updateFlow'] = async (
+const updateFlow: NonNullable<MutationResolvers['updateFlow']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -12,11 +12,9 @@ import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const updateStepPositions: NonNullable<
+  MutationResolvers['updateStepPositions']
+> = async (_parent, params, context) => {
   const { input } = params
   const { stepPositions } = input
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -13,7 +13,7 @@ import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateStep: MutationResolvers['updateStep'] = async (
+const updateStep: NonNullable<MutationResolvers['updateStep']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -12,158 +12,159 @@ import FlowCollaborator from '@/models/flow-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
-  async (_parent, params, context) => {
-    const { flowId, email, role } = params.input as {
-      flowId: string
-      email: string
-      role: IFlowCollabRole
-    }
+const upsertFlowCollaborator: NonNullable<
+  MutationResolvers['upsertFlowCollaborator']
+> = async (_parent, params, context) => {
+  const { flowId, email, role } = params.input as {
+    flowId: string
+    email: string
+    role: IFlowCollabRole
+  }
 
-    // TODO (kevinkim-ogp): remove this once collaborators is released to all
-    const collaboratorsFlag = await getLdFlagValue(
-      'collaborators',
-      context.currentUser.email,
-      false,
-    )
-    if (!collaboratorsFlag) {
-      throw new ForbiddenError(' You are not allowed to add collaborators.')
-    }
+  // TODO (kevinkim-ogp): remove this once collaborators is released to all
+  const collaboratorsFlag = await getLdFlagValue(
+    'collaborators',
+    context.currentUser.email,
+    false,
+  )
+  if (!collaboratorsFlag) {
+    throw new ForbiddenError(' You are not allowed to add collaborators.')
+  }
 
-    const validatedEmail = await validateAndParseEmail(email)
-    if (!validatedEmail) {
-      throw new BadUserInputError('Invalid collaborator email')
-    }
+  const validatedEmail = await validateAndParseEmail(email)
+  if (!validatedEmail) {
+    throw new BadUserInputError('Invalid collaborator email')
+  }
 
-    if (context.currentUser.email === validatedEmail) {
-      throw new BadUserInputError('Cannot change own role')
-    }
+  if (context.currentUser.email === validatedEmail) {
+    throw new BadUserInputError('Cannot change own role')
+  }
 
-    try {
+  try {
+    /**
+     * We check if a flow collaborator has been added before (could have been soft deleted)
+     * and if so, we update the role
+     */
+    await FlowCollaborator.transaction(async (trx) => {
       /**
-       * We check if a flow collaborator has been added before (could have been soft deleted)
-       * and if so, we update the role
+       * this mutation only allows for adding / updating collaborators.
+       * flow transfer is still handled by the updateFlowTransferStatus mutation.
+       * new user will be created if not exists
        */
-      await FlowCollaborator.transaction(async (trx) => {
-        /**
-         * this mutation only allows for adding / updating collaborators.
-         * flow transfer is still handled by the updateFlowTransferStatus mutation.
-         * new user will be created if not exists
-         */
-        await FlowCollaborator.hasAccess({
-          userId: context.currentUser.id,
-          flowId,
-          requiredRole: 'editor',
-          trx,
-        })
+      await FlowCollaborator.hasAccess({
+        userId: context.currentUser.id,
+        flowId,
+        requiredRole: 'editor',
+        trx,
+      })
 
-        /**
-         * NOTE: we only automatically add all connections
-         * in the Pipe to the flow_connections table the first time
-         * the Pipe is shared.
-         *
-         * What is added:
-         * 1. Connections
-         * 2. Connection metadata, i.e. fields that are like connections:
-         *    see helpers/get-shared-connection-details.ts for more details
-         */
-        const hasCollaborators = await Flow.hasCollaborators({
-          flowId,
-          trx,
-        })
+      /**
+       * NOTE: we only automatically add all connections
+       * in the Pipe to the flow_connections table the first time
+       * the Pipe is shared.
+       *
+       * What is added:
+       * 1. Connections
+       * 2. Connection metadata, i.e. fields that are like connections:
+       *    see helpers/get-shared-connection-details.ts for more details
+       */
+      const hasCollaborators = await Flow.hasCollaborators({
+        flowId,
+        trx,
+      })
 
-        const flow = await Flow.query(trx)
-          .withGraphFetched('steps')
-          .findById(flowId)
-        const connectionDetails = await getConnectionDetails(flow?.steps)
+      const flow = await Flow.query(trx)
+        .withGraphFetched('steps')
+        .findById(flowId)
+      const connectionDetails = await getConnectionDetails(flow?.steps)
 
-        if (!hasCollaborators) {
-          // add all connections to the flow_connections table
-          // first time sharing is always by the owner
-          // so we use the flow user_id
-          const connectionInserts = Object.entries(
-            connectionDetails.connection,
-          ).map(([connectionId, metadata]) => ({
-            flow_id: flowId,
-            connection_id: connectionId,
-            added_by: flow.userId,
-            connection_type: 'connection' as const,
-            metadata,
-          }))
+      if (!hasCollaborators) {
+        // add all connections to the flow_connections table
+        // first time sharing is always by the owner
+        // so we use the flow user_id
+        const connectionInserts = Object.entries(
+          connectionDetails.connection,
+        ).map(([connectionId, metadata]) => ({
+          flow_id: flowId,
+          connection_id: connectionId,
+          added_by: flow.userId,
+          connection_type: 'connection' as const,
+          metadata,
+        }))
 
-          if (connectionInserts.length > 0) {
-            await trx
-              .table('flow_connections')
-              .insert(connectionInserts)
-              .onConflict(['flow_id', 'connection_id'])
-              .ignore()
-          }
+        if (connectionInserts.length > 0) {
+          await trx
+            .table('flow_connections')
+            .insert(connectionInserts)
+            .onConflict(['flow_id', 'connection_id'])
+            .ignore()
         }
+      }
 
-        const collaboratorUser = await getOrCreateUser(validatedEmail)
-        if (!collaboratorUser) {
-          throw new BadUserInputError('Error creating user')
-        }
+      const collaboratorUser = await getOrCreateUser(validatedEmail)
+      if (!collaboratorUser) {
+        throw new BadUserInputError('Error creating user')
+      }
 
-        const existingCollaborator = await FlowCollaborator.query(trx)
-          .findOne({
-            flow_id: flowId,
-            user_id: collaboratorUser.id,
-          })
-          .withSoftDeleted()
+      const existingCollaborator = await FlowCollaborator.query(trx)
+        .findOne({
+          flow_id: flowId,
+          user_id: collaboratorUser.id,
+        })
+        .withSoftDeleted()
 
-        if (existingCollaborator) {
-          await existingCollaborator
-            .$query(trx)
-            .patchAndFetch({
-              role,
-              deletedAt: null,
-              updatedBy: context.currentUser.id,
-            })
-            .withSoftDeleted()
-        } else {
-          await FlowCollaborator.query(trx).insert({
-            flowId,
-            userId: collaboratorUser.id,
+      if (existingCollaborator) {
+        await existingCollaborator
+          .$query(trx)
+          .patchAndFetch({
             role,
+            deletedAt: null,
             updatedBy: context.currentUser.id,
           })
-        }
-
-        /**
-         * use Promise.all so that we use the addFlowTableConnection function, which checks
-         * if the collaborator already exists to avoid duplicates and adds the tile to
-         * flow_connections at the same time
-         */
-        if (connectionDetails.table.length > 0) {
-          await Promise.all(
-            connectionDetails.table.map(async (tableId) => {
-              await addFlowTableConnection({
-                flowId,
-                tableId,
-                addedBy: context.currentUser.id,
-                flowOwnerId: flow.userId,
-                trx,
-              })
-            }),
-          )
-        }
-      })
-    } catch (error) {
-      logger.error({
-        message: 'Error upserting flow collaborator',
-        data: {
+          .withSoftDeleted()
+      } else {
+        await FlowCollaborator.query(trx).insert({
           flowId,
-          email,
+          userId: collaboratorUser.id,
           role,
-        },
-        userId: context.currentUser.id,
-        error,
-      })
-      throw new Error(error.message ?? 'Error upserting flow collaborator')
-    }
+          updatedBy: context.currentUser.id,
+        })
+      }
 
-    return true
+      /**
+       * use Promise.all so that we use the addFlowTableConnection function, which checks
+       * if the collaborator already exists to avoid duplicates and adds the tile to
+       * flow_connections at the same time
+       */
+      if (connectionDetails.table.length > 0) {
+        await Promise.all(
+          connectionDetails.table.map(async (tableId) => {
+            await addFlowTableConnection({
+              flowId,
+              tableId,
+              addedBy: context.currentUser.id,
+              flowOwnerId: flow.userId,
+              trx,
+            })
+          }),
+        )
+      }
+    })
+  } catch (error) {
+    logger.error({
+      message: 'Error upserting flow collaborator',
+      data: {
+        flowId,
+        email,
+        role,
+      },
+      userId: context.currentUser.id,
+      error,
+    })
+    throw new Error(error.message ?? 'Error upserting flow collaborator')
   }
+
+  return true
+}
 
 export default upsertFlowCollaborator

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -9,11 +9,9 @@ import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const verifyConnection: MutationResolvers['verifyConnection'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const verifyConnection: NonNullable<
+  MutationResolvers['verifyConnection']
+> = async (_parent, params, context) => {
   const flow = await context.currentUser
     .withAccessibleFlows({ requiredRole: 'editor' })
     .findById(params.input.flowId)

--- a/packages/backend/src/graphql/mutations/verify-otp.ts
+++ b/packages/backend/src/graphql/mutations/verify-otp.ts
@@ -11,7 +11,7 @@ const MAX_OTP_ATTEMPTS = 5
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const verifyOtp: MutationResolvers['verifyOtp'] = async (
+const verifyOtp: NonNullable<MutationResolvers['verifyOtp']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/get-app.ts
+++ b/packages/backend/src/graphql/queries/get-app.ts
@@ -47,7 +47,11 @@ const getSharedConnections = async (
   }
 }
 
-const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
+const getApp: NonNullable<QueryResolvers['getApp']> = async (
+  _parent,
+  params,
+  context,
+) => {
   const { flowId, key } = params
   const app = await App.findOneByKey(key)
 

--- a/packages/backend/src/graphql/queries/get-connected-apps.ts
+++ b/packages/backend/src/graphql/queries/get-connected-apps.ts
@@ -2,11 +2,9 @@ import App from '@/models/app'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getConnectedApps: QueryResolvers['getConnectedApps'] = async (
-  _parent,
-  _params,
-  context,
-) => {
+const getConnectedApps: NonNullable<
+  QueryResolvers['getConnectedApps']
+> = async (_parent, _params, context) => {
   let apps = await App.findAll()
 
   const connections = await context.currentUser

--- a/packages/backend/src/graphql/queries/get-current-user.ts
+++ b/packages/backend/src/graphql/queries/get-current-user.ts
@@ -2,7 +2,7 @@ import User from '@/models/user'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getCurrentUser: QueryResolvers['getCurrentUser'] = async (
+const getCurrentUser: NonNullable<QueryResolvers['getCurrentUser']> = async (
   _parent,
   _params,
   context,

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -7,7 +7,7 @@ import globalVariable from '@/helpers/global-variable'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getDynamicData: QueryResolvers['getDynamicData'] = async (
+const getDynamicData: NonNullable<QueryResolvers['getDynamicData']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-execution-steps.ts
@@ -4,11 +4,9 @@ import paginate from '@/helpers/pagination'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const getExecutionSteps: NonNullable<
+  QueryResolvers['getExecutionSteps']
+> = async (_parent, params, context) => {
   const execution = await context.currentUser
     .withAccessibleExecutions({ requiredRole: 'viewer' })
     .withGraphFetched({ executionSteps: true })

--- a/packages/backend/src/graphql/queries/get-execution.ts
+++ b/packages/backend/src/graphql/queries/get-execution.ts
@@ -1,6 +1,6 @@
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getExecution: QueryResolvers['getExecution'] = async (
+const getExecution: NonNullable<QueryResolvers['getExecution']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/get-executions.ts
+++ b/packages/backend/src/graphql/queries/get-executions.ts
@@ -14,7 +14,7 @@ import type { QueryResolvers } from '../__generated__/types.generated'
 // rather than hiding data the archival job will never remove.
 const EXECUTION_HISTORY_WINDOW = { months: 3 }
 
-const getExecutions: QueryResolvers['getExecutions'] = async (
+const getExecutions: NonNullable<QueryResolvers['getExecutions']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/get-flow-connections.ts
+++ b/packages/backend/src/graphql/queries/get-flow-connections.ts
@@ -15,11 +15,9 @@ function findApp(appKey: string, apps: IApp[]): IApp {
   return app
 }
 
-const getFlowConnections: QueryResolvers['getFlowConnections'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const getFlowConnections: NonNullable<
+  QueryResolvers['getFlowConnections']
+> = async (_parent, params, context) => {
   const apps = await App.findAll()
 
   const flow = await context.currentUser

--- a/packages/backend/src/graphql/queries/get-flow-transfer-details.ts
+++ b/packages/backend/src/graphql/queries/get-flow-transfer-details.ts
@@ -7,11 +7,9 @@ import globalVariable from '@/helpers/global-variable'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getFlowTransferDetails: QueryResolvers['getFlowTransferDetails'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const getFlowTransferDetails: NonNullable<
+  QueryResolvers['getFlowTransferDetails']
+> = async (_parent, params, context) => {
   const flowTransferDetails: ITransferDetails[] = []
 
   const flow = await context.currentUser

--- a/packages/backend/src/graphql/queries/get-flow.ts
+++ b/packages/backend/src/graphql/queries/get-flow.ts
@@ -2,7 +2,11 @@ import { z } from 'zod'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getFlow: QueryResolvers['getFlow'] = async (_parent, params, context) => {
+const getFlow: NonNullable<QueryResolvers['getFlow']> = async (
+  _parent,
+  params,
+  context,
+) => {
   // To avoid the gibberish error code if a user keys in an invalid editor route e.g. editor/123
   if (!z.string().uuid().safeParse(params.id).success) {
     throw new Error('Please provide a valid pipe ID in your URL.')

--- a/packages/backend/src/graphql/queries/get-flows.ts
+++ b/packages/backend/src/graphql/queries/get-flows.ts
@@ -2,7 +2,7 @@ import paginate from '@/helpers/pagination'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getFlows: QueryResolvers['getFlows'] = async (
+const getFlows: NonNullable<QueryResolvers['getFlows']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/get-pending-flow-transfers.ts
+++ b/packages/backend/src/graphql/queries/get-pending-flow-transfers.ts
@@ -2,17 +2,18 @@ import FlowTransfer from '@/models/flow-transfers'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getPendingFlowTransfers: QueryResolvers['getPendingFlowTransfers'] =
-  async (_parent, _params, context) => {
-    const flowTransfers = await FlowTransfer.query()
-      .joinRelated('flow') // inner join ensures flow exists
-      .where({ new_owner_id: context.currentUser.id, status: 'pending' })
-      .withGraphFetched({
-        oldOwner: true,
-        newOwner: true,
-        flow: true,
-      })
-    return flowTransfers
-  }
+const getPendingFlowTransfers: NonNullable<
+  QueryResolvers['getPendingFlowTransfers']
+> = async (_parent, _params, context) => {
+  const flowTransfers = await FlowTransfer.query()
+    .joinRelated('flow') // inner join ensures flow exists
+    .where({ new_owner_id: context.currentUser.id, status: 'pending' })
+    .withGraphFetched({
+      oldOwner: true,
+      newOwner: true,
+      flow: true,
+    })
+  return flowTransfers
+}
 
 export default getPendingFlowTransfers

--- a/packages/backend/src/graphql/queries/get-templates.ts
+++ b/packages/backend/src/graphql/queries/get-templates.ts
@@ -2,7 +2,10 @@ import { TEMPLATES } from '@/db/storage'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getTemplates: QueryResolvers['getTemplates'] = (_parent, params) => {
+const getTemplates: NonNullable<QueryResolvers['getTemplates']> = (
+  _parent,
+  params,
+) => {
   const tag = params?.tag
   if (!tag) {
     return TEMPLATES // retrieve all templates if tag is not present

--- a/packages/backend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-test-execution-steps.ts
@@ -2,11 +2,9 @@ import { getTestExecutionSteps as getTestExecutionStepsHelper } from '@/helpers/
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const getTestExecutionSteps: QueryResolvers['getTestExecutionSteps'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const getTestExecutionSteps: NonNullable<
+  QueryResolvers['getTestExecutionSteps']
+> = async (_parent, params, context) => {
   const { flowId } = params
   // For checking if user is a collaborator
   const flow = await context.currentUser

--- a/packages/backend/src/graphql/queries/healthcheck.ts
+++ b/packages/backend/src/graphql/queries/healthcheck.ts
@@ -2,7 +2,7 @@ import appConfig from '@/config/app'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const healthcheck: QueryResolvers['healthcheck'] = () => {
+const healthcheck: NonNullable<QueryResolvers['healthcheck']> = () => {
   return {
     version: appConfig.version ?? 'test',
     nodeVersion: process.version,

--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -7,7 +7,7 @@ import { getConnection } from '@/services/connection'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
-const testConnection: QueryResolvers['testConnection'] = async (
+const testConnection: NonNullable<QueryResolvers['testConnection']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -17,7 +17,7 @@ import type { QueryResolvers } from '../../__generated__/types.generated'
 
 import { fetchTableWithViewOnlyCheck } from './view-only.helper'
 
-const getAllRows: QueryResolvers['getAllRows'] = async (
+const getAllRows: NonNullable<QueryResolvers['getAllRows']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
@@ -16,11 +16,9 @@ interface TableConnection {
   [key: string]: number
 }
 
-const getTableConnections: QueryResolvers['getTableConnections'] = async (
-  _parent,
-  params,
-  context,
-) => {
+const getTableConnections: NonNullable<
+  QueryResolvers['getTableConnections']
+> = async (_parent, params, context) => {
   const { tableIds } = params
   if (!tableIds) {
     throw new Error('tableIds is required')

--- a/packages/backend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table.ts
@@ -9,7 +9,7 @@ import type { QueryResolvers } from '../../__generated__/types.generated'
 
 import { fetchTableWithViewOnlyCheck } from './view-only.helper'
 
-const getTable: QueryResolvers['getTable'] = async (
+const getTable: NonNullable<QueryResolvers['getTable']> = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/queries/tiles/get-tables.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-tables.ts
@@ -2,7 +2,7 @@ import paginate from '@/helpers/pagination'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
 
-const getTables: QueryResolvers['getTables'] = async (
+const getTables: NonNullable<QueryResolvers['getTables']> = async (
   _parent,
   { limit, offset, name },
   context,


### PR DESCRIPTION
## Problem

Thirtieth PR in the backend `strict: true` rollout (stacked on round 29). A full-tree probe of `src/graphql/` (the only directory left ungated) showed 1,557 strict-mode errors across ~90 files. Reading a sample of the biggest bucket (`__tests__/mutations/`, 1,006 errors) showed the same three-error cascade repeated almost everywhere: `someResolver(parent, args, context)` fails with "cannot invoke an object which is possibly 'undefined'," then "argument not assignable" on the next argument, then "result possibly undefined" on whatever the test does with the return value.

Root cause: every mutation/query/custom-resolver file declares its resolver as `const x: MutationResolvers['x'] = async (...) => {...}` (or the `QueryResolvers`/`AdminMutationResolvers`/`AdminQueryResolvers`/field-resolver-alias equivalents). `MutationResolvers['x']` indexes into an *optional* interface field (graphql-codegen generates every resolver-map field as optional, since not every implementation needs every field) — so the local constant `x` itself gets typed `Fn | undefined`, even though it's always assigned a concrete, always-defined function. Every test file that imports `x` directly and calls it inherits that phantom optionality.

## Solution

Wrapped the type annotation in `NonNullable<...>` at all 85 affected declaration sites (`const x: NonNullable<MutationResolvers['x']> = ...`), stripping the spurious `| undefined` while keeping the declaration honest about what it actually is — the concrete implementation is genuinely always defined. This is the same pattern already established in round 28 (`backoff.ts`'s `BackoffStrategy` type alias) and round 29 (`get-generic-app-queue.ts`), just applied at scale here since the pattern was repeated across nearly every file in `graphql/mutations/`, `graphql/queries/`, `graphql/admin/`, and `graphql/custom-resolvers/`.

Purely mechanical: a scripted regex swap (`const (\w+): (\w+Resolvers?(\['\w+'\])?)\['(\w+)'\] =` → wrap with `NonNullable<...>`) followed by `prettier --write` to reflow. Verified every matching declaration was caught (no stragglers left with the old unwrapped pattern) and every changed file's diff is exclusively the type annotation plus prettier's re-indentation — no logic touched anywhere.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible (type-only change, zero behavior difference — confirmed via diff review of every file)

**Improvements**:

- 85 resolver declarations across `graphql/mutations/` (incl. `tiles/`, `ai/`), `graphql/queries/` (incl. `tiles/`), `graphql/admin/mutations/`, `graphql/admin/queries/`, and `graphql/custom-resolvers/` now correctly type their resolver constant as always-defined, matching reality.
- This is **not a gating round** — none of these files are added to `tsconfig.strict.json`. Each individual file still has its own separate, pre-existing strict-mode errors (null checks, optional chaining, etc.) unrelated to this fix, to be gated file-by-file in future rounds same as every prior directory. This PR exists purely to remove the dominant repeated-pattern noise first, so those future rounds deal with each file's real, distinct issues instead of re-deriving the same fix 85 times.

**Bug Fixes**:

- None — type-level fix only.

## Tests

- Full `src/**/*.ts` strict probe: `graphql/`'s error count dropped from 1,557 to 981 (-576, ~37%), with the TS2722 ("cannot invoke possibly undefined") count dropping from 436 to 5 — the 5 remaining are unrelated, genuine per-file issues (confirmed by reading each: `register-connection.ts`, `verify-connection.ts`, `get-app.ts`, `test-connection.ts`, and one `__tests__` file), not instances of this pattern.
- Full non-strict `npm run -w backend typecheck`: passes, 0 errors, no regressions.
- `@plumber/types` untouched — no frontend impact.
- Ran every unit-testable (`.test.ts`, non-`.itest.ts`) test file under `src/graphql/`: 73/73 passing, confirming the type-only change didn't alter runtime behavior.
- Lint: clean across all 85 changed files.

**New scripts**: none.
**New dependencies**: none.
**New dev dependencies**: none.
