### PR TITLE
PLU-916: chore(ai-builder): merge exit-survey submit into Exit button

### DIFF
--- a/packages/frontend/src/components/ConfettiEmbeddedSurvey.css
+++ b/packages/frontend/src/components/ConfettiEmbeddedSurvey.css
@@ -1,0 +1,24 @@
+.confetti-embedded-survey {
+  --confetti-rating-active-bg-color: #cf1a68;
+  --confetti-indicator-active-bg-color: #cf1a68;
+}
+
+.confetti-embedded-survey .confetti {
+  gap: 20px;
+}
+
+.confetti-embedded-survey .cf-rating-section {
+  gap: 8px;
+}
+
+.confetti-embedded-survey .cf-title {
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  letter-spacing: 0;
+  color: #666c7a;
+}
+
+.confetti-embedded-survey .cf-rating-display-star {
+  justify-content: start;
+}

--- a/packages/frontend/src/components/ConfettiEmbeddedSurvey.tsx
+++ b/packages/frontend/src/components/ConfettiEmbeddedSurvey.tsx
@@ -1,0 +1,93 @@
+import './ConfettiEmbeddedSurvey.css'
+
+import {
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import { Box, Skeleton, VStack } from '@chakra-ui/react'
+import {
+  Answer,
+  ConfettiController,
+  ConfettiProvider,
+  SurveyQuestionFactory,
+} from '@opengovsg/confetti'
+
+export interface ConfettiEmbeddedSurveyRef {
+  submit: () => void
+}
+
+interface ConfettiEmbeddedSurveyProps {
+  surveyId: string
+  publishableKey: string
+  respondent?: string
+  metadata?: Record<string, string>
+}
+
+// ConfettiController renders nothing until the survey has loaded, so this
+// only ever mounts once questions are ready to show.
+function NotifyLoaded({ onLoaded }: { onLoaded: () => void }) {
+  useLayoutEffect(() => {
+    onLoaded()
+  }, [onLoaded])
+  return null
+}
+
+const ConfettiEmbeddedSurvey = forwardRef<
+  ConfettiEmbeddedSurveyRef,
+  ConfettiEmbeddedSurveyProps
+>(({ surveyId, publishableKey, respondent, metadata }, ref) => {
+  const submitRef = useRef<() => void>()
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useImperativeHandle(ref, () => ({
+    submit: () => submitRef.current?.(),
+  }))
+
+  return (
+    <div className="confetti-embedded-survey">
+      {!isLoaded && (
+        <VStack align="stretch" gap={5}>
+          <Skeleton height="16px" width="60%" borderRadius="base" />
+          <Skeleton height="40px" borderRadius="base" />
+        </VStack>
+      )}
+      <Box display={isLoaded ? 'block' : 'none'}>
+        <ConfettiProvider
+          surveyId={surveyId}
+          publishableKey={publishableKey}
+          respondent={respondent}
+          metadata={metadata}
+        >
+          <ConfettiController>
+            {({ questions, update, errors, submit }) => {
+              submitRef.current = submit
+              return (
+                <>
+                  <NotifyLoaded onLoaded={() => setIsLoaded(true)} />
+                  {questions
+                    .filter((question) => question.visible)
+                    .map((question) => (
+                      <SurveyQuestionFactory
+                        key={question.id}
+                        question={question}
+                        error={errors[question.id]}
+                        onChange={(answer: Answer) =>
+                          update({ question: question.position, answer })
+                        }
+                      />
+                    ))}
+                </>
+              )
+            }}
+          </ConfettiController>
+        </ConfettiProvider>
+      </Box>
+    </div>
+  )
+})
+ConfettiEmbeddedSurvey.displayName = 'ConfettiEmbeddedSurvey'
+
+export default ConfettiEmbeddedSurvey

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -8,6 +8,7 @@ interface AppConfig {
   ssoHostname: string
   confettiSurveyPublishableKey: string
   confettiSurveyId: string
+  confettiAiBuilderSurveyId: string
 }
 
 function getAppConfig(): AppConfig {
@@ -32,6 +33,7 @@ function getAppConfig(): AppConfig {
         ssoClientId: 'plumber-prod',
         ssoHostname: 'https://sso.open.gov.sg',
         confettiSurveyId: 'n1yv6rl15ynq6wazr3x1pdjc',
+        confettiAiBuilderSurveyId: 'he8paxvow3kv4lp0ozdtxw44',
         ...commonEnv,
       }
     case 'uat':
@@ -42,6 +44,7 @@ function getAppConfig(): AppConfig {
         ssoClientId: 'plumber-uat',
         ssoHostname: 'https://sso.open.gov.sg',
         confettiSurveyId: 'i4wpjgv7x45la64coglh6h9p',
+        confettiAiBuilderSurveyId: 'm6g5hm6803jcbgkip7hqoqim',
         ...commonEnv,
       }
     case 'staging':
@@ -52,6 +55,7 @@ function getAppConfig(): AppConfig {
         ssoClientId: 'plumber-staging',
         ssoHostname: 'https://sso.open.gov.sg',
         confettiSurveyId: 'i4wpjgv7x45la64coglh6h9p',
+        confettiAiBuilderSurveyId: 'm6g5hm6803jcbgkip7hqoqim',
         ...commonEnv,
       }
     default:
@@ -62,6 +66,7 @@ function getAppConfig(): AppConfig {
         ssoClientId: 'plumber-local',
         ssoHostname: 'http://localhost:5354',
         confettiSurveyId: 'i4wpjgv7x45la64coglh6h9p',
+        confettiAiBuilderSurveyId: 'm6g5hm6803jcbgkip7hqoqim',
         ...commonEnv,
       }
   }

--- a/packages/frontend/src/pages/AiBuilder/components/ExitAlert.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ExitAlert.tsx
@@ -1,5 +1,7 @@
+import { useRef } from 'react'
 import {
   AlertDialog,
+  AlertDialogBody,
   AlertDialogContent,
   AlertDialogFooter,
   AlertDialogHeader,
@@ -8,6 +10,14 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
+
+import ConfettiEmbeddedSurvey, {
+  ConfettiEmbeddedSurveyRef,
+} from '@/components/ConfettiEmbeddedSurvey'
+import appConfig from '@/config/app'
+import useAuthentication from '@/hooks/useAuthentication'
+
+import { useAiBuilderContext } from '../AiBuilderContext'
 
 interface ExitAlertProps {
   cancelRef: React.RefObject<HTMLButtonElement>
@@ -19,7 +29,7 @@ interface ExitAlertProps {
 const defaultStyles = {
   ml: 6 /* Add spacing from the left edge */,
   my: 6 /* Remove default vertical margins */,
-  maxW: '300px' /* Set a maximum width */,
+  maxW: '514px' /* Set a maximum width */,
   w: '100%' /* Ensure it takes full width */,
 }
 
@@ -36,8 +46,14 @@ export default function ExitAlert({
 }: ExitAlertProps) {
   const isMobile = useIsMobile()
   const contentStyles = isMobile ? mobileStyles : defaultStyles
+  const confettiRef = useRef<ConfettiEmbeddedSurveyRef>(null)
+  const { chatId } = useAiBuilderContext()
+  const { currentUser } = useAuthentication()
+  const userEmail = currentUser?.email ?? 'unknown-user'
 
   const handleExit = () => {
+    // Fire-and-forget: exiting must never block on the survey network call.
+    confettiRef.current?.submit()
     onExit?.()
     onClose()
   }
@@ -57,26 +73,35 @@ export default function ExitAlert({
           <AlertDialogHeader p={6}>
             <Text textStyle="h5">Your progress will be lost if you exit</Text>
           </AlertDialogHeader>
-
+          <AlertDialogBody gap={5} display="flex" flexDirection="column">
+            <Text textStyle="subhead-1">
+              Please take 5 seconds to help the Plumber team
+            </Text>
+            <ConfettiEmbeddedSurvey
+              ref={confettiRef}
+              surveyId={appConfig.confettiAiBuilderSurveyId}
+              publishableKey={appConfig.confettiSurveyPublishableKey}
+              respondent={`${userEmail}-${chatId}`}
+            />
+          </AlertDialogBody>
           <AlertDialogFooter
             display="flex"
-            flexDirection="column"
+            flexDirection="row"
             gap={2}
-            pt={0}
+            pt={6}
             pb={6}
             px={6}
           >
-            <Button colorScheme="critical" onClick={handleExit} width="full">
-              Exit anyway
-            </Button>
             <Button
               ref={cancelRef}
               variant="clear"
               colorScheme="secondary"
               onClick={onClose}
-              width="full"
             >
               Cancel
+            </Button>
+            <Button colorScheme="critical" onClick={handleExit}>
+              Submit and exit
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## TL;DR

Replace `EmbeddedConfetti`'s built-in submit button in the AI Builder exit dialog with a custom `ConfettiEmbeddedSurvey` component, so the existing "Submit and exit" button both submits the feedback survey and exits — instead of needing two separate button clicks.

## What changed?

- Added `ConfettiEmbeddedSurvey` (`packages/frontend/src/components/ConfettiEmbeddedSurvey.tsx`): renders the survey's questions via `ConfettiController` + `SurveyQuestionFactory` directly (no built-in submit button), and exposes an imperative `submit()` via `forwardRef`/`useImperativeHandle` so a sibling button outside the survey body can trigger it.
  - Shows a `Skeleton` placeholder while the survey loads, swapped in for the real content in the same paint (via `useLayoutEffect`) to avoid a layout jump.
- Added `ConfettiEmbeddedSurvey.css`, adapting the relevant visual styles from `EditorLayout/ConfettiSurvey.css` (rating/choice colors, spacing, title style matching the app's `subhead-2` text style and `base.content.medium` color) — dropped the popover-only rules (`position: fixed`, submit-button color, dialog max-width/padding) that don't apply to this embedded, no-chrome usage.
- Updated `ExitAlert.tsx`: swapped `EmbeddedConfetti` for `ConfettiEmbeddedSurvey`, merged its submit into the existing exit button (fire-and-forget — exiting must never block on the survey network call), and set `respondent` to `${userEmail}-${chatId}` (matching the pattern already used in `ConfettiSurvey.tsx`).
- Added `confettiAiBuilderSurveyId` to `config/app.ts`, following the existing `confettiSurveyId` per-environment pattern, replacing a hardcoded survey ID.

## Tests

- [ ] Open the AI Builder exit dialog, confirm the survey question renders without a visible layout jump.
- [ ] Answer the survey question, click "Submit and exit" — confirm (via network tab) a submit request fires to the confetti API and the dialog closes/exits without waiting on it.
- [ ] Click "Submit and exit" with no answer given — confirm it still exits cleanly with no console error.
- [ ] Verify the other Confetti integration (`EditorLayout/ConfettiSurvey.tsx`, the popover widget) still displays and behaves as before — unaffected by this change.

## Deploy notes

None. `confettiAiBuilderSurveyId` values are already environment-scoped in `config/app.ts` (prod uses `he8paxvow3kv4lp0ozdtxw44`, other environments share the previously-hardcoded `m6g5hm6803jcbgkip7hqoqim`).


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62112930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/opengovsg/-/pull-requests/opengovsg/plumber/2181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking need for regression tests around loading, submission, and immediate teardown.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FConfettiEmbeddedSurvey.tsx%3A45-47%0AThe%20new%20imperative%20submission%20path%20has%20no%20automated%20coverage%20for%20its%20lifecycle-sensitive%20behavior.%20%60submit%28%29%60%20does%20nothing%20until%20the%20controller%20has%20rendered%2C%20while%20%60ExitAlert%60%20invokes%20it%20immediately%20before%20tearing%20down%20the%20dialog%20and%20navigating%20away.%20Add%20tests%20for%20submission%20after%20loading%2C%20clicking%20while%20loading%2C%20unanswered%20questions%2C%20and%20network%20failures%20so%20future%20changes%20cannot%20silently%20stop%20survey%20requests%20or%20interfere%20with%20exiting.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Submission Flow Lacks Coverage** <a href="https://github.com/opengovsg/plumber/pull/2181#discussion_r3969166045">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds a reusable imperative survey component with loading placeholders and custom styling.
- Adds environment-specific configuration for the AI Builder survey.
- Expands the exit dialog and combines survey submission with navigation.
- The behavior is reasonable, but its lifecycle-sensitive submission flow lacks regression coverage.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant Dialog as ExitAlert
  participant Survey as ConfettiEmbeddedSurvey
  participant Confetti as Confetti API
  participant Guard as Navigation guard

  User->>Dialog: Click "Submit and exit"
  Dialog->>Survey: submit()
  Survey-->>Confetti: Start feedback submission
  Note over Dialog,Confetti: Submission does not block exit
  Dialog->>Guard: confirm()
  Guard->>Dialog: Close and unmount dialog
  Guard->>Guard: Clear AI Builder state
  Guard->>Guard: Navigate to flows
```
</details>

<!-- /greptile_comment -->