### PR TITLE
chore(backend): fix graphql resolver test parent-arg mismatch, round 2 of root-cause cleanup (round 31)

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-connection.itest.ts
@@ -51,7 +51,7 @@ describe('createConnection', () => {
     it('should not create connection without a flowId', async () => {
       await expect(
         createConnection(
-          null,
+          {},
           {
             // @ts-expect-error - intentionally exclude the flowId
             input: {
@@ -67,7 +67,7 @@ describe('createConnection', () => {
 
   describe('with flowId', () => {
     it('should add connection to flow_connections', async () => {
-      await createConnection(null, { input: defaultInput }, context)
+      await createConnection({}, { input: defaultInput }, context)
 
       const flowConnections = await FlowConnections.query()
       expect(flowConnections).toHaveLength(1)
@@ -76,7 +76,7 @@ describe('createConnection', () => {
     describe('access control', () => {
       it('should allow owner to create connection', async () => {
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -89,7 +89,7 @@ describe('createConnection', () => {
         context.currentUser = editor
 
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -101,7 +101,7 @@ describe('createConnection', () => {
         context.currentUser = viewer
 
         await expect(
-          createConnection(null, { input: defaultInput }, context),
+          createConnection({}, { input: defaultInput }, context),
         ).rejects.toThrow()
       })
 
@@ -110,7 +110,7 @@ describe('createConnection', () => {
 
         await expect(
           createConnection(
-            null,
+            {},
             { input: { ...defaultInput, flowId: testFlow.id } },
             context,
           ),
@@ -123,7 +123,7 @@ describe('createConnection', () => {
         context.currentUser = editor
 
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -134,7 +134,7 @@ describe('createConnection', () => {
 
       it('owner-created connection has owner userId', async () => {
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -149,7 +149,7 @@ describe('createConnection', () => {
         context.currentUser = editor
 
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -166,7 +166,7 @@ describe('createConnection', () => {
 
       it('owner-created connection is added to flow_connections when flow has collaborators', async () => {
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -184,7 +184,7 @@ describe('createConnection', () => {
         const soloFlow = await generateMockFlow(context, randomUUID())
 
         const result = await createConnection(
-          null,
+          {},
           { input: { ...defaultInput, flowId: soloFlow.id } },
           context,
         )
@@ -203,7 +203,7 @@ describe('createConnection', () => {
         context.currentUser = editor
 
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )
@@ -218,7 +218,7 @@ describe('createConnection', () => {
         context.currentUser = editor
 
         const result = await createConnection(
-          null,
+          {},
           { input: defaultInput },
           context,
         )

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -80,7 +80,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
 
       // Verify flow was created
       expect(result).toBeDefined()
@@ -146,7 +146,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
 
       expect(result.name).toBe('Trimmed Flow Name')
     })
@@ -176,7 +176,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
       const steps = await Step.query()
         .where('flow_id', result.id)
         .orderBy('position', 'asc')
@@ -226,7 +226,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
       const steps = await Step.query()
         .where('flow_id', result.id)
         .orderBy('position', 'asc')
@@ -260,7 +260,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe name needs to have at least 1 character.',
       )
 
@@ -289,7 +289,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe name needs to have at least 1 character.',
       )
 
@@ -318,7 +318,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe contains invalid action steps',
       )
 
@@ -356,7 +356,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Must be contiguous steps!',
       )
 
@@ -399,7 +399,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Must be contiguous steps!',
       )
 
@@ -435,7 +435,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Must be contiguous steps!',
       )
 
@@ -473,7 +473,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe must always start with a trigger',
       )
 
@@ -509,7 +509,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Must be contiguous steps!',
       )
 
@@ -538,7 +538,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe must always start with a trigger',
       )
 
@@ -582,7 +582,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
       },
     }
 
-    await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+    await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
       'Pipe contains invalid action steps',
     )
 
@@ -648,7 +648,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
 
       expect(result).toBeDefined()
       expect(result.name).toBe('Test Flow with If-Then')
@@ -702,7 +702,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
       expect(result).toBeDefined()
 
       const steps = await Step.query()
@@ -749,7 +749,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
       expect(result).toBeDefined()
 
       const steps = await Step.query()
@@ -789,7 +789,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe contains invalid action steps',
       )
 
@@ -825,7 +825,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe contains invalid action steps',
       )
 
@@ -868,7 +868,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      const result = await createFlowWithSteps(null, params, context)
+      const result = await createFlowWithSteps({}, params, context)
       expect(result).toBeDefined()
 
       const steps = await Step.query()
@@ -908,7 +908,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe contains invalid action steps',
       )
     })
@@ -942,7 +942,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      await expect(createFlowWithSteps({}, params, context)).rejects.toThrow(
         'Pipe must always start with a trigger',
       )
     })

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -156,7 +156,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    const newStep = await createStep(null, params, context)
+    const newStep = await createStep({}, params, context)
 
     // Ensure the new step is returned as expected.
     expect(newStep).toBeDefined()
@@ -192,7 +192,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    const newStep = await createStep(null, params, context)
+    const newStep = await createStep({}, params, context)
 
     expect(newStep).toBeDefined()
     expect(newStep.position).toBe(existingSteps[2].position + 1)
@@ -222,7 +222,7 @@ describe('createStep mutation integration tests', async () => {
         previousStep: { id: existingSteps[2].id },
       },
     }
-    await createStep(null, params, context)
+    await createStep({}, params, context)
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -247,7 +247,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    await expect(createStep(null, params, context)).rejects.toThrow()
+    await expect(createStep({}, params, context)).rejects.toThrow()
   })
 
   it('throws an error if the previous step is not found', async () => {
@@ -264,11 +264,11 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    await expect(createStep(null, params, context)).rejects.toThrow()
+    await expect(createStep({}, params, context)).rejects.toThrow()
   })
 
   it('owner can create a new step', async () => {
-    const newStep = await createStep(null, genericNewStepParams, context)
+    const newStep = await createStep({}, genericNewStepParams, context)
 
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
@@ -280,7 +280,7 @@ describe('createStep mutation integration tests', async () => {
 
   it('editor can create a new step', async () => {
     context.currentUser = editor
-    const newStep = await createStep(null, genericNewStepParams, context)
+    const newStep = await createStep({}, genericNewStepParams, context)
 
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
@@ -305,7 +305,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    const newStep = await createStep(null, params, context)
+    const newStep = await createStep({}, params, context)
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
     expect(newStep.key).toBe('sendTransactionalEmail')
@@ -315,16 +315,16 @@ describe('createStep mutation integration tests', async () => {
 
   it('viewer should not be able to create a new step', async () => {
     context.currentUser = viewer
-    await expect(
-      createStep(null, genericNewStepParams, context),
-    ).rejects.toThrow(NotFoundError)
+    await expect(createStep({}, genericNewStepParams, context)).rejects.toThrow(
+      NotFoundError,
+    )
   })
 
   it('non-collaborator should not be able to create a new step', async () => {
     context.currentUser = nonCollaborator
-    await expect(
-      createStep(null, genericNewStepParams, context),
-    ).rejects.toThrow(NotFoundError)
+    await expect(createStep({}, genericNewStepParams, context)).rejects.toThrow(
+      NotFoundError,
+    )
   })
 
   it('creates a step with connection and adds flow connection for owner', async () => {
@@ -343,7 +343,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    const newStep = await createStep(null, params, context)
+    const newStep = await createStep({}, params, context)
 
     expect(newStep).toBeDefined()
     expect((newStep as any).connectionId).toBe(testConnection.id)
@@ -372,9 +372,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    await expect(createStep(null, params, context)).rejects.toThrow(
-      NotFoundError,
-    )
+    await expect(createStep({}, params, context)).rejects.toThrow(NotFoundError)
   })
 
   // TODO (kevinkim-ogp): update this test when we allow editors to add their own connections to the Pipe
@@ -404,9 +402,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    await expect(createStep(null, params, context)).rejects.toThrow(
-      NotFoundError,
-    )
+    await expect(createStep({}, params, context)).rejects.toThrow(NotFoundError)
   })
 
   it('throws error when user does not have access to connection', async () => {
@@ -436,9 +432,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    await expect(createStep(null, params, context)).rejects.toThrow(
-      NotFoundError,
-    )
+    await expect(createStep({}, params, context)).rejects.toThrow(NotFoundError)
   })
 
   it('creates a step without connection when connection is not provided', async () => {
@@ -455,7 +449,7 @@ describe('createStep mutation integration tests', async () => {
       },
     }
 
-    const newStep = await createStep(null, params, context)
+    const newStep = await createStep({}, params, context)
 
     expect(newStep).toBeDefined()
     expect((newStep as any).connectionId).toBeNull()
@@ -465,7 +459,7 @@ describe('createStep mutation integration tests', async () => {
     it('defaults to version 1 when app has no stepTransformer', async () => {
       // postman has no stepTransformer - version should default to 1
       const newStep = await createStep(
-        null,
+        {},
         {
           input: {
             flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
@@ -483,7 +477,7 @@ describe('createStep mutation integration tests', async () => {
 
     it('defaults to version 1 when no appKey is provided', async () => {
       const newStep = await createStep(
-        null,
+        {},
         {
           input: {
             flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
@@ -509,7 +503,7 @@ describe('createStep mutation integration tests', async () => {
 
       try {
         const newStep = await createStep(
-          null,
+          {},
           {
             input: {
               flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
@@ -547,7 +541,7 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      const newStep = await createStep(null, params, context)
+      const newStep = await createStep({}, params, context)
 
       expect(newStep).toBeDefined()
       expect(newStep.key).toBe('sendTransactionalEmail')
@@ -570,7 +564,7 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      const newStep = await createStep(null, params, context)
+      const newStep = await createStep({}, params, context)
 
       expect(newStep).toBeDefined()
       expect(newStep.key).toBe('sendTransactionalEmail')
@@ -594,10 +588,10 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      await expect(createStep(null, params, context)).rejects.toThrow(
+      await expect(createStep({}, params, context)).rejects.toThrow(
         BadUserInputError,
       )
-      await expect(createStep(null, params, context)).rejects.toThrow(
+      await expect(createStep({}, params, context)).rejects.toThrow(
         REFRESH_PIPE_MESSAGE,
       )
     })
@@ -620,10 +614,10 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      await expect(createStep(null, params, context)).rejects.toThrow(
+      await expect(createStep({}, params, context)).rejects.toThrow(
         BadUserInputError,
       )
-      await expect(createStep(null, params, context)).rejects.toThrow(
+      await expect(createStep({}, params, context)).rejects.toThrow(
         REFRESH_PIPE_MESSAGE,
       )
     })
@@ -642,7 +636,7 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      const newStep = await createStep(null, params, context)
+      const newStep = await createStep({}, params, context)
 
       expect(newStep).toBeDefined()
       expect(newStep.key).toBe('sendTransactionalEmail')
@@ -719,7 +713,7 @@ describe('createStep endStepId write rules', () => {
     ])
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -746,7 +740,7 @@ describe('createStep endStepId write rules', () => {
     ])
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -792,7 +786,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -823,7 +817,7 @@ describe('createStep endStepId write rules', () => {
 
     await expect(
       createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -859,7 +853,7 @@ describe('createStep endStepId write rules', () => {
 
     await expect(
       createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -898,7 +892,7 @@ describe('createStep endStepId write rules', () => {
     ])
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -929,7 +923,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -955,7 +949,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: ifThenA.id } })
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -993,7 +987,7 @@ describe('createStep endStepId write rules', () => {
     })
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1025,7 +1019,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
 
     const newIfThen = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1054,7 +1048,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: stepB.id } })
 
     await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1081,7 +1075,7 @@ describe('createStep endStepId write rules', () => {
     const [, , stepA] = seeded
 
     await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1109,7 +1103,7 @@ describe('createStep endStepId write rules', () => {
 
     await expect(
       createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1135,7 +1129,7 @@ describe('createStep endStepId write rules', () => {
     ])
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1160,7 +1154,7 @@ describe('createStep endStepId write rules', () => {
 
     await expect(
       createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1195,7 +1189,7 @@ describe('createStep endStepId write rules', () => {
     ])
 
     const newStep = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1223,7 +1217,7 @@ describe('createStep endStepId write rules', () => {
     await ifThenA.$query().patch({ config: { endStepId: stepA.id } })
 
     const newIfThen = await createStep(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -1257,7 +1251,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1289,7 +1283,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1326,7 +1320,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       const newStep = await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1360,7 +1354,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(false)
 
       await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1389,7 +1383,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       const newStep = await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),
@@ -1426,7 +1420,7 @@ describe('createStep endStepId write rules', () => {
       mocks.getLdFlagValue.mockResolvedValue(false)
 
       await createStep(
-        null,
+        {},
         {
           input: {
             flow: flowInput(),

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -68,7 +68,7 @@ describe('delete flow collaborators', () => {
 
   it('should be able to delete collaborators', async () => {
     await deleteFlowCollaborator(
-      null,
+      {},
       { input: { flowId: dummyFlow.id, email: viewer.email } },
       context,
     )
@@ -86,7 +86,7 @@ describe('delete flow collaborators', () => {
   it('should throw an error if collaborator is not found', async () => {
     await expect(
       deleteFlowCollaborator(
-        null,
+        {},
         { input: { flowId: dummyFlow.id, email: 'viewer332@plumber.gov.sg' } },
         context,
       ),
@@ -97,7 +97,7 @@ describe('delete flow collaborators', () => {
     context.currentUser = editor
     await expect(
       deleteFlowCollaborator(
-        null,
+        {},
         { input: { flowId: dummyFlow.id, email: editor.email } },
         context,
       ),
@@ -108,7 +108,7 @@ describe('delete flow collaborators', () => {
     context.currentUser = editor
     await expect(
       deleteFlowCollaborator(
-        null,
+        {},
         { input: { flowId: dummyFlow.id, email: owner.email } },
         context,
       ),
@@ -118,7 +118,7 @@ describe('delete flow collaborators', () => {
   it('should throw an error if user is not a collaborator', async () => {
     await expect(
       deleteFlowCollaborator(
-        null,
+        {},
         {
           input: {
             flowId: dummyFlow.id,
@@ -134,7 +134,7 @@ describe('delete flow collaborators', () => {
     context.currentUser = viewer
     await expect(
       deleteFlowCollaborator(
-        null,
+        {},
         { input: { flowId: dummyFlow.id, email: editor.email } },
         context,
       ),

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-connection.itest.ts
@@ -101,7 +101,7 @@ describe('deleteFlowConnection', () => {
       })
 
       const result = await deleteFlowConnection(
-        null,
+        {},
         { input: defaultInput },
         context,
       )
@@ -119,7 +119,7 @@ describe('deleteFlowConnection', () => {
       })
 
       const result = await deleteFlowConnection(
-        null,
+        {},
         { input: defaultInput },
         context,
       )
@@ -131,7 +131,7 @@ describe('deleteFlowConnection', () => {
       context.currentUser = viewer
 
       await expect(
-        deleteFlowConnection(null, { input: defaultInput }, context),
+        deleteFlowConnection({}, { input: defaultInput }, context),
       ).rejects.toThrow('You do not have access to this flow')
     })
 
@@ -139,7 +139,7 @@ describe('deleteFlowConnection', () => {
       context.currentUser = nonCollaborator
 
       await expect(
-        deleteFlowConnection(null, { input: defaultInput }, context),
+        deleteFlowConnection({}, { input: defaultInput }, context),
       ).rejects.toThrow('You do not have access to this flow')
     })
   })
@@ -188,7 +188,7 @@ describe('deleteFlowConnection', () => {
       })
 
       await expect(
-        deleteFlowConnection(null, { input: defaultInput }, context),
+        deleteFlowConnection({}, { input: defaultInput }, context),
       ).rejects.toThrow('Connection is in use and cannot be deleted.')
 
       // Check flow connection is not deleted
@@ -237,7 +237,7 @@ describe('deleteFlowConnection', () => {
         addedBy: owner.id,
       })
 
-      await deleteFlowConnection(null, { input: defaultInput }, context)
+      await deleteFlowConnection({}, { input: defaultInput }, context)
 
       // Check flow connection is deleted
       const flowConnection = await FlowConnections.query().findOne({
@@ -291,7 +291,7 @@ describe('deleteFlowConnection', () => {
         addedBy: owner.id,
       })
 
-      await deleteFlowConnection(null, { input: defaultInput }, context)
+      await deleteFlowConnection({}, { input: defaultInput }, context)
 
       // Check other flow's step is NOT affected
       const unchangedStep = await Step.query().findById(otherStep.id)
@@ -328,7 +328,7 @@ describe('deleteFlowConnection', () => {
 
       await expect(
         deleteFlowConnection(
-          null,
+          {},
           {
             input: {
               flowId: testFlow.id,
@@ -376,7 +376,7 @@ describe('deleteFlowConnection', () => {
       })
 
       await deleteFlowConnection(
-        null,
+        {},
         {
           input: {
             flowId: testFlow.id,

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -102,7 +102,7 @@ describe('deleteStep mutation', () => {
 
   it('should throw error when no steps to delete', async () => {
     await expect(
-      deleteStep(null, { input: { ids: [], ...defaultFlowInput } }, context),
+      deleteStep({}, { input: { ids: [], ...defaultFlowInput } }, context),
     ).rejects.toThrow('Nothing to delete')
   })
 
@@ -125,7 +125,7 @@ describe('deleteStep mutation', () => {
 
     await expect(
       deleteStep(
-        null,
+        {},
         {
           input: { ids: [testSteps[0].id, otherStep.id], ...defaultFlowInput },
         },
@@ -136,7 +136,7 @@ describe('deleteStep mutation', () => {
 
   it('should delete a single trigger step and create a new one', async () => {
     await deleteStep(
-      null,
+      {},
       { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
       context,
     )
@@ -154,7 +154,7 @@ describe('deleteStep mutation', () => {
 
   it('should delete contiguous action steps and update positions', async () => {
     await deleteStep(
-      null,
+      {},
       {
         input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
       },
@@ -184,7 +184,7 @@ describe('deleteStep mutation', () => {
 
     await expect(
       deleteStep(
-        null,
+        {},
         {
           input: { ids: [testSteps[1].id, fourthStep.id], ...defaultFlowInput },
         },
@@ -206,7 +206,7 @@ describe('deleteStep mutation', () => {
     )
 
     await deleteStep(
-      null,
+      {},
       { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
       context,
     )
@@ -218,7 +218,7 @@ describe('deleteStep mutation', () => {
 
   it('should call patchLastUpdated when deleting trigger step', async () => {
     await deleteStep(
-      null,
+      {},
       { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
       context,
     )
@@ -227,7 +227,7 @@ describe('deleteStep mutation', () => {
 
   it('should call patchLastUpdated when deleting action steps', async () => {
     await deleteStep(
-      null,
+      {},
       {
         input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
       },
@@ -238,7 +238,7 @@ describe('deleteStep mutation', () => {
 
   it('should allow owner to delete steps', async () => {
     await deleteStep(
-      null,
+      {},
       { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
       context,
     )
@@ -254,7 +254,7 @@ describe('deleteStep mutation', () => {
   it('should allow editor to delete steps', async () => {
     context.currentUser = editor
     await deleteStep(
-      null,
+      {},
       { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
       context,
     )
@@ -271,7 +271,7 @@ describe('deleteStep mutation', () => {
     context.currentUser = nonCollaborator
     await expect(
       deleteStep(
-        null,
+        {},
         { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
         context,
       ),
@@ -288,7 +288,7 @@ describe('deleteStep mutation', () => {
     context.currentUser = viewer
     await expect(
       deleteStep(
-        null,
+        {},
         { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
         context,
       ),
@@ -349,7 +349,7 @@ describe('deleteStep mutation', () => {
       const after = await addPlain(5)
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [ifThen.id], ...blockFlowInput } },
         context,
       )
@@ -370,7 +370,7 @@ describe('deleteStep mutation', () => {
       const after = await addPlain(5)
 
       await deleteStep(
-        null,
+        {},
         {
           input: { ids: [ifThen.id, s3.id, s4.id], ...blockFlowInput },
         },
@@ -388,7 +388,7 @@ describe('deleteStep mutation', () => {
       const s4 = await addPlain(4)
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [legacy.id], ...blockFlowInput } },
         context,
       )
@@ -406,7 +406,7 @@ describe('deleteStep mutation', () => {
       const ifThen = await addIfThen(2, { endStepId: s4.id })
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [s4.id], ...blockFlowInput } },
         context,
       )
@@ -422,7 +422,7 @@ describe('deleteStep mutation', () => {
       const ifThen = await addIfThen(2, { endStepId: s3.id })
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [s3.id], ...blockFlowInput } },
         context,
       )
@@ -438,7 +438,7 @@ describe('deleteStep mutation', () => {
       const ifThen = await addIfThen(2, { endStepId: 'does-not-exist' })
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [ifThen.id], ...blockFlowInput } },
         context,
       )
@@ -472,7 +472,7 @@ describe('deleteStep mutation', () => {
       )
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [trigger.id], ...blockFlowInput } },
         context,
       )
@@ -546,7 +546,7 @@ describe('deleteStep mutation', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [unrelated.id], ...blockFlowInput } },
         context,
       )
@@ -570,7 +570,7 @@ describe('deleteStep mutation', () => {
       mocks.getLdFlagValue.mockResolvedValue(false)
 
       await deleteStep(
-        null,
+        {},
         { input: { ids: [unrelated.id], ...blockFlowInput } },
         context,
       )

--- a/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
@@ -81,7 +81,7 @@ describe('deleteFromS3', () => {
   it('should successfully delete an object when user owns the flow', async () => {
     await expect(
       deleteUploadedFile(
-        null,
+        {},
         { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
         context,
       ),
@@ -100,7 +100,7 @@ describe('deleteFromS3', () => {
 
     await expect(
       deleteUploadedFile(
-        null,
+        {},
         { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
         context,
       ),
@@ -119,7 +119,7 @@ describe('deleteFromS3', () => {
     })
 
     await deleteUploadedFile(
-      null,
+      {},
       { id: fileToDelete, flowUpdatedAt: mockFlow.updatedAt },
       context,
     )
@@ -136,7 +136,7 @@ describe('deleteFromS3', () => {
 
     await expect(
       deleteUploadedFile(
-        null,
+        {},
         { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
         context,
       ),
@@ -155,7 +155,7 @@ describe('deleteFromS3', () => {
 
     await expect(
       deleteUploadedFile(
-        null,
+        {},
         { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
         context,
       ),

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-branch.itest.ts
@@ -79,7 +79,7 @@ describe('duplicateBranch endStepId remap', () => {
     await ifThen.$query().patch({ config: { endStepId: member.id } })
 
     const result = await duplicateBranch(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -119,7 +119,7 @@ describe('duplicateBranch endStepId remap', () => {
     await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
 
     const result = await duplicateBranch(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),
@@ -146,7 +146,7 @@ describe('duplicateBranch endStepId remap', () => {
     await ifThen.$query().patch({ config: { endStepId: tail.id } })
 
     const result = await duplicateBranch(
-      null,
+      {},
       {
         input: {
           flow: flowInput(),

--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
@@ -72,7 +72,7 @@ describe('duplicateFlow endStepId remap', () => {
     const [, ifThen, s3] = steps
     await ifThen.$query().patch({ config: { endStepId: s3.id } })
 
-    await duplicateFlow(null, { input: { id: flow.id } }, context)
+    await duplicateFlow({}, { input: { id: flow.id } }, context)
 
     const copies = await copiedSteps()
     const copiedIfThen = copies[1]
@@ -90,7 +90,7 @@ describe('duplicateFlow endStepId remap', () => {
     const [, ifThen] = steps
     await ifThen.$query().patch({ config: { endStepId: ifThen.id } })
 
-    await duplicateFlow(null, { input: { id: flow.id } }, context)
+    await duplicateFlow({}, { input: { id: flow.id } }, context)
 
     const copies = await copiedSteps()
     const copiedIfThen = copies[1]
@@ -108,7 +108,7 @@ describe('duplicateFlow endStepId remap', () => {
     await ifThen.$query().patch({ config: { endStepId: 'does-not-exist' } })
 
     await expect(
-      duplicateFlow(null, { input: { id: flow.id } }, context),
+      duplicateFlow({}, { input: { id: flow.id } }, context),
     ).rejects.toThrow(/dangling endStepId/)
 
     const copy = await Flow.query().where('name', '[COPY] Source Flow').first()

--- a/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
@@ -112,7 +112,7 @@ describe('executeStep mutation - access control', () => {
         testRunMetadata: { testKey: 'testValue' },
       }
 
-      const result = await executeStep(null, { input }, context)
+      const result = await executeStep({}, { input }, context)
 
       expect(testStepSpy).toHaveBeenCalledWith({
         stepId: mockStepId,
@@ -143,7 +143,7 @@ describe('executeStep mutation - access control', () => {
         stepId: mockStepId,
         testRunMetadata: { testKey: 'testValue' },
       }
-      const result = await executeStep(null, { input }, context)
+      const result = await executeStep({}, { input }, context)
 
       expect(testStepSpy).toHaveBeenCalledWith({
         stepId: mockStepId,
@@ -169,7 +169,7 @@ describe('executeStep mutation - access control', () => {
         testRunMetadata: { testKey: 'testValue' },
       }
 
-      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+      await expect(executeStep({}, { input }, context)).rejects.toThrow(
         ForbiddenError,
       )
     })
@@ -189,7 +189,7 @@ describe('executeStep mutation - access control', () => {
         testRunMetadata: { testKey: 'testValue' },
       }
 
-      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+      await expect(executeStep({}, { input }, context)).rejects.toThrow(
         ForbiddenError,
       )
     })
@@ -237,7 +237,7 @@ describe('executeStep mutation - access control', () => {
         }
       })
 
-    await expect(executeStep(null, { input } as any, context)).rejects.toThrow()
+    await expect(executeStep({}, { input } as any, context)).rejects.toThrow()
   })
 
   it('should call testStep service with correct parameters', async () => {
@@ -283,7 +283,7 @@ describe('executeStep mutation - access control', () => {
       testRunMetadata: { testKey: 'testValue' },
     }
 
-    await executeStep(null, { input }, context)
+    await executeStep({}, { input }, context)
 
     expect(testStepSpy).toHaveBeenCalledWith({
       stepId: mockStepId,
@@ -311,7 +311,7 @@ describe('executeStep mutation - access control', () => {
         }
       })
 
-    await expect(executeStep(null, { input }, context)).rejects.toThrow(
+    await expect(executeStep({}, { input }, context)).rejects.toThrow(
       NotFoundError,
     )
   })

--- a/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
@@ -56,7 +56,7 @@ describe('generatePresignedPost', () => {
     const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
 
     await generatePresignedPost(
-      null,
+      {},
       {
         input: {
           ...VALID_PARAMS,
@@ -97,7 +97,7 @@ describe('generatePresignedPost', () => {
     context.currentUser = editor
 
     await generatePresignedPost(
-      null,
+      {},
       {
         input: {
           ...VALID_PARAMS,
@@ -120,7 +120,7 @@ describe('generatePresignedPost', () => {
       .where('id', VALID_PARAMS.flow.id)
 
     await expect(
-      generatePresignedPost(null, { input: VALID_PARAMS }, context),
+      generatePresignedPost({}, { input: VALID_PARAMS }, context),
     ).rejects.toThrow(ForbiddenError)
   })
 
@@ -136,7 +136,7 @@ describe('generatePresignedPost', () => {
     context.currentUser = viewer
 
     await expect(
-      generatePresignedPost(null, { input: VALID_PARAMS }, context),
+      generatePresignedPost({}, { input: VALID_PARAMS }, context),
     ).rejects.toThrow(ForbiddenError)
   })
 
@@ -149,7 +149,7 @@ describe('generatePresignedPost', () => {
 
     const tooLargeParams = { ...VALID_PARAMS, size: 20 * 1024 * 1024 + 1 }
     await expect(
-      generatePresignedPost(null, { input: tooLargeParams }, context),
+      generatePresignedPost({}, { input: tooLargeParams }, context),
     ).rejects.toThrow('Size of attachment exceeds 20MB')
   })
 
@@ -170,7 +170,7 @@ describe('generatePresignedPost', () => {
       }
 
       await expect(
-        generatePresignedPost(null, { input: unsupportedParams }, context),
+        generatePresignedPost({}, { input: unsupportedParams }, context),
       ).rejects.toThrow('Unsupported file type')
     },
   )
@@ -183,7 +183,7 @@ describe('generatePresignedPost', () => {
       const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
 
       await generatePresignedPost(
-        null,
+        {},
         {
           input: {
             ...VALID_PARAMS,

--- a/packages/backend/src/graphql/__tests__/mutations/login-with-selected-sgid.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/login-with-selected-sgid.test.ts
@@ -71,7 +71,7 @@ describe('Login with selected SGID', () => {
     mocks.getOrCreateUser.mockResolvedValueOnce({ id: 'abc-def' } as User)
 
     const result = await loginWithSelectedSgid(
-      null,
+      {},
       {
         input: {
           workEmail: 'loong_loong@coffee.gov.sg',
@@ -113,7 +113,7 @@ describe('Login with selected SGID', () => {
 
     await expect(
       loginWithSelectedSgid(
-        null,
+        {},
         {
           input: {
             workEmail: 'not_loong@coffee.gov.sg',
@@ -137,7 +137,7 @@ describe('Login with selected SGID', () => {
 
     await expect(
       loginWithSelectedSgid(
-        null,
+        {},
         {
           input: {
             workEmail: 'not_loong@coffee.gov.sg',

--- a/packages/backend/src/graphql/__tests__/mutations/login-with-sgid.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/login-with-sgid.test.ts
@@ -88,7 +88,7 @@ describe('Login with SGID', () => {
     })
     mocks.getOrCreateUser.mockResolvedValueOnce({ id: 'abc-def' } as User)
 
-    const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+    const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
     expect(mocks.getOrCreateUser).toHaveBeenCalledWith(
       'loong_loong@coffee.gov.sg',
@@ -119,7 +119,7 @@ describe('Login with SGID', () => {
     async (data) => {
       mocks.sgidUserInfo.mockResolvedValueOnce({ data })
 
-      const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+      const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
       expect(mocks.getOrCreateUser).not.toBeCalled()
       expect(mocks.setAuthCookie).not.toBeCalled()
@@ -142,7 +142,7 @@ describe('Login with SGID', () => {
       },
     })
 
-    const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+    const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
     expect(mocks.getOrCreateUser).not.toBeCalled()
     expect(mocks.sendOnboardingEmail).not.toBeCalled()
@@ -181,7 +181,7 @@ describe('Login with SGID', () => {
     })
     mocks.getOrCreateUser.mockResolvedValueOnce({ id: 'abc-def' } as User)
 
-    const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+    const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
     expect(mocks.getOrCreateUser).toHaveBeenCalledWith('loong@tea.gov.sg')
     expect(mocks.sendOnboardingEmail).toHaveBeenCalledWith({ id: 'abc-def' })
@@ -219,7 +219,7 @@ describe('Login with SGID', () => {
         },
       })
       mocks.getOrCreateUser.mockResolvedValueOnce({ id: 'abc-def' } as User)
-      const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+      const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
       if (isWhitelisted) {
         expect(mocks.getOrCreateUser).toHaveBeenCalledWith(
@@ -253,7 +253,7 @@ describe('Login with SGID', () => {
     })
 
     await expect(
-      loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT),
+      loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT),
     ).rejects.toThrowError('Received malformed data from POCDEX')
 
     expect(mocks.logError).toBeCalledWith(
@@ -275,7 +275,7 @@ describe('Login with SGID', () => {
     })
 
     await expect(
-      loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT),
+      loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT),
     ).rejects.toThrowError('derp')
 
     expect(mocks.logError).toBeCalledWith('Unable to query user info', {
@@ -343,7 +343,7 @@ describe('Login with SGID', () => {
       },
     ]
 
-    const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+    const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
     expect(result.publicOfficerEmployments).toEqual(expectedEntries)
     expect(mocks.signJwt).toBeCalledWith(
@@ -379,7 +379,7 @@ describe('Login with SGID', () => {
       },
     })
 
-    const result = await loginWithSgid(null, STUB_PARAMS, STUB_CONTEXT)
+    const result = await loginWithSgid({}, STUB_PARAMS, STUB_CONTEXT)
 
     expect(result.publicOfficerEmployments).toEqual([
       {

--- a/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
@@ -130,7 +130,7 @@ describe('retryExecutionStep mutation', () => {
   describe('authorization tests', () => {
     it('should allow owner to retry execution step successfully', async () => {
       const result = await retryExecutionStep(
-        null,
+        {},
         { input: genericInputParams },
         context,
       )
@@ -144,7 +144,7 @@ describe('retryExecutionStep mutation', () => {
       context.currentUser = editor
 
       const result = await retryExecutionStep(
-        null,
+        {},
         { input: genericInputParams },
         context,
       )
@@ -158,7 +158,7 @@ describe('retryExecutionStep mutation', () => {
       context.currentUser = viewer
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow(Error)
     })
 
@@ -166,7 +166,7 @@ describe('retryExecutionStep mutation', () => {
       context.currentUser = nonCollaborator
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow(Error)
     })
   })
@@ -177,9 +177,9 @@ describe('retryExecutionStep mutation', () => {
         executionStepId: randomUUID(), // Non-existent ID
       }
 
-      await expect(
-        retryExecutionStep(null, { input }, context),
-      ).rejects.toThrow('Execution step not found')
+      await expect(retryExecutionStep({}, { input }, context)).rejects.toThrow(
+        'Execution step not found',
+      )
     })
 
     it('should throw error when execution step has no job_id', async () => {
@@ -187,7 +187,7 @@ describe('retryExecutionStep mutation', () => {
       await mockExecutionStep.$query().patch({ jobId: null })
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow('Execution step not found')
     })
 
@@ -196,7 +196,7 @@ describe('retryExecutionStep mutation', () => {
       await mockExecutionStep.$query().patch({ status: 'success' })
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow('Execution step not found')
     })
   })
@@ -206,7 +206,7 @@ describe('retryExecutionStep mutation', () => {
       getActionJobSpy.mockResolvedValue(null)
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow('Job not found or has expired')
 
       // Verify that job_id was removed from execution step
@@ -221,7 +221,7 @@ describe('retryExecutionStep mutation', () => {
         executionStepId: mockExecutionStep.id,
       }
 
-      const result = await retryExecutionStep(null, { input }, context)
+      const result = await retryExecutionStep({}, { input }, context)
 
       expect(result).toBe(true)
       expect(getActionJobSpy).toHaveBeenCalledWith('test-job-id')
@@ -231,7 +231,7 @@ describe('retryExecutionStep mutation', () => {
     it('should stamp retryTimestamp on the job before calling retry', async () => {
       vi.spyOn(Date, 'now').mockReturnValue(123456789)
 
-      await retryExecutionStep(null, { input: genericInputParams }, context)
+      await retryExecutionStep({}, { input: genericInputParams }, context)
 
       expect(mockJob.updateData).toHaveBeenCalledWith({
         ...mockJobData,
@@ -247,7 +247,7 @@ describe('retryExecutionStep mutation', () => {
       mockJob.retry.mockRejectedValue(retryErr)
 
       await expect(
-        retryExecutionStep(null, { input: genericInputParams }, context),
+        retryExecutionStep({}, { input: genericInputParams }, context),
       ).rejects.toThrow(retryErr)
 
       expect(mockJob.updateData).toHaveBeenNthCalledWith(1, {
@@ -260,7 +260,7 @@ describe('retryExecutionStep mutation', () => {
 
   describe('execution status updates', () => {
     it('should set execution status to null after successful retry', async () => {
-      await retryExecutionStep(null, { input: genericInputParams }, context)
+      await retryExecutionStep({}, { input: genericInputParams }, context)
 
       const updatedExecution = await Execution.query().findById(
         mockExecution.id,
@@ -281,7 +281,7 @@ describe('retryExecutionStep mutation', () => {
         .mockResolvedValue(undefined)
 
       const result = await retryExecutionStep(
-        null,
+        {},
         { input: genericInputParams },
         context,
       )
@@ -299,7 +299,7 @@ describe('retryExecutionStep mutation', () => {
         .spyOn(ExecutionStep, 'patchIterationStatus')
         .mockResolvedValue(undefined)
 
-      await retryExecutionStep(null, { input: genericInputParams }, context)
+      await retryExecutionStep({}, { input: genericInputParams }, context)
 
       expect(patchIterationStatusSpy).not.toHaveBeenCalled()
     })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
@@ -62,7 +62,7 @@ describe.each([['ddb'], ['pg']])(
       mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
 
       const row = await createRow(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -95,7 +95,7 @@ describe.each([['ddb'], ['pg']])(
         columnIds: dummyColumnIds,
       })
       const row = await createRow(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -127,7 +127,7 @@ describe.each([['ddb'], ['pg']])(
       })
       await expect(
         createRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -143,7 +143,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         createRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -159,7 +159,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = viewer
       await expect(
         createRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
@@ -61,7 +61,7 @@ describe.each([['pg'], ['ddb']])(
       }
 
       await createRows(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -94,7 +94,7 @@ describe.each([['pg'], ['ddb']])(
       }
 
       await createRows(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -137,7 +137,7 @@ describe.each([['pg'], ['ddb']])(
       context.currentUser = editor
       await expect(
         createRows(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -153,7 +153,7 @@ describe.each([['pg'], ['ddb']])(
       context.currentUser = viewer
       await expect(
         createRows(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -61,7 +61,7 @@ describe.each([['pg'], ['ddb']])(
     it('should create a blank table', async () => {
       mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
       const table = await createTable(
-        null,
+        {},
         { input: { name: 'Test Table', isBlank: true } },
         context,
       )
@@ -80,7 +80,7 @@ describe.each([['pg'], ['ddb']])(
     it('should create a table and with placeholder rows and columns', async () => {
       mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
       const table = await createTable(
-        null,
+        {},
         { input: { name: 'Test Table', isBlank: false } },
         context,
       )
@@ -98,13 +98,13 @@ describe.each([['pg'], ['ddb']])(
 
     it('should be able create tables with the same name', async () => {
       const table = await createTable(
-        null,
+        {},
         { input: { name: 'Test Table', isBlank: false } },
         context,
       )
 
       const table2 = await createTable(
-        null,
+        {},
         { input: { name: 'Test Table', isBlank: false } },
         context,
       )
@@ -114,7 +114,7 @@ describe.each([['pg'], ['ddb']])(
 
     it('should throw an error when table name is empty', async () => {
       await expect(
-        createTable(null, { input: { name: '', isBlank: false } }, context),
+        createTable({}, { input: { name: '', isBlank: false } }, context),
       ).rejects.toThrow()
     })
 
@@ -136,7 +136,7 @@ describe.each([['pg'], ['ddb']])(
         mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
 
         const table = await createTable(
-          null,
+          {},
           {
             input: {
               name: 'Flow Table',
@@ -193,7 +193,7 @@ describe.each([['pg'], ['ddb']])(
 
         await expect(
           createTable(
-            null,
+            {},
             {
               input: {
                 name: 'Editor Flow Table',
@@ -213,7 +213,7 @@ describe.each([['pg'], ['ddb']])(
 
         await expect(
           createTable(
-            null,
+            {},
             {
               input: {
                 name: 'Flow Table',

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
@@ -71,7 +71,7 @@ describe.each([['pg'], ['ddb']])(
       const slicedRows = rowIds.slice(0, 5)
 
       const success = await deleteRows(
-        null,
+        {},
         { input: { tableId: dummyTable.id, rowIds: slicedRows } },
         context,
       )
@@ -104,7 +104,7 @@ describe.each([['pg'], ['ddb']])(
 
     it('should be able to delete more than 25 rows', async () => {
       const success = await deleteRows(
-        null,
+        {},
         { input: { tableId: dummyTable.id, rowIds } },
         context,
       )
@@ -140,7 +140,7 @@ describe.each([['pg'], ['ddb']])(
 
       await expect(
         deleteRows(
-          null,
+          {},
           { input: { tableId: dummyTable.id, rowIds: invalidRowIds } },
           context,
         ),
@@ -167,7 +167,7 @@ describe.each([['pg'], ['ddb']])(
       context.currentUser = editor
       await expect(
         deleteRows(
-          null,
+          {},
           { input: { tableId: dummyTable.id, rowIds: slicedRows } },
           context,
         ),
@@ -180,7 +180,7 @@ describe.each([['pg'], ['ddb']])(
       context.currentUser = viewer
       await expect(
         deleteRows(
-          null,
+          {},
           { input: { tableId: dummyTable.id, rowIds: slicedRows } },
           context,
         ),

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
@@ -32,7 +32,7 @@ describe('delete table collaborators', () => {
 
   it('should be able to delete collaborators', async () => {
     await deleteTableCollaborator(
-      null,
+      {},
       {
         input: {
           tableId: dummyTable.id,
@@ -55,7 +55,7 @@ describe('delete table collaborators', () => {
   it('should throw an error if user is not found', async () => {
     await expect(
       deleteTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -69,7 +69,7 @@ describe('delete table collaborators', () => {
 
   it('should throw an error if collaborator is not found', async () => {
     await deleteTableCollaborator(
-      null,
+      {},
       {
         input: {
           tableId: dummyTable.id,
@@ -80,7 +80,7 @@ describe('delete table collaborators', () => {
     )
     await expect(
       deleteTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -96,7 +96,7 @@ describe('delete table collaborators', () => {
     context.currentUser = editor
     await expect(
       deleteTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -112,7 +112,7 @@ describe('delete table collaborators', () => {
     context.currentUser = editor
     await expect(
       deleteTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
@@ -43,7 +43,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should delete table, columns and collaborators', async () => {
       const success = await deleteTable(
-        null,
+        {},
         { input: { id: dummyTable.id } },
         context,
       )
@@ -64,12 +64,12 @@ describe.each([['ddb'], ['pg']])(
     it('should throw an error if user is not the owner', async () => {
       context.currentUser = editor
       await expect(
-        deleteTable(null, { input: { id: dummyTable.id } }, context),
+        deleteTable({}, { input: { id: dummyTable.id } }, context),
       ).rejects.toThrow(ForbiddenError)
 
       context.currentUser = viewer
       await expect(
-        deleteTable(null, { input: { id: dummyTable.id } }, context),
+        deleteTable({}, { input: { id: dummyTable.id } }, context),
       ).rejects.toThrow(ForbiddenError)
     })
   },
@@ -85,7 +85,7 @@ describe('delete table mutation - general tests', () => {
 
   it('should throw an error if table is not found', async () => {
     const deleteTableAction = deleteTable(
-      null,
+      {},
       { input: { id: randomUUID() } },
       context,
     )

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
@@ -86,7 +86,7 @@ describe.each([['ddb'], ['pg']])(
       const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
 
       const updatedId = await updateRow(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -141,7 +141,7 @@ describe.each([['ddb'], ['pg']])(
         columnIds: dummyColumnIds.slice(2),
       })
       const updatedId = await updateRow(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -178,7 +178,7 @@ describe.each([['ddb'], ['pg']])(
       })
       await expect(
         updateRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -194,7 +194,7 @@ describe.each([['ddb'], ['pg']])(
     it('should throw an error if row id is not found', async () => {
       await expect(
         updateRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -216,7 +216,7 @@ describe.each([['ddb'], ['pg']])(
 
       await expect(
         updateRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -241,7 +241,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         updateRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -257,7 +257,7 @@ describe.each([['ddb'], ['pg']])(
 
       await expect(
         updateRow(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
@@ -47,7 +47,7 @@ describe.each([['ddb'], ['pg']])(
       it('is able to update table name', async () => {
         const newTableName = 'New Table Name'
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -64,7 +64,7 @@ describe.each([['ddb'], ['pg']])(
 
       it('will not amend table name if undefined', async () => {
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -82,7 +82,7 @@ describe.each([['ddb'], ['pg']])(
     describe('adding columns to table', () => {
       it('should add columns to table with correct positions', async () => {
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -112,7 +112,7 @@ describe.each([['ddb'], ['pg']])(
 
       it('should add columns to table with same name', async () => {
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -133,7 +133,7 @@ describe.each([['ddb'], ['pg']])(
     describe('modify columns in table', () => {
       it('should modify column name', async () => {
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -154,7 +154,7 @@ describe.each([['ddb'], ['pg']])(
 
       it('should modify column widths', async () => {
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -178,7 +178,7 @@ describe.each([['ddb'], ['pg']])(
 
       it('should fail if column does not exist', async () => {
         const updateTableAction = updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -203,7 +203,7 @@ describe.each([['ddb'], ['pg']])(
       it('should delete columns', async () => {
         // add more columns for deletion
         const updatedTable = await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -215,7 +215,7 @@ describe.each([['ddb'], ['pg']])(
         )
 
         await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -252,7 +252,7 @@ describe.each([['ddb'], ['pg']])(
       it('should not delete last column', async () => {
         await expect(() =>
           updateTable(
-            null,
+            {},
             {
               input: {
                 id: dummyTable.id,
@@ -269,7 +269,7 @@ describe.each([['ddb'], ['pg']])(
       it('should throw an error if trying to delete a column from a different table', async () => {
         // add more columns for deletion
         await updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -294,7 +294,7 @@ describe.each([['ddb'], ['pg']])(
           })
         await expect(
           updateTable(
-            null,
+            {},
             {
               input: {
                 id: dummyTable.id,
@@ -313,7 +313,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,
@@ -332,7 +332,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = viewer
       await expect(
         updateTable(
-          null,
+          {},
           {
             input: {
               id: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
@@ -43,7 +43,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should be able to add new viewers', async () => {
       await upsertTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -65,7 +65,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should be able to add new editors', async () => {
       await upsertTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -87,7 +87,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should be able to update roles', async () => {
       await upsertTableCollaborator(
-        null,
+        {},
         {
           input: {
             tableId: dummyTable.id,
@@ -111,7 +111,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         upsertTableCollaborator(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -128,7 +128,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         upsertTableCollaborator(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -144,7 +144,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         upsertTableCollaborator(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -161,7 +161,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = viewer
       await expect(
         upsertTableCollaborator(
-          null,
+          {},
           {
             input: {
               tableId: dummyTable.id,
@@ -179,7 +179,7 @@ describe.each([['ddb'], ['pg']])(
         context.currentUser = editor
         await expect(
           upsertTableCollaborator(
-            null,
+            {},
             {
               input: {
                 tableId: dummyTable.id,
@@ -195,7 +195,7 @@ describe.each([['ddb'], ['pg']])(
       it('should allow transfer of owner role if you are owner, old owner will become editor', async () => {
         await expect(
           upsertTableCollaborator(
-            null,
+            {},
             {
               input: {
                 tableId: dummyTable.id,
@@ -220,7 +220,7 @@ describe.each([['ddb'], ['pg']])(
       it('should not allow transfer of ownership to non-existent user', async () => {
         await expect(
           upsertTableCollaborator(
-            null,
+            {},
             {
               input: {
                 tableId: dummyTable.id,

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -75,7 +75,7 @@ describe('updateConnection', () => {
       // Editor tries to update - should hit ownership guard
       await expect(
         updateConnection(
-          null,
+          {},
           {
             input: {
               id: ownerConnection.id,
@@ -94,7 +94,7 @@ describe('updateConnection', () => {
       context.currentUser = editor
 
       const result = await updateConnection(
-        null,
+        {},
         {
           input: {
             id: collaboratorConnection.id,
@@ -111,7 +111,7 @@ describe('updateConnection', () => {
 
     it('should allow owner to update their own personal connection', async () => {
       const result = await updateConnection(
-        null,
+        {},
         {
           input: {
             id: ownerConnection.id,
@@ -128,7 +128,7 @@ describe('updateConnection', () => {
 
     it('should allow owner to update shared connection in their flow', async () => {
       const result = await updateConnection(
-        null,
+        {},
         {
           input: {
             id: collaboratorConnection.id,

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -61,7 +61,7 @@ describe('updateFlowTransferStatus', () => {
     it('should reject setting status back to pending', async () => {
       await expect(
         updateFlowTransferStatus(
-          null,
+          {},
           { input: { id: transfer.id, status: 'pending' } },
           context,
         ),
@@ -72,7 +72,7 @@ describe('updateFlowTransferStatus', () => {
       context.currentUser = otherUser
       await expect(
         updateFlowTransferStatus(
-          null,
+          {},
           { input: { id: transfer.id, status: 'approved' } },
           context,
         ),
@@ -83,7 +83,7 @@ describe('updateFlowTransferStatus', () => {
       context.currentUser = otherUser
       await expect(
         updateFlowTransferStatus(
-          null,
+          {},
           { input: { id: transfer.id, status: 'rejected' } },
           context,
         ),
@@ -94,7 +94,7 @@ describe('updateFlowTransferStatus', () => {
       context.currentUser = otherUser
       await expect(
         updateFlowTransferStatus(
-          null,
+          {},
           { input: { id: transfer.id, status: 'cancelled' } },
           context,
         ),
@@ -106,7 +106,7 @@ describe('updateFlowTransferStatus', () => {
     it('new owner can reject; only status is updated', async () => {
       context.currentUser = newOwner
       const res = await updateFlowTransferStatus(
-        null,
+        {},
         { input: { id: transfer.id, status: 'rejected' } },
         context,
       )
@@ -119,7 +119,7 @@ describe('updateFlowTransferStatus', () => {
     it('old owner can cancel; only status is updated', async () => {
       context.currentUser = owner
       const res = await updateFlowTransferStatus(
-        null,
+        {},
         { input: { id: transfer.id, status: 'cancelled' } },
         context,
       )
@@ -159,7 +159,7 @@ describe('updateFlowTransferStatus', () => {
 
       context.currentUser = newOwner
       const result = await updateFlowTransferStatus(
-        null,
+        {},
         { input: { id: transfer.id, status: 'approved' } },
         context,
       )
@@ -261,7 +261,7 @@ describe('updateFlowTransferStatus', () => {
       // Approve the transfer
       context.currentUser = newOwner
       const result = await updateFlowTransferStatus(
-        null,
+        {},
         { input: { id: transfer.id, status: 'approved' } },
         context,
       )
@@ -322,7 +322,7 @@ describe('updateFlowTransferStatus', () => {
       // Approve the transfer as new owner
       context.currentUser = newOwner
       const result = await updateFlowTransferStatus(
-        null,
+        {},
         { input: { id: transfer.id, status: 'approved' } },
         context,
       )
@@ -383,7 +383,7 @@ describe('updateFlowTransferStatus', () => {
       // Should throw an error indicating old owner lacks permissions
       await expect(
         updateFlowTransferStatus(
-          null,
+          {},
           { input: { id: transfer.id, status: 'approved' } },
           context,
         ),

--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -169,7 +169,7 @@ describe('updateStepPositions mutation', () => {
       },
     }
 
-    await updateStepPositions(null, { input }, context)
+    await updateStepPositions({}, { input }, context)
 
     // should call and update the step positions
     expect(stepFindByIdSpy).toHaveBeenCalledTimes(3)
@@ -201,7 +201,7 @@ describe('updateStepPositions mutation', () => {
       ],
     } as any
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Step not found',
     )
   })
@@ -222,10 +222,10 @@ describe('updateStepPositions mutation', () => {
       ],
     } as any
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Failed to update: must update contiguous action steps!',
     )
   })
@@ -246,10 +246,10 @@ describe('updateStepPositions mutation', () => {
       ],
     } as any
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Failed to update: must update contiguous action steps!',
     )
   })
@@ -273,10 +273,10 @@ describe('updateStepPositions mutation', () => {
       },
     } as any
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Failed to update: step positions are out of bounds.',
     )
   })
@@ -307,10 +307,10 @@ describe('updateStepPositions mutation', () => {
       ],
     } as any
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Pipe is active. Cannot update step in active pipe!',
     )
   })
@@ -338,10 +338,10 @@ describe('updateStepPositions mutation', () => {
       },
     }
 
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+    await expect(updateStepPositions({}, { input }, context)).rejects.toThrow(
       'Failed to update: steps were not found',
     )
   })
@@ -422,7 +422,7 @@ describe('updateStepPositions endStepId repair', () => {
 
     // Reorder the block interior [s3, s4, s5] -> [s5, s3, s4].
     await updateStepPositions(
-      null,
+      {},
       {
         input: {
           stepPositions: [
@@ -452,7 +452,7 @@ describe('updateStepPositions endStepId repair', () => {
 
     // Reorder two later steps that sit outside the block.
     await updateStepPositions(
-      null,
+      {},
       {
         input: {
           stepPositions: [
@@ -478,7 +478,7 @@ describe('updateStepPositions endStepId repair', () => {
     ])
 
     await updateStepPositions(
-      null,
+      {},
       {
         input: {
           stepPositions: [
@@ -532,7 +532,7 @@ describe('updateStepPositions endStepId repair', () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
 
       await updateStepPositions(
-        null,
+        {},
         { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
         context,
       )
@@ -549,7 +549,7 @@ describe('updateStepPositions endStepId repair', () => {
       mocks.getLdFlagValue.mockResolvedValue(false)
 
       await updateStepPositions(
-        null,
+        {},
         { input: swapBlocksInput(ifThenB, childB, ifThenA, childA) },
         context,
       )

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -132,7 +132,7 @@ describe('updateStep mutation', () => {
       parameters: { updatedParam: 'newValue' },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -152,7 +152,7 @@ describe('updateStep mutation', () => {
       connection: { id: connectionId },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -178,7 +178,7 @@ describe('updateStep mutation', () => {
       connectionNotFound: true,
     })
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+    await expect(updateStep({}, { input }, context)).rejects.toThrow(
       NotFoundError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
@@ -198,7 +198,7 @@ describe('updateStep mutation', () => {
       stepNotFound: true,
     })
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+    await expect(updateStep({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
@@ -213,7 +213,7 @@ describe('updateStep mutation', () => {
       connection: { id: null } as any,
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendMessage',
@@ -232,7 +232,7 @@ describe('updateStep mutation', () => {
       key: 'invalidKey',
     }
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+    await expect(updateStep({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
 
@@ -241,7 +241,7 @@ describe('updateStep mutation', () => {
       appKey: 'invalidAppKey',
     }
 
-    await expect(updateStep(null, { input: input2 }, context)).rejects.toThrow(
+    await expect(updateStep({}, { input: input2 }, context)).rejects.toThrow(
       BadUserInputError,
     )
   })
@@ -252,7 +252,7 @@ describe('updateStep mutation', () => {
       status: 'incomplete',
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -271,7 +271,7 @@ describe('updateStep mutation', () => {
       config: { stepName: 'Updated Step Name' },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -290,7 +290,7 @@ describe('updateStep mutation', () => {
       config: { stepName: '' },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -324,7 +324,7 @@ describe('updateStep mutation', () => {
       config: { stepName: 'Updated Step Name' },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -369,7 +369,7 @@ describe('updateStep mutation', () => {
       config: { stepName: '' },
     }
 
-    await updateStep(null, { input }, context)
+    await updateStep({}, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
       key: 'sendTransactionalEmail',
@@ -404,7 +404,7 @@ describe('updateStep mutation', () => {
       stepAppKey: 'postman',
       flowUpdatedAt: testFlowISODateString,
     })
-    await updateStep(null, { input: { ...genericInputParams } }, context)
+    await updateStep({}, { input: { ...genericInputParams } }, context)
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -415,7 +415,7 @@ describe('updateStep mutation', () => {
       key: 'forEach',
       parameters: { items: 'not a valid items variable' },
     }
-    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+    await expect(updateStep({}, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
   })
@@ -440,7 +440,7 @@ describe('updateStep mutation', () => {
           },
         )
 
-        await expect(updateStep(null, { input }, context)).rejects.toThrow(
+        await expect(updateStep({}, { input }, context)).rejects.toThrow(
           BadUserInputError,
         )
         expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
@@ -472,9 +472,7 @@ describe('updateStep mutation', () => {
           connectionKey: 'postman',
         })
 
-        await expect(
-          updateStep(null, { input }, context),
-        ).resolves.not.toThrow()
+        await expect(updateStep({}, { input }, context)).resolves.not.toThrow()
         expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
           key: 'sendTransactionalEmail',
           appKey: 'postman',
@@ -491,7 +489,7 @@ describe('updateStep mutation', () => {
   describe('version assignment', () => {
     it('does not include version in patch when app has no stepTransformer', async () => {
       // postman has no stepTransformer
-      await updateStep(null, { input: { ...genericInputParams } }, context)
+      await updateStep({}, { input: { ...genericInputParams } }, context)
 
       expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(
         mockStepId,
@@ -524,7 +522,7 @@ describe('updateStep mutation', () => {
       })
 
       try {
-        await updateStep(null, { input: { ...genericInputParams } }, context)
+        await updateStep({}, { input: { ...genericInputParams } }, context)
 
         expect(mockTransformStepParameters).toHaveBeenCalledWith(
           'sendTransactionalEmail',
@@ -574,7 +572,7 @@ describe('updateStep mutation', () => {
       try {
         // Frontend sends params in old format (stale)
         await updateStep(
-          null,
+          {},
           {
             input: {
               ...genericInputParams,
@@ -652,7 +650,7 @@ describe('updateStep mutation', () => {
         parameters: { fileId: '1234567890' },
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(patchSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
@@ -675,7 +673,7 @@ describe('updateStep mutation', () => {
         connection: { id: mockConnectionId },
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(patchSpy).not.toHaveBeenCalled()
       expect(addSpy).toHaveBeenCalledWith({
@@ -696,7 +694,7 @@ describe('updateStep mutation', () => {
         connection: { id: mockConnectionId },
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(addSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
@@ -746,7 +744,7 @@ describe('updateStep mutation', () => {
         connection: { id: mockConnectionId },
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(patchSpy).not.toHaveBeenCalled()
       expect(addSpy).not.toHaveBeenCalled()
@@ -776,7 +774,7 @@ describe('updateStep mutation', () => {
         connection: {},
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(patchSpy).not.toHaveBeenCalled()
       expect(addSpy).not.toHaveBeenCalled()
@@ -827,7 +825,7 @@ describe('updateStep mutation', () => {
         parameters: { tableId: mockTableId },
       }
 
-      await updateStep(null, { input }, context)
+      await updateStep({}, { input }, context)
 
       expect(patchSpy).not.toHaveBeenCalled()
       expect(addSpy).toHaveBeenCalledWith({
@@ -923,7 +921,7 @@ describe('updateStep endStepId config merge', () => {
     ])
 
     await updateStep(
-      null,
+      {},
       {
         input: {
           id: ifThen.id,
@@ -952,7 +950,7 @@ describe('updateStep endStepId config merge', () => {
     })
 
     await updateStep(
-      null,
+      {},
       {
         input: {
           id: ifThen.id,
@@ -977,7 +975,7 @@ describe('updateStep endStepId config merge', () => {
 
     await expect(
       updateStep(
-        null,
+        {},
         {
           input: {
             id: postmanStep.id,
@@ -1010,7 +1008,7 @@ describe('updateStep endStepId config merge', () => {
 
     await expect(
       updateStep(
-        null,
+        {},
         {
           input: {
             id: ifThen.id,

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -51,7 +51,7 @@ describe('upsert flow collaborator', () => {
 
   it('owner should be able to add new editor', async () => {
     await upsertFlowCollaborator(
-      null,
+      {},
       { input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' } },
       context,
     )
@@ -66,7 +66,7 @@ describe('upsert flow collaborator', () => {
 
   it('owner should be able to add new viewer', async () => {
     await upsertFlowCollaborator(
-      null,
+      {},
       { input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' } },
       context,
     )
@@ -81,7 +81,7 @@ describe('upsert flow collaborator', () => {
 
   it('should be able to update roles', async () => {
     await upsertFlowCollaborator(
-      null,
+      {},
       { input: { flowId: dummyFlow.id, email: editor.email, role: 'viewer' } },
       context,
     )
@@ -98,7 +98,7 @@ describe('upsert flow collaborator', () => {
   it('should not allow editing role of owner', async () => {
     await expect(
       upsertFlowCollaborator(
-        null,
+        {},
         {
           input: {
             flowId: dummyFlow.id,
@@ -115,7 +115,7 @@ describe('upsert flow collaborator', () => {
     context.currentUser = editor
     await expect(
       upsertFlowCollaborator(
-        null,
+        {},
         {
           input: {
             flowId: dummyFlow.id,
@@ -132,7 +132,7 @@ describe('upsert flow collaborator', () => {
     context.currentUser = viewer
     await expect(
       upsertFlowCollaborator(
-        null,
+        {},
         {
           input: {
             flowId: dummyFlow.id,
@@ -196,7 +196,7 @@ describe('upsert flow collaborator', () => {
 
       // Add first collaborator - this should trigger connection sharing
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -239,7 +239,7 @@ describe('upsert flow collaborator', () => {
 
       // Add first collaborator - this should trigger connection sharing
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -248,7 +248,7 @@ describe('upsert flow collaborator', () => {
 
       // Add second collaborator - this should NOT trigger connection sharing again
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
         },
@@ -279,7 +279,7 @@ describe('upsert flow collaborator', () => {
 
       // Add collaborator - this should not fail even with no connections
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -322,7 +322,7 @@ describe('upsert flow collaborator', () => {
 
       // Add collaborator
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -353,7 +353,7 @@ describe('upsert flow collaborator', () => {
 
       // Add collaborator - this should not fail
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -384,7 +384,7 @@ describe('upsert flow collaborator', () => {
 
       // Step 2: Add first collaborator
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -425,7 +425,7 @@ describe('upsert flow collaborator', () => {
       // Step 6: Add a new collaborator - should not fail on duplicate connection
       await expect(
         upsertFlowCollaborator(
-          null,
+          {},
           {
             input: {
               flowId: dummyFlow.id,
@@ -509,7 +509,7 @@ describe('upsert flow collaborator', () => {
 
       // Add collaborator - this should trigger table collaborator sharing
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -551,7 +551,7 @@ describe('upsert flow collaborator', () => {
 
       // Add viewer collaborator
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
         },
@@ -581,7 +581,7 @@ describe('upsert flow collaborator', () => {
       })
 
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -618,7 +618,7 @@ describe('upsert flow collaborator', () => {
       ])
 
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -665,7 +665,7 @@ describe('upsert flow collaborator', () => {
 
       // Add first collaborator - this should trigger both connection and table sharing
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -719,7 +719,7 @@ describe('upsert flow collaborator', () => {
       })
 
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -758,7 +758,7 @@ describe('upsert flow collaborator', () => {
       context.currentUser = editor
       await expect(
         upsertFlowCollaborator(
-          null,
+          {},
           {
             input: {
               flowId: dummyFlow.id,
@@ -785,7 +785,7 @@ describe('upsert flow collaborator', () => {
 
       // add the editor as a collaborator of the Pipe first
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -802,7 +802,7 @@ describe('upsert flow collaborator', () => {
 
       // now we downgrade the Pipe collaborator from an Editor to a Viewer
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'viewer' },
         },
@@ -831,7 +831,7 @@ describe('upsert flow collaborator', () => {
 
       // add the editor as a collaborator of the Pipe first
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },
@@ -852,7 +852,7 @@ describe('upsert flow collaborator', () => {
         email: 'new-collaborator@plumber.gov.sg',
       })
       await upsertFlowCollaborator(
-        null,
+        {},
         {
           input: {
             flowId: dummyFlow.id,
@@ -927,7 +927,7 @@ describe('upsert flow collaborator', () => {
       // so the error should be silently ignored
       await expect(
         upsertFlowCollaborator(
-          null,
+          {},
           {
             input: {
               flowId: dummyFlow.id,
@@ -997,7 +997,7 @@ describe('upsert flow collaborator', () => {
       // Add old owner as viewer (even though they're Tile owner)
       await expect(
         upsertFlowCollaborator(
-          null,
+          {},
           {
             input: {
               flowId: dummyFlow.id,
@@ -1030,7 +1030,7 @@ describe('upsert flow collaborator', () => {
     mocks.getLdFlagValue.mockResolvedValue(false)
     await expect(
       upsertFlowCollaborator(
-        null,
+        {},
         {
           input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
         },

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -88,7 +88,7 @@ describe('verifyConnection', () => {
   describe('access control', () => {
     it('should allow owner to verify their personal connection', async () => {
       const result = await verifyConnection(
-        null,
+        {},
         { input: { id: ownerConnection.id, flowId: testFlow.id } },
         context,
       )
@@ -101,7 +101,7 @@ describe('verifyConnection', () => {
       context.currentUser = editor
 
       const result = await verifyConnection(
-        null,
+        {},
         { input: { id: collaboratorConnection.id, flowId: testFlow.id } },
         context,
       )
@@ -115,7 +115,7 @@ describe('verifyConnection', () => {
 
       await expect(
         verifyConnection(
-          null,
+          {},
           { input: { id: ownerConnection.id, flowId: testFlow.id } },
           context,
         ),
@@ -127,7 +127,7 @@ describe('verifyConnection', () => {
 
       await expect(
         verifyConnection(
-          null,
+          {},
           { input: { id: ownerConnection.id, flowId: testFlow.id } },
           context,
         ),
@@ -138,7 +138,7 @@ describe('verifyConnection', () => {
   describe('owner path - fetches from personal connections', () => {
     it('should verify connection belonging to owner', async () => {
       const result = await verifyConnection(
-        null,
+        {},
         { input: { id: ownerConnection.id, flowId: testFlow.id } },
         context,
       )
@@ -158,7 +158,7 @@ describe('verifyConnection', () => {
 
       await expect(
         verifyConnection(
-          null,
+          {},
           {
             input: {
               id: editorPersonalConnection.id,
@@ -176,7 +176,7 @@ describe('verifyConnection', () => {
       context.currentUser = editor
 
       const result = await verifyConnection(
-        null,
+        {},
         { input: { id: collaboratorConnection.id, flowId: testFlow.id } },
         context,
       )
@@ -191,7 +191,7 @@ describe('verifyConnection', () => {
       // connectionId that exists but is NOT in this flow's flow_connections
       await expect(
         verifyConnection(
-          null,
+          {},
           { input: { id: ownerConnection.id, flowId: testFlow.id } },
           context,
         ),
@@ -213,7 +213,7 @@ describe('verifyConnection', () => {
       // Editor tries to verify - should hit ownership guard, not "not found"
       await expect(
         verifyConnection(
-          null,
+          {},
           { input: { id: ownerConnection.id, flowId: testFlow.id } },
           context,
         ),
@@ -250,7 +250,7 @@ describe('verifyConnection', () => {
       // Editor tries to verify a connection from otherFlow, but passes testFlow's id
       await expect(
         verifyConnection(
-          null,
+          {},
           { input: { id: otherFlowConnection.id, flowId: testFlow.id } },
           context,
         ),
@@ -261,7 +261,7 @@ describe('verifyConnection', () => {
   describe('post-verification state', () => {
     it('should mark connection as verified and non-draft after successful verification', async () => {
       await verifyConnection(
-        null,
+        {},
         { input: { id: ownerConnection.id, flowId: testFlow.id } },
         context,
       )
@@ -273,7 +273,7 @@ describe('verifyConnection', () => {
 
     it('should call verifyCredentials exactly once', async () => {
       await verifyConnection(
-        null,
+        {},
         { input: { id: ownerConnection.id, flowId: testFlow.id } },
         context,
       )

--- a/packages/backend/src/graphql/__tests__/mutations/verify-otp.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-otp.itest.ts
@@ -37,7 +37,7 @@ describe('verifyOtp', () => {
   it('should throw error when is not gov.sg email', async () => {
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '123456', email: 'test@example.com' } },
         context,
       ),
@@ -47,7 +47,7 @@ describe('verifyOtp', () => {
   it('should throw error when no otp provided', async () => {
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '', email: context.currentUser.email } },
         context,
       ),
@@ -57,7 +57,7 @@ describe('verifyOtp', () => {
   it('should throw error when no user found', async () => {
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '123456', email: 'non-existent-user@open.gov.sg' } },
         context,
       ),
@@ -70,7 +70,7 @@ describe('verifyOtp', () => {
       .where({ email: context.currentUser.email })
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '123456', email: context.currentUser.email } },
         context,
       ),
@@ -83,7 +83,7 @@ describe('verifyOtp', () => {
       .where({ email: context.currentUser.email })
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '123456', email: context.currentUser.email } },
         context,
       ),
@@ -99,7 +99,7 @@ describe('verifyOtp', () => {
       .where({ email: context.currentUser.email })
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: '123456', email: context.currentUser.email } },
         context,
       ),
@@ -119,7 +119,7 @@ describe('verifyOtp', () => {
 
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: 'incorrect-otp', email: context.currentUser.email } },
         context,
       ),
@@ -138,7 +138,7 @@ describe('verifyOtp', () => {
 
     await expect(
       verifyOtp(
-        null,
+        {},
         { input: { otp: 'invalid-otp', email: context.currentUser.email } },
         context,
       ),
@@ -159,7 +159,7 @@ describe('verifyOtp', () => {
       .where({ email: context.currentUser.email })
 
     await verifyOtp(
-      null,
+      {},
       { input: { otp: TEST_OTP, email: context.currentUser.email } },
       context,
     )

--- a/packages/backend/src/graphql/__tests__/queries/get-executions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-executions.itest.ts
@@ -100,7 +100,7 @@ const callGetExecutions = async (
   params = {},
 ) => {
   return await getExecutions(
-    null,
+    {},
     { flowId, ...DEFAULT_LIMIT_OFFSET, ...params },
     context,
   )

--- a/packages/backend/src/graphql/__tests__/queries/get-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-flow.itest.ts
@@ -89,7 +89,7 @@ describe('getFlow', () => {
 
   describe('successful flow retrieval', () => {
     it('should return flow data for owner', async () => {
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       expect(result).toMatchObject({
         id: mockFlow.id,
@@ -131,7 +131,7 @@ describe('getFlow', () => {
     })
 
     it('should include owner as collaborator with correct role', async () => {
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       // Test collaborators by manually calling the custom resolver
       const collaborators = await flowResolvers.collaborators(
@@ -147,7 +147,7 @@ describe('getFlow', () => {
 
     it('should return flow data for editor', async () => {
       context.currentUser = editor
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       expect(result).toMatchObject({
         id: mockFlow.id,
@@ -168,7 +168,7 @@ describe('getFlow', () => {
 
     it('should return flow data for viewer', async () => {
       context.currentUser = viewer
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       expect(result).toMatchObject({
         id: mockFlow.id,
@@ -192,7 +192,7 @@ describe('getFlow', () => {
     it('should throw error for non-collaborator user', async () => {
       context.currentUser = nonCollaborator
 
-      await expect(getFlow(null, { id: mockFlow.id }, context)).rejects.toThrow(
+      await expect(getFlow({}, { id: mockFlow.id }, context)).rejects.toThrow(
         NotFoundError,
       )
     })
@@ -201,7 +201,7 @@ describe('getFlow', () => {
       const nonExistentFlowId = randomUUID()
 
       await expect(
-        getFlow(null, { id: nonExistentFlowId }, context),
+        getFlow({}, { id: nonExistentFlowId }, context),
       ).rejects.toThrow(NotFoundError)
     })
 
@@ -214,7 +214,7 @@ describe('getFlow', () => {
 
       context.currentUser = editor
 
-      await expect(getFlow(null, { id: mockFlow.id }, context)).rejects.toThrow(
+      await expect(getFlow({}, { id: mockFlow.id }, context)).rejects.toThrow(
         NotFoundError,
       )
     })
@@ -223,18 +223,18 @@ describe('getFlow', () => {
   describe('input validation', () => {
     it('should throw error for invalid UUID format', async () => {
       await expect(
-        getFlow(null, { id: 'invalid-uuid' }, context),
+        getFlow({}, { id: 'invalid-uuid' }, context),
       ).rejects.toThrow('Please provide a valid pipe ID in your URL.')
     })
 
     it('should throw error for non-string ID', async () => {
-      await expect(getFlow(null, { id: 123 as any }, context)).rejects.toThrow(
+      await expect(getFlow({}, { id: 123 as any }, context)).rejects.toThrow(
         'Please provide a valid pipe ID in your URL.',
       )
     })
 
     it('should throw error for empty string ID', async () => {
-      await expect(getFlow(null, { id: '' }, context)).rejects.toThrow(
+      await expect(getFlow({}, { id: '' }, context)).rejects.toThrow(
         'Please provide a valid pipe ID in your URL.',
       )
     })
@@ -249,7 +249,7 @@ describe('getFlow', () => {
 
       // Note: This would require the FlowTransfer model to be imported
       // For now, we'll test that the query structure supports it
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       expect(result).toMatchObject({
         id: mockFlow.id,
@@ -270,7 +270,7 @@ describe('getFlow', () => {
 
       await mockStep2.$query().patch({ connectionId: connection.id })
 
-      const result = await getFlow(null, { id: mockFlow.id }, context)
+      const result = await getFlow({}, { id: mockFlow.id }, context)
 
       expect(result.steps).toHaveLength(2)
       const stepWithConnection = result.steps.find((s) => s.id === mockStep2.id)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -57,7 +57,7 @@ describe.each([['ddb'], ['pg']])(
       )
 
       const { rows } = await getAllRows(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -83,7 +83,7 @@ describe.each([['ddb'], ['pg']])(
       }
 
       const { rows } = await getAllRows(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -107,7 +107,7 @@ describe.each([['ddb'], ['pg']])(
       let rows: ITableRow[] = []
       do {
         const { rows: pageRows, stringifiedCursor } = await getAllRows(
-          null,
+          {},
           {
             tableId: dummyTable.id,
             stringifiedCursor: cursor,
@@ -122,7 +122,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should return empty array if no rows', async () => {
       const { rows } = await getAllRows(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -145,7 +145,7 @@ describe.each([['ddb'], ['pg']])(
       await dummyTable.$relatedQuery('columns').deleteById(dummyColumnIds[0])
 
       const { rows: returnedRows } = await getAllRows(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -168,7 +168,7 @@ describe.each([['ddb'], ['pg']])(
       })
 
       const { rows: returnedRows } = await getAllRows(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -183,7 +183,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         getAllRows(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -194,7 +194,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = viewer
       await expect(
         getAllRows(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -211,7 +211,7 @@ describe.each([['ddb'], ['pg']])(
         .andWhere('user_id', editor.id)
       await expect(
         getAllRows(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -229,7 +229,7 @@ describe.each([['ddb'], ['pg']])(
           })
           .where('table_id', dummyTable.id)
           .andWhere('user_id', context.currentUser.id)
-        await getAllRows(null, { tableId: dummyTable.id }, context)
+        await getAllRows({}, { tableId: dummyTable.id }, context)
         const { lastAccessedAt } = await TableCollaborator.query().findOne({
           table_id: dummyTable.id,
           user_id: context.currentUser.id,
@@ -248,7 +248,7 @@ describe.each([['ddb'], ['pg']])(
           })
           .where('table_id', dummyTable.id)
           .andWhere('user_id', context.currentUser.id)
-        await getAllRows(null, { tableId: dummyTable.id }, context)
+        await getAllRows({}, { tableId: dummyTable.id }, context)
         const { lastAccessedAt } = await TableCollaborator.query().findOne({
           table_id: dummyTable.id,
           user_id: context.currentUser.id,

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -29,12 +29,12 @@ describe('get table connections query', () => {
   })
 
   it('should return empty object if no tables found', async () => {
-    const { edges } = await getTables(null, { limit: 10, offset: 0 }, context)
+    const { edges } = await getTables({}, { limit: 10, offset: 0 }, context)
     const tables = edges.map((edge) => edge.node)
     expect(tables).toHaveLength(0)
 
     const tableConnections = await getTableConnections(
-      null,
+      {},
       { tableIds: [] },
       context,
     )
@@ -49,7 +49,7 @@ describe('get table connections query', () => {
     const testIds = Array.from({ length: numTables }, () => crypto.randomUUID())
 
     const tableConnections = await getTableConnections(
-      null,
+      {},
       { tableIds: testIds },
       context,
     )
@@ -86,7 +86,7 @@ describe('get table connections query', () => {
       for (let i = 0; i < Math.ceil(numTables / 2); i++) {
         const offset = limit * i
         const { edges, pageInfo } = await getTables(
-          null,
+          {},
           { limit, offset },
           context,
         )
@@ -100,7 +100,7 @@ describe('get table connections query', () => {
         const pageTableIds = edges.map((edge) => edge.node.id)
 
         const tableConnections = await getTableConnections(
-          null,
+          {},
           { tableIds: pageTableIds },
           context,
         )
@@ -154,7 +154,7 @@ describe('get table connections query', () => {
       for (let i = 0; i < Math.ceil(numTables / 2); i++) {
         const offset = limit * i
         const { edges, pageInfo } = await getTables(
-          null,
+          {},
           { limit, offset },
           context,
         )
@@ -168,7 +168,7 @@ describe('get table connections query', () => {
         const pageTableIds = edges.map((edge) => edge.node.id)
 
         const tableConnections = await getTableConnections(
-          null,
+          {},
           { tableIds: pageTableIds },
           context,
         )
@@ -219,7 +219,7 @@ describe('get table connections query', () => {
 
       // test as a whole
       const { edges, pageInfo } = await getTables(
-        null,
+        {},
         { limit: 10, offset: 0 },
         context,
       )
@@ -233,7 +233,7 @@ describe('get table connections query', () => {
       const testIds = [...pageTableIds, crypto.randomUUID()] // add a random table id
       expect(testIds).toHaveLength(numTables + 1)
       const tableConnections = await getTableConnections(
-        null,
+        {},
         { tableIds: testIds },
         context,
       )
@@ -248,7 +248,7 @@ describe('get table connections query', () => {
 
   it('should throw error if tableIds is null', async () => {
     await expect(
-      getTableConnections(null, { tableIds: null }, context),
+      getTableConnections({}, { tableIds: null }, context),
     ).rejects.toThrow('tableIds is required')
   })
 })

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -44,7 +44,7 @@ describe.each([['ddb'], ['pg']])(
     })
     it('should return table metadata with ordered columns', async () => {
       const table = await getTable(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -61,7 +61,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should return table metadata with role', async () => {
       const table = await getTable(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },
@@ -76,7 +76,7 @@ describe.each([['ddb'], ['pg']])(
         databaseType,
       })
       const table = await getTable(
-        null,
+        {},
         {
           tableId: insertedTable.id,
         },
@@ -89,7 +89,7 @@ describe.each([['ddb'], ['pg']])(
     it('should throw an error if table does not exist', async () => {
       await expect(
         getTable(
-          null,
+          {},
           {
             tableId: randomUUID(),
           },
@@ -106,7 +106,7 @@ describe.each([['ddb'], ['pg']])(
         .andWhere('user_id', editor.id)
       await expect(
         getTable(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -119,7 +119,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = editor
       await expect(
         getTable(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -130,7 +130,7 @@ describe.each([['ddb'], ['pg']])(
       context.currentUser = viewer
       await expect(
         getTable(
-          null,
+          {},
           {
             tableId: dummyTable.id,
           },
@@ -141,7 +141,7 @@ describe.each([['ddb'], ['pg']])(
 
     it('should return all collaborators ordered by roles', async () => {
       const table = await getTable(
-        null,
+        {},
         {
           tableId: dummyTable.id,
         },

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
@@ -25,7 +25,7 @@ describe('get tables query', () => {
       })
     }
     const { edges, pageInfo } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0 },
       context,
     )
@@ -37,7 +37,7 @@ describe('get tables query', () => {
 
   it('should return empty array if no tables found', async () => {
     const { edges, pageInfo } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0 },
       context,
     )
@@ -56,7 +56,7 @@ describe('get tables query', () => {
       })
     }
     const { edges, pageInfo } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0 },
       context,
     )
@@ -69,7 +69,7 @@ describe('get tables query', () => {
       .where('table_id', tables[0].id)
       .andWhere('user_id', context.currentUser.id)
     const { edges: newEdges } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0 },
       context,
     )
@@ -87,7 +87,7 @@ describe('get tables query', () => {
       })
     }
     const { edges } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0, name: 'Test Table' },
       context,
     )
@@ -95,7 +95,7 @@ describe('get tables query', () => {
     expect(tables).toHaveLength(numTables)
 
     const { edges: newEdges } = await getTables(
-      null,
+      {},
       { limit: 10, offset: 0, name: 'Invalid name' },
       context,
     )
@@ -112,7 +112,7 @@ describe('get tables query', () => {
       })
     }
     const { edges: firstPage, pageInfo: firstPageInfo } = await getTables(
-      null,
+      {},
       { limit: 2, offset: 0 },
       context,
     )
@@ -122,7 +122,7 @@ describe('get tables query', () => {
     expect(firstPageInfo.totalCount).toBe(numTables)
 
     const { edges: secondPage, pageInfo: secondPageInfo } = await getTables(
-      null,
+      {},
       { limit: 2, offset: 2 },
       context,
     )
@@ -140,7 +140,7 @@ describe('get tables query', () => {
         databaseType: i % 2 ? 'ddb' : 'pg',
       })
     }
-    const { edges } = await getTables(null, { limit: 10, offset: 0 }, context)
+    const { edges } = await getTables({}, { limit: 10, offset: 0 }, context)
     const tables = edges.map((edge) => edge.node)
     for (const table of tables) {
       expect(table.role).toBe('owner')


### PR DESCRIPTION
## Problem

Thirty-first PR in the backend `strict: true` rollout (stacked on round 30). After round 30's `NonNullable` fix, `graphql/`'s remaining error count was 981. Reading the largest remaining bucket (TS2345, 434 errors) showed a second systemic pattern: `graphql/__tests__/mutations/` and `graphql/__tests__/queries/` files call resolvers directly as `someResolver(null, args, context)`, but the generated resolver signature types the parent argument as exactly `{}` (graphql-codegen's root-value convention for Query/Mutation fields) — `null` isn't assignable to it.

## Solution

Confirmed no production resolver actually reads the parent argument — every one is declared `async (_parent, ...) => ...`, the leading underscore signaling it's intentionally unused. This makes the fix purely type-level: swap the literal `null` for `{}` at every call site. Scripted per-file (find the resolver's import name, replace `<name>(null,` → `<name>({},` only for that name, avoiding any risk of touching an unrelated `null` elsewhere in the file) across 36 test files, 393 call sites.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible (type-only, zero behavior change — no resolver reads the parent value)

**Improvements**:

- 393 call sites across 36 `graphql/__tests__/mutations/`+`graphql/__tests__/queries/` files (including `tiles/`) now pass a type-correct `{}` instead of `null` for each resolver's parent argument.
- Still not a gating round — the goal here (like round 30) was clearing systemic noise, not gating individual files, since many still have their own separate remaining errors.

**Bug Fixes**:

- None — type-level fix only.

## Tests

- Full `src/**/*.ts` strict probe: `graphql/`'s error count dropped from 981 to 588 (-393), and the "null not assignable to `{}`" error is now fully gone (0 remaining).
- Full non-strict `npm run -w backend typecheck`: passes, 0 errors, no regressions.
- Ran the 2 unit-testable (`.test.ts`, non-`.itest.ts`) files touched: 14/14 passing. The 34 `.itest.ts` files can't run in this dev environment (pre-existing AWS SSO/DynamoDB blocker) — verified via typecheck + lint only.
- Lint: clean across all 36 changed files.

**New scripts**: none.
**New dependencies**: none.
**New dev dependencies**: none.
