### PR TITLE
chore: cache AI Builder PAIR prompts

### DIFF
--- a/packages/backend/src/helpers/__tests__/pair-prompt-cache.test.ts
+++ b/packages/backend/src/helpers/__tests__/pair-prompt-cache.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  injectPromptCacheControl,
+  wrapFetchWithPromptCache,
+} from '../pair-prompt-cache'
+
+describe('injectPromptCacheControl', () => {
+  it('rewrites a string system message to a cached text block', () => {
+    const result = injectPromptCacheControl({
+      model: 'claude',
+      messages: [
+        { role: 'system', content: 'You are Plumber AI Builder.' },
+        { role: 'user', content: 'Reply with OK.' },
+      ],
+    })
+
+    expect(result).toEqual({
+      model: 'claude',
+      messages: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'text',
+              text: 'You are Plumber AI Builder.',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+        { role: 'user', content: 'Reply with OK.' },
+      ],
+    })
+  })
+
+  it('marks cache_control on the last function tool', () => {
+    const result = injectPromptCacheControl({
+      tools: [
+        {
+          type: 'function',
+          function: { name: 'search', parameters: { type: 'object' } },
+        },
+        {
+          type: 'function',
+          function: { name: 'create_flow', parameters: { type: 'object' } },
+        },
+      ],
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+
+    expect(result).toEqual({
+      tools: [
+        {
+          type: 'function',
+          function: { name: 'search', parameters: { type: 'object' } },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'create_flow',
+            parameters: { type: 'object' },
+            cache_control: { type: 'ephemeral' },
+          },
+        },
+      ],
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+  })
+
+  it('rewrites a developer system message the OpenAI SDK emits for Claude', () => {
+    const result = injectPromptCacheControl({
+      messages: [
+        { role: 'developer', content: 'You are Plumber AI Builder.' },
+        { role: 'user', content: 'Reply with OK.' },
+      ],
+    })
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'developer',
+          content: [
+            {
+              type: 'text',
+              text: 'You are Plumber AI Builder.',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+        { role: 'user', content: 'Reply with OK.' },
+      ],
+    })
+  })
+
+  it('leaves non-system messages unchanged', () => {
+    const body = {
+      messages: [{ role: 'user', content: 'hello' }],
+    }
+    expect(injectPromptCacheControl(body)).toEqual(body)
+  })
+
+  it('returns non-chat bodies unchanged', () => {
+    expect(injectPromptCacheControl(null)).toBeNull()
+    expect(injectPromptCacheControl({ prompt: 'hi' })).toEqual({
+      prompt: 'hi',
+    })
+  })
+})
+
+describe('wrapFetchWithPromptCache', () => {
+  it('injects cache_control into /chat/completions JSON bodies', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{}'))
+    const wrapped = wrapFetchWithPromptCache(fetchImpl)
+
+    await wrapped('https://engine.pair.gov.sg/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({
+        tools: [
+          {
+            type: 'function',
+            function: { name: 'search', parameters: { type: 'object' } },
+          },
+        ],
+        messages: [{ role: 'system', content: 'fixed prompt' }],
+      }),
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://engine.pair.gov.sg/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'search',
+                parameters: { type: 'object' },
+                cache_control: { type: 'ephemeral' },
+              },
+            },
+          ],
+          messages: [
+            {
+              role: 'system',
+              content: [
+                {
+                  type: 'text',
+                  text: 'fixed prompt',
+                  cache_control: { type: 'ephemeral' },
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+    )
+  })
+
+  it('does not rewrite non-chat requests', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('{}'))
+    const wrapped = wrapFetchWithPromptCache(fetchImpl)
+    const init = {
+      method: 'POST',
+      body: JSON.stringify({
+        messages: [{ role: 'system', content: 'fixed prompt' }],
+      }),
+    }
+
+    await wrapped('https://engine.pair.gov.sg/images/generations', init)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://engine.pair.gov.sg/images/generations',
+      init,
+    )
+  })
+})

--- a/packages/backend/src/helpers/pair-prompt-cache.ts
+++ b/packages/backend/src/helpers/pair-prompt-cache.ts
@@ -1,0 +1,121 @@
+import logger from '@/helpers/logger'
+
+/**
+ * PAIR's OpenAI-compatible /chat/completions accepts Anthropic-style
+ * cache_control. The AI SDK OpenAI provider strips providerOptions, so
+ * we rewrite the JSON body after it serialises.
+ *
+ * Matches what @ai-sdk/openai emits: a string system/developer message
+ * and { type: 'function', function } tools. Prefix order is tools →
+ * system → messages. Do not mark the current user turn.
+ */
+const EPHEMERAL_CACHE_CONTROL = { type: 'ephemeral' } as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function withCacheControlOnLastTool(tools: unknown[]): unknown[] {
+  const lastIndex = tools.length - 1
+  const lastTool = tools[lastIndex]
+  if (!isRecord(lastTool) || !isRecord(lastTool.function)) {
+    return tools
+  }
+
+  const nextTools = [...tools]
+  nextTools[lastIndex] = {
+    ...lastTool,
+    function: {
+      ...lastTool.function,
+      cache_control: EPHEMERAL_CACHE_CONTROL,
+    },
+  }
+  return nextTools
+}
+
+function withCacheControlOnSystemMessage(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  // @ai-sdk/openai remaps system → developer for any model ID it does not
+  // treat as GPT chat (PAIR Claude IDs fall into that bucket).
+  if (
+    (message.role !== 'system' && message.role !== 'developer') ||
+    typeof message.content !== 'string'
+  ) {
+    return message
+  }
+
+  return {
+    ...message,
+    content: [
+      {
+        type: 'text',
+        text: message.content,
+        cache_control: EPHEMERAL_CACHE_CONTROL,
+      },
+    ],
+  }
+}
+
+export function injectPromptCacheControl(body: unknown): unknown {
+  if (!isRecord(body)) {
+    return body
+  }
+
+  const next: Record<string, unknown> = { ...body }
+
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    next.tools = withCacheControlOnLastTool(body.tools)
+  }
+
+  if (Array.isArray(body.messages)) {
+    next.messages = body.messages.map((message) =>
+      isRecord(message) ? withCacheControlOnSystemMessage(message) : message,
+    )
+  }
+
+  return next
+}
+
+type FetchInput = Parameters<typeof globalThis.fetch>[0]
+
+function requestUrl(input: FetchInput): string {
+  if (typeof input === 'string') {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.href
+  }
+  return input.url
+}
+
+export function wrapFetchWithPromptCache(
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch.bind(globalThis),
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    if (
+      !requestUrl(input).includes('/chat/completions') ||
+      typeof init?.body !== 'string'
+    ) {
+      return fetchImpl(input, init)
+    }
+
+    try {
+      const nextBody = injectPromptCacheControl(JSON.parse(init.body))
+      return fetchImpl(input, {
+        ...init,
+        body: JSON.stringify(nextBody),
+      })
+    } catch (error) {
+      // Only log the error message, never init.body/headers, since PAIR
+      // requests carry API credentials and prompt content.
+      logger.error(
+        'Failed to inject prompt cache control; sending request uncached',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
+      return fetchImpl(input, init)
+    }
+  }
+}

--- a/packages/backend/src/helpers/pair.ts
+++ b/packages/backend/src/helpers/pair.ts
@@ -2,12 +2,26 @@ import { createOpenAI } from '@ai-sdk/openai'
 
 import appConfig from '@/config/app'
 
+import { wrapFetchWithPromptCache } from './pair-prompt-cache'
+
 const MODEL_TYPE = appConfig.pair.foundry.model
-const engineProvider = createOpenAI({
+
+const pairOpenAISettings = {
   name: 'pair-engine',
   baseURL: 'https://engine.pair.gov.sg',
   apiKey: appConfig.pair.foundry.apiKey,
-})
+} as const
+
+const engineProvider = createOpenAI(pairOpenAISettings)
 const model = engineProvider.chat(MODEL_TYPE)
 
-export { engineProvider, model, MODEL_TYPE }
+/**
+ * AI Builder sends a large stable system prompt and tool list across turns.
+ * PAIR pipe actions do not, so they use `model` / `engineProvider` instead.
+ */
+const chatModel = createOpenAI({
+  ...pairOpenAISettings,
+  fetch: wrapFetchWithPromptCache(),
+}).chat(MODEL_TYPE)
+
+export { chatModel, engineProvider, model, MODEL_TYPE }

--- a/packages/backend/src/routes/api/__tests__/chat.itest.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.itest.ts
@@ -65,6 +65,7 @@ vi.mock('@/helpers/logger', () => ({
 }))
 
 vi.mock('@/helpers/pair', () => ({
+  chatModel: {},
   model: {},
   MODEL_TYPE: 'test-model',
   engineProvider: {

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -82,6 +82,7 @@ vi.mock('@/helpers/ai/get-ai-builder-flag', () => ({
 }))
 
 vi.mock('@/helpers/pair', () => ({
+  chatModel: 'mock-model',
   model: 'mock-model',
   MODEL_TYPE: 'mock-model-type',
   engineProvider: {

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -36,7 +36,7 @@ import { buildSystemPrompt } from '@/helpers/build-system-prompt'
 import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { createMcpBridgeTools } from '@/helpers/mcp-bridge-tools'
-import { model, MODEL_TYPE } from '@/helpers/pair'
+import { chatModel, MODEL_TYPE } from '@/helpers/pair'
 import { pipeWebResponseToExpress } from '@/helpers/stream'
 import Connection from '@/models/connection'
 import Flow from '@/models/flow'
@@ -233,7 +233,7 @@ const handleChatStream = observe(
           )
 
           const result = streamText({
-            model,
+            model: chatModel,
             messages: allMessages,
             tools: { ...gitbookTools, ...mcpTools },
             stopWhen: stepCountIs(10),


### PR DESCRIPTION
## Stack Context

Single PR on `develop-v2`. Cuts AI Builder PAIR input cost by marking the stable prompt prefix for Anthropic-style prompt caching.

## Why?

AI Builder resends a large Langfuse system prompt and the GitBook plus MCP tool list on every turn. PAIR Foundry accepts `cache_control` on `/chat/completions`. `@ai-sdk/openai` strips those markers, so they have to be added after the SDK serialises the body.

## What?

- Wrap only the AI Builder `chatModel` fetch. PAIR pipe actions stay on the uncached client.
- Inject `{ type: "ephemeral" }` on the last OpenAI function tool and on the string `system` / `developer` message.
- `@ai-sdk/openai` remaps `system` to `developer` for PAIR Claude model IDs. Both roles are marked.

Prefix order is tools → system → messages. The current user turn is not marked. Default TTL is 5 minutes, refreshed on each hit.

More detailed write-up in this Notion [doc](https://app.notion.com/p/opengov/Reducing-costs-v1-3d677dbba788802d8ed1cb2586c61602?source=copy_link) 

## Test plan

- [ ] Restart backend so it picks up `chatModel`.
- [ ] Send two AI Builder turns with the same tools and system prompt.
- [ ] Turn 1 usage shows a cache write (`cache_creation_input_tokens` > 0).
- [ ] Turn 2 usage shows a cache read (`cache_read_input_tokens` or `prompt_tokens_details.cached_tokens` > 0).
- [ ] Change the connection reminder or Langfuse prompt version. System cache misses. Tools can still hit if the tool list is unchanged.
- [ ] Process text and Process image still run with no cache rewrite.
- [ ] `npm run -w backend test:unit -- src/helpers/__tests__/pair-prompt-cache.test.ts src/routes/api/chat/index.test.ts`


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62116805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/opengovsg/-/pull-requests/opengovsg/plumber/2184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking test gap around the external SDK serialization boundary.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fhelpers%2F__tests__%2Fpair-prompt-cache.test.ts%3A115-131%0AThis%20test%20supplies%20a%20hand-written%20request%20body%2C%20so%20it%20does%20not%20verify%20the%20SDK%20behavior%20this%20change%20relies%20on%3A%20that%20%60%40ai-sdk%2Fopenai%60%20calls%20the%20custom%20fetch%20with%20a%20string%20%60%2Fchat%2Fcompletions%60%20body%20containing%20function-wrapped%20tools%20and%20string%20system%20or%20developer%20messages.%20If%20the%20provider%20serializes%20any%20of%20these%20differently%2C%20the%20test%20will%20still%20pass%20while%20caching%20silently%20stops%20applying.%20Add%20a%20provider-level%20test%20that%20sends%20a%20request%20through%20%60createOpenAI%60%20and%20asserts%20the%20intercepted%20wire%20body.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**SDK Boundary Remains Untested** <a href="https://github.com/opengovsg/plumber/pull/2184#discussion_r3969275209">▶</a>

<details><summary><h3>Summary</h3></summary>

- Caches the last serialized tool definition and system/developer prompt block.
- Leaves PAIR pipe actions on the existing unwrapped provider.
- Adds transformation and fetch-wrapper unit coverage, though not coverage through the actual OpenAI provider serialization path.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Chat as AI Builder route
    participant SDK as @ai-sdk/openai
    participant Wrapper as Prompt-cache fetch wrapper
    participant PAIR as PAIR chat completions

    Chat->>SDK: streamText(chatModel, messages, tools)
    SDK->>Wrapper: POST /chat/completions with serialized JSON
    Wrapper->>Wrapper: Add cache_control to last tool and system prompt
    Wrapper->>PAIR: Forward rewritten request
    PAIR-->>SDK: Streaming completion response
    SDK-->>Chat: Streamed result
```
</details>

<!-- /greptile_comment -->