### PR TITLE
PLU-743: [IF-THEN-THEN-V2] UX updates v1

### DIFF
--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -2,9 +2,11 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 
+import OnlyContinueIf from '@/components/FlowStepGroup/Content/OnlyContinueIf'
 import { SortableItemContext } from '@/components/SortableList/components/SortableItem'
 import { MrfContext } from '@/contexts/MrfContext'
 import { FlowStep } from '@/exports/components'
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
 
 import { AddStepButton } from './AddStepButton'
 import { DisabledFlowStep } from './DisabledFlowStep'
@@ -19,6 +21,7 @@ export default function FlowStepWithAddButton({
     isDisabled = false,
     showEmptyAction = false,
   },
+  asConditionBlock = false,
 }: {
   step: IStep
   isLastStep: boolean
@@ -31,6 +34,8 @@ export default function FlowStepWithAddButton({
     isDisabled: boolean
     showEmptyAction: boolean
   }
+  /** Draw an only-continue-if step as a CONTINUE IF condition block. */
+  asConditionBlock?: boolean
 }) {
   const { disabledMrfStepToDisplay } = useContext(MrfContext)
   const { isOverlay, isSorting } = useContext(SortableItemContext)
@@ -39,13 +44,22 @@ export default function FlowStepWithAddButton({
 
   return (
     <>
-      <FlowStep
-        step={step}
-        isLastStep={isLastStep}
-        isNested={isNested}
-        // only allow reordering if there are more than 1 action steps
-        allowReorder={allowReorder}
-      />
+      {asConditionBlock && isOnlyContinueIfStep(step) ? (
+        <OnlyContinueIf
+          step={step}
+          isLastStep={isLastStep}
+          isNested={isNested}
+          allowReorder={allowReorder}
+        />
+      ) : (
+        <FlowStep
+          step={step}
+          isLastStep={isLastStep}
+          isNested={isNested}
+          // only allow reordering if there are more than 1 action steps
+          allowReorder={allowReorder}
+        />
+      )}
       {/* Hide the add step button and dividers for the drag overlay */}
       {!isOverlay && (
         <AddStepButton

--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -230,6 +230,8 @@ export function StepsList({ isNested }: StepsListProps) {
                     allowReorder={canReorderBlocks}
                     stepsBeforeGroup={[]}
                     groupedSteps={[]}
+                    // Reads the if-then V2 gate once here, not per step.
+                    asConditionBlock
                     addButtonProps={{
                       isHidden: readOnly || !!isOverlay,
                       isDisabled: false,

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -24,10 +24,18 @@ interface DeleteStepButtonProps {
   step: IStep
   stepName: string
   displayPosition?: number
+  /** Skip FlowStep's hover-reveal CSS, since the parent controls visibility. */
+  alwaysVisible?: boolean
 }
 
 export default function DeleteStepButton(props: DeleteStepButtonProps) {
-  const { isNested, step, stepName, displayPosition } = props
+  const {
+    isNested,
+    step,
+    stepName,
+    displayPosition,
+    alwaysVisible = false,
+  } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
   const customBody = stepName
     ? `Are you sure you want to delete step **${
@@ -139,8 +147,10 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
           icon={<BiTrash />}
           minHeight={isNested ? 6 : 8}
           minWidth={isNested ? 6 : 8}
-          className={isMobile ? undefined : 'hover-remove-button'}
-          visibility={isMobile ? 'visible' : 'hidden'}
+          className={
+            isMobile || alwaysVisible ? undefined : 'hover-remove-button'
+          }
+          visibility={isMobile || alwaysVisible ? 'visible' : 'hidden'}
         />
       </Flex>
 

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -15,10 +15,12 @@ import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 interface DuplicateStepButtonProps {
   isNested?: boolean
   step: IStep
+  /** Skip FlowStep's hover-reveal CSS, since the parent controls visibility. */
+  alwaysVisible?: boolean
 }
 
 export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
-  const { isNested, step } = props
+  const { isNested, step, alwaysVisible = false } = props
 
   const { flow, isMobile, onDrawerOpen, setCurrentStepId } =
     useContext(EditorContext)
@@ -84,8 +86,10 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
           icon={<BiDuplicate />}
           minHeight={isNested ? 6 : 8}
           minWidth={isNested ? 6 : 8}
-          className={isMobile ? undefined : 'hover-remove-button'}
-          visibility={isMobile ? 'visible' : 'hidden'}
+          className={
+            isMobile || alwaysVisible ? undefined : 'hover-remove-button'
+          }
+          visibility={isMobile || alwaysVisible ? 'visible' : 'hidden'}
         />
       </Tooltip>
       <UnsavedChangesAlert

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/__tests__/useIsAppSelectable.test.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/__tests__/useIsAppSelectable.test.ts
@@ -1,0 +1,160 @@
+import type { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+
+import {
+  FOR_EACH_INSIDE_BLOCK_REASON,
+  getIfThenV2Selectability,
+  IF_THEN_INSIDE_BLOCK_REASON,
+  LAST_STEP_ONLY_REASON,
+} from '../useIsAppSelectable'
+
+//
+// Fixtures. Selectability runs over the MRF-filtered action-step list (the
+// trigger already removed), ordered by position, so these never include a
+// trigger.
+//
+
+const plain = (id: string): IStep =>
+  ({ id, appKey: 'postman', key: 'sendTransactionalEmail' } as IStep)
+
+// The endStepId marker is what makes an if-then V2, so every block here
+// carries one. A marker pointing at the if-then itself is an empty block.
+const ifThen = (id: string, endStepId: string): IStep => {
+  const marker: Partial<IStep> = { config: { endStepId } }
+  return {
+    id,
+    appKey: 'toolbox',
+    key: 'ifThen',
+    parameters: { depth: '0' },
+    ...marker,
+  } as IStep
+}
+
+const forEach = (id: string): IStep =>
+  ({ id, appKey: 'toolbox', key: 'forEach' } as IStep)
+
+const GROUPING_ACTIONS = new Set(['toolbox-ifThen', 'toolbox-forEach'])
+
+describe('getIfThenV2Selectability', () => {
+  describe('inside an if-then block', () => {
+    it('rejects both grouping actions when the launcher states the placement', () => {
+      // The empty-block placeholder's anchor is the if-then step itself, which
+      // is not inside its own block, so it can only say so explicitly.
+      const emptyBlock = ifThen('ifThen', 'ifThen')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'inside-if-then-block',
+        anchorStep: emptyBlock,
+        actionSteps: [emptyBlock],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: FOR_EACH_INSIDE_BLOCK_REASON,
+      })
+      expect(result[TOOLBOX_ACTIONS.IfThen]).toEqual({
+        isSelectable: false,
+        disabledReason: IF_THEN_INSIDE_BLOCK_REASON,
+      })
+    })
+
+    it('rejects both grouping actions when the anchor is a block child', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach].isSelectable).toBe(false)
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(false)
+    })
+  })
+
+  describe('outside every if-then block', () => {
+    it('allows both grouping actions after the last block, at the last step', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'after-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach].isSelectable).toBe(true)
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(true)
+    })
+
+    it('holds for-each to the last step while an if-then goes anywhere', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: false,
+        anchorPlacement: 'after-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child, plain('after')],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: LAST_STEP_ONLY_REASON,
+      })
+      expect(result[TOOLBOX_ACTIONS.IfThen].isSelectable).toBe(true)
+    })
+
+    it('rejects a second for-each in the flow', () => {
+      const inBody = plain('inBody')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: inBody,
+        actionSteps: [forEach('forEach'), inBody],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result[TOOLBOX_ACTIONS.ForEach]).toEqual({
+        isSelectable: false,
+        disabledReason: LAST_STEP_ONLY_REASON,
+      })
+    })
+  })
+
+  describe('delay', () => {
+    it('rejects a delay inside a for-each body', () => {
+      const inBody = plain('inBody')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorStep: inBody,
+        actionSteps: [forEach('forEach'), inBody],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result.delay.isSelectable).toBe(false)
+    })
+
+    it('allows a delay inside an if-then block', () => {
+      const child = plain('child')
+
+      const result = getIfThenV2Selectability({
+        isLastStep: true,
+        anchorPlacement: 'inside-if-then-block',
+        anchorStep: child,
+        actionSteps: [ifThen('ifThen', 'child'), child],
+        groupingActions: GROUPING_ACTIONS,
+      })
+
+      expect(result.delay.isSelectable).toBe(true)
+    })
+  })
+})

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -26,10 +26,11 @@ export const LAST_STEP_ONLY_REASON = 'This can only be used as the last step'
  * An if-then block runs the steps it contains, so an if-then among them would
  * be a nested branch — which the block model does not support.
  */
-const IF_THEN_INSIDE_BLOCK_REASON =
+export const IF_THEN_INSIDE_BLOCK_REASON =
   'You cannot add an If-then inside another If-then'
 
-const FOR_EACH_INSIDE_BLOCK_REASON = 'For-each cannot be used in an If-then'
+export const FOR_EACH_INSIDE_BLOCK_REASON =
+  'For-each cannot be used in an If-then'
 
 export interface AppSelectability {
   isSelectable: boolean
@@ -119,7 +120,7 @@ function isIfThenSelectable({
  * leaving nesting as the sole restriction. For-each has no such extent, so it
  * still swallows every later step and must stay last.
  */
-function getIfThenV2Selectability({
+export function getIfThenV2Selectability({
   isLastStep,
   anchorPlacement,
   anchorStep,

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/ForEachV1.tsx
@@ -1,0 +1,122 @@
+import { IStep } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+import { Flex } from '@chakra-ui/react'
+
+import { SortableList } from '@/components/SortableList'
+import { EditorContext } from '@/contexts/Editor'
+import { FlowStepGroup } from '@/exports/components'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
+import useReorderSteps from '@/hooks/useReorderSteps'
+
+import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+
+interface ForEachV1Props {
+  groupedSteps: IStep[][]
+  stepsBeforeGroup: IStep[]
+}
+
+/**
+ * The for-each V1 body, retired wholesale once the if-then V2 flag is fully
+ * rolled out, along with FlowStepGroup's fork.
+ */
+export default function ForEachV1(props: ForEachV1Props) {
+  const { groupedSteps } = props
+  const { flow } = useContext(EditorContext)
+  // Only for isLoading, since the nested group must not render before the flag
+  // resolves.
+  const { isLoading: isIfThenV2Loading } = useIfThenV2Enabled()
+  const { handleReorderUpdate } = useReorderSteps(flow.id)
+
+  const forEachSteps = groupedSteps[0]
+  const ifThenSteps = useMemo(() => {
+    if (groupedSteps.length === 1) {
+      return []
+    }
+    return groupedSteps.slice(1)
+  }, [groupedSteps])
+
+  // NOTE: groupedSteps includes for-each and if-then actions
+  // so groupedSteps === 1 means that there is only the for-each action
+  const nonForEachActionSteps = forEachSteps.filter(
+    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.ForEach,
+  )
+  const hasNoActionSteps =
+    nonForEachActionSteps.length === 0 && groupedSteps.length === 1
+
+  const { conditionStep, actionSteps } = useMemo(() => {
+    const conditionStep = forEachSteps[0]
+    const actionSteps = forEachSteps.slice(1)
+
+    return { conditionStep, actionSteps }
+  }, [forEachSteps])
+
+  const handleReorderSteps = async (items: any[]) => {
+    const forEachPosition = conditionStep.position
+    const stepPositions = items.map((item, index) => ({
+      id: item.id,
+      position: forEachPosition + index + 1, // index is 0-based
+      type: item.step.type,
+    }))
+
+    try {
+      handleReorderUpdate(stepPositions)
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
+  return (
+    <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
+      <Flex flexDir="column" w="100%" px={4} py={3}>
+        <GroupStepWithAddButton
+          step={conditionStep}
+          canAddStep={true}
+          isLastStep={hasNoActionSteps}
+          allowReorder={false}
+          showEmptyAction={hasNoActionSteps}
+          // So the header reserves width for a sibling item's drag handle.
+          canChildStepsReorder={actionSteps.length > 1}
+        />
+        <SortableList
+          items={actionSteps.map((step, index) => ({
+            id: step.id,
+            step,
+            index,
+          }))}
+          onChange={handleReorderSteps}
+          renderItem={(item, isOverlay) => {
+            const { step, index } = item
+            const isLastStep =
+              index === actionSteps.length - 1 && ifThenSteps.length === 0
+            return (
+              <SortableList.Item id={item.id}>
+                <Flex w="100%" flexDir="column">
+                  <GroupStepWithAddButton
+                    step={step}
+                    canAddStep={true}
+                    isLastStep={isLastStep}
+                    isOverlay={isOverlay}
+                    allowReorder={actionSteps.length > 1}
+                  />
+                </Flex>
+              </SortableList.Item>
+            )
+          }}
+        />
+
+        {ifThenSteps.length > 0 && !isIfThenV2Loading && (
+          <FlowStepGroup
+            stepsBeforeGroup={forEachSteps}
+            groupedSteps={ifThenSteps}
+          />
+        )}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -139,7 +139,7 @@ export default function ForEach(props: ForEachProps) {
       <BlockHeader
         badgeLabel="REPEAT"
         previewParts={previewParts}
-        stepId={conditionStep.id}
+        step={conditionStep}
         isSelected={isSelected}
         actions={
           readOnly ? undefined : (

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -1,7 +1,9 @@
 import { IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
+import { BiTrash } from 'react-icons/bi'
 import { Flex } from '@chakra-ui/react'
+import { IconButton } from '@opengovsg/design-system-react'
 
 import {
   buildStepsList,
@@ -11,35 +13,37 @@ import {
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { FlowStepGroup } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
-import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
+import BlockHeader from '../../components/BlockHeader'
+import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
+import { getForEachBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
+import useDeleteStepConfirmation from '../../hooks/useDeleteStepConfirmation'
+import { HoverAddStepButton } from '../IfThen/HoverAddStepButton'
 import IfThen from '../IfThen/IfThen'
+import { blockActionButtonStyles, conditionBlockStyles } from '../IfThen/styles'
 
 interface ForEachProps {
   groupedSteps: IStep[][]
   stepsBeforeGroup: IStep[]
 }
 
+/**
+ * A for-each V2 loop drawn as a REPEAT condition block, picked over
+ * `ForEachV1` by `FlowStepGroup`.
+ */
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
-  const { flow, readOnly } = useContext(EditorContext)
+  const { currentStepId, flow, isDrawerOpen, onDrawerClose, readOnly } =
+    useContext(EditorContext)
   const { groupingActions } = useContext(StepsToDisplayContext)
-  const { isEnabled: isIfThenV2Enabled, isLoading: isIfThenV2Loading } =
-    useIfThenV2Enabled()
   const { handleReorderUpdate } = useReorderSteps(flow.id)
 
   const forEachSteps = groupedSteps[0]
-  const ifThenSteps = useMemo(() => {
-    if (groupedSteps.length === 1) {
-      return []
-    }
-    return groupedSteps.slice(1)
-  }, [groupedSteps])
+  const conditionStep = forEachSteps[0]
 
   // NOTE: groupedSteps includes for-each and if-then actions
   // so groupedSteps === 1 means that there is only the for-each action
@@ -49,32 +53,6 @@ export default function ForEach(props: ForEachProps) {
   const hasNoActionSteps =
     nonForEachActionSteps.length === 0 && groupedSteps.length === 1
 
-  const { conditionStep, actionSteps } = useMemo(() => {
-    const conditionStep = forEachSteps[0]
-    const actionSteps = forEachSteps.slice(1)
-
-    return { conditionStep, actionSteps }
-  }, [forEachSteps])
-
-  const handleReorderSteps = async (items: any[]) => {
-    const forEachPosition = conditionStep.position
-    const stepPositions = items.map((item, index) => ({
-      id: item.id,
-      position: forEachPosition + index + 1, // index is 0-based
-      type: item.step.type,
-    }))
-
-    try {
-      handleReorderUpdate(stepPositions)
-    } catch (error) {
-      console.error(
-        'Error updating step positions: ',
-        error,
-        JSON.stringify(stepPositions),
-      )
-    }
-  }
-
   // Every non-condition step in the body shares one reorder domain, matching
   // the top-level list — a plain step immediately next to an if-then V2
   // block must be able to swap with it, not be stuck in a separate list. A
@@ -82,8 +60,8 @@ export default function ForEach(props: ForEachProps) {
   // within the block's own SortableList (in IfThen), never into this one.
   const bodySteps = useMemo(() => groupedSteps.flat().slice(1), [groupedSteps])
 
-  const ifThenBlockItems = useMemo(() => {
-    if (!isIfThenV2Enabled || bodySteps.length === 0) {
+  const blockItems = useMemo(() => {
+    if (bodySteps.length === 0) {
       return []
     }
     return buildStepsList(
@@ -92,24 +70,22 @@ export default function ForEach(props: ForEachProps) {
     ).filter(
       (item): item is IfThenBlock | SingleStep => item.type !== 'forEachBlock',
     )
-  }, [isIfThenV2Enabled, bodySteps, groupingActions])
+  }, [bodySteps, groupingActions])
 
-  const hasIfThenBlockItem = ifThenBlockItems.some(
-    (item) => item.type === 'ifThenBlock',
-  )
+  const hasBlock = blockItems.some((item) => item.type === 'ifThenBlock')
 
-  const sortableBlockItems = useMemo(
+  const sortableItems = useMemo(
     () =>
-      ifThenBlockItems.map((item) => ({
+      blockItems.map((item) => ({
         id: item.type === 'ifThenBlock' ? item.ifThenStep.id : item.step.id,
         item,
       })),
-    [ifThenBlockItems],
+    [blockItems],
   )
-  const canReorderBlocks = !readOnly && ifThenBlockItems.length > 1
-  const lastBlockItemId = sortableBlockItems[sortableBlockItems.length - 1]?.id
+  const canReorder = !readOnly && blockItems.length > 1
+  const lastItemId = sortableItems[sortableItems.length - 1]?.id
 
-  const handleReorderBlockItems = async (
+  const handleReorder = async (
     reordered: Array<{ id: string; item: IfThenBlock | SingleStep }>,
   ) => {
     const reorderedSteps = reordered.flatMap(({ item }) =>
@@ -134,31 +110,69 @@ export default function ForEach(props: ForEachProps) {
     }
   }
 
+  const {
+    cancelRef,
+    isOpen: isDeleteConfirmationOpen,
+    onClose: closeDeleteConfirmation,
+    onDelete: deleteForEach,
+    openDeleteConfirmation,
+  } = useDeleteStepConfirmation(TOOLBOX_ACTIONS.ForEach, groupedSteps)
+
+  const handleForEachDelete = useCallback(async () => {
+    await deleteForEach()
+    onDrawerClose()
+  }, [deleteForEach, onDrawerClose])
+
+  const isSelected = currentStepId === conditionStep.id
+
+  const previewParts = useMemo(
+    () => getForEachBlockPreviewParts(conditionStep.parameters),
+    [conditionStep.parameters],
+  )
+
   return (
-    <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
-      <Flex flexDir="column" w="100%" px={4} py={3}>
-        <GroupStepWithAddButton
-          step={conditionStep}
-          canAddStep={true}
-          isLastStep={hasNoActionSteps}
-          allowReorder={false}
-          showEmptyAction={hasNoActionSteps}
-          // True when either sibling list has a reorderable item, so the
-          // header still reserves width for that item's drag handle.
-          canChildStepsReorder={actionSteps.length > 1 || canReorderBlocks}
-        />
-        {isIfThenV2Enabled ? (
-          <Flex
-            flexDir="column"
-            w="100%"
-            gap={hasIfThenBlockItem ? 2 : undefined}
-          >
+    <Flex
+      {...conditionBlockStyles.container}
+      borderWidth="1px"
+      borderColor={isSelected ? 'base.content.brand' : 'base.divider.medium'}
+    >
+      <BlockHeader
+        badgeLabel="REPEAT"
+        previewParts={previewParts}
+        stepId={conditionStep.id}
+        isSelected={isSelected}
+        actions={
+          readOnly ? undefined : (
+            <IconButton
+              {...blockActionButtonStyles}
+              onClick={openDeleteConfirmation}
+              aria-label="Delete for each action"
+              icon={<BiTrash />}
+            />
+          )
+        }
+      />
+
+      <Flex {...conditionBlockStyles.body}>
+        {hasNoActionSteps ? (
+          <HoverAddStepButton
+            isDisabled={readOnly}
+            isDrawerOpen={isDrawerOpen}
+            isLastStep={true}
+            prevStep={conditionStep}
+            showEmptyAction={true}
+            hideLeadingConnector
+            step={conditionStep}
+            allowReorder={false}
+          />
+        ) : (
+          <Flex flexDir="column" w="100%" gap={hasBlock ? 2 : undefined}>
             <SortableList
-              items={sortableBlockItems}
-              onChange={handleReorderBlockItems}
+              items={sortableItems}
+              onChange={handleReorder}
               renderItem={(sortableItem, isOverlay) => {
                 const { id, item } = sortableItem
-                const isLastItem = id === lastBlockItemId
+                const isLastItem = id === lastItemId
 
                 if (item.type === 'ifThenBlock') {
                   return (
@@ -166,24 +180,25 @@ export default function ForEach(props: ForEachProps) {
                       <IfThen
                         block={item}
                         isLastBlock={isLastItem}
-                        allowReorder={canReorderBlocks}
+                        allowReorder={canReorder}
                       />
                     </SortableList.Item>
                   )
                 }
 
                 // A plain step around if-then V2 blocks in the body — an
-                // explicit endStepId marker can end a block before the
-                // body's last step, unlike a derived if-then V1 extent.
+                // explicit endStepId marker can end a block before the body's
+                // last step, unlike a derived if-then V1 extent.
                 return (
                   <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
                     <Flex w="100%" flexDir="column">
                       <GroupStepWithAddButton
                         step={item.step}
+                        asConditionBlock
                         canAddStep={true}
                         isLastStep={isLastItem}
                         isOverlay={isOverlay}
-                        allowReorder={canReorderBlocks}
+                        allowReorder={canReorder}
                       />
                     </Flex>
                   </SortableList.Item>
@@ -191,44 +206,17 @@ export default function ForEach(props: ForEachProps) {
               }}
             />
           </Flex>
-        ) : (
-          <>
-            <SortableList
-              items={actionSteps.map((step, index) => ({
-                id: step.id,
-                step,
-                index,
-              }))}
-              onChange={handleReorderSteps}
-              renderItem={(item, isOverlay) => {
-                const { step, index } = item
-                const isLastStep =
-                  index === actionSteps.length - 1 && ifThenSteps.length === 0
-                return (
-                  <SortableList.Item id={item.id}>
-                    <Flex w="100%" flexDir="column">
-                      <GroupStepWithAddButton
-                        step={step}
-                        canAddStep={true}
-                        isLastStep={isLastStep}
-                        isOverlay={isOverlay}
-                        allowReorder={actionSteps.length > 1}
-                      />
-                    </Flex>
-                  </SortableList.Item>
-                )
-              }}
-            />
-
-            {ifThenSteps.length > 0 && !isIfThenV2Loading && (
-              <FlowStepGroup
-                stepsBeforeGroup={forEachSteps}
-                groupedSteps={ifThenSteps}
-              />
-            )}
-          </>
         )}
       </Flex>
+
+      <DeleteConfirmationDialog
+        name="For each"
+        cancelRef={cancelRef}
+        isOpen={isDeleteConfirmationOpen}
+        onClose={closeDeleteConfirmation}
+        onDelete={handleForEachDelete}
+        onCancel={closeDeleteConfirmation}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -24,7 +24,12 @@ import { getForEachBlockPreviewParts } from '../../helpers/getConditionBlockPrev
 import useDeleteStepConfirmation from '../../hooks/useDeleteStepConfirmation'
 import { HoverAddStepButton } from '../IfThen/HoverAddStepButton'
 import IfThen from '../IfThen/IfThen'
-import { blockActionButtonStyles, conditionBlockStyles } from '../IfThen/styles'
+import {
+  blockActionButtonStyles,
+  CONDITION_BLOCK_BODY_PB,
+  conditionBlockStyles,
+  EMPTY_CONDITION_BLOCK_BODY_PB,
+} from '../IfThen/styles'
 
 interface ForEachProps {
   groupedSteps: IStep[][]
@@ -153,7 +158,14 @@ export default function ForEach(props: ForEachProps) {
         }
       />
 
-      <Flex {...conditionBlockStyles.body}>
+      <Flex
+        {...conditionBlockStyles.body}
+        pb={
+          hasNoActionSteps
+            ? EMPTY_CONDITION_BLOCK_BODY_PB
+            : CONDITION_BLOCK_BODY_PB
+        }
+      >
         {hasNoActionSteps ? (
           <HoverAddStepButton
             isDisabled={readOnly}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -21,6 +21,8 @@ interface HoverAddStepButtonProps {
   isLastStep: boolean
   prevStep: IStep
   showEmptyAction?: boolean
+  // Drops the vertical connector above an empty-state add card.
+  hideLeadingConnector?: boolean
   step: IStep
   allowReorder?: boolean
   canChildStepsReorder?: boolean
@@ -41,6 +43,7 @@ export function HoverAddStepButton(
     isLastStep,
     prevStep,
     showEmptyAction,
+    hideLeadingConnector,
     step,
     allowReorder,
     canChildStepsReorder,
@@ -67,9 +70,14 @@ export function HoverAddStepButton(
     <>
       {showEmptyAction ? (
         <Flex flexDir="column" alignItems="center" mb={1}>
-          <Flex h="2rem">
-            <Divider orientation="vertical" borderColor="base.divider.strong" />
-          </Flex>
+          {!hideLeadingConnector && (
+            <Flex h="2rem">
+              <Divider
+                orientation="vertical"
+                borderColor="base.divider.strong"
+              />
+            </Flex>
+          )}
           <EmptyFlowStepHeader
             isNested={true}
             isTrigger={false}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -25,21 +25,20 @@ import { SortableList } from '@/components/SortableList'
 import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { FlowStep } from '@/exports/components'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
-import getStepName from '@/helpers/getStepName'
 import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
+import BlockHeader from '../../components/BlockHeader'
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
-import { flowStepGroupStyles } from '../../styles'
+import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
 
 import { AddAfterBlockButton } from './AddAfterBlockButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
-import { blockActionButtonStyles, branchStyles } from './styles'
+import { blockActionButtonStyles, conditionBlockStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 
 interface IfThenProps {
@@ -59,11 +58,8 @@ interface ReorderItem {
 }
 
 /**
- * Drawn as the same grouped box as an if-then V1 group, despite having only
- * one branch, so the two variants read as the same thing in the editor.
- *
- * The interior reuses the shared display building blocks, so a step's own
- * add/reorder affordances behave exactly as they do elsewhere in the editor.
+ * A single-branch if-then block: the condition step plus the steps that run
+ * when it passes.
  */
 export default function IfThen({
   block,
@@ -72,7 +68,6 @@ export default function IfThen({
 }: IfThenProps): JSX.Element {
   const { ifThenStep, children } = block
   const {
-    allApps,
     currentStepId,
     flow,
     isDrawerOpen,
@@ -103,11 +98,11 @@ export default function IfThen({
     groupingActions ?? new Set<string>(),
   )
 
-  // Reuses getStepName rather than re-deriving the same rule here, so a
-  // leftover V1 block's branchName keeps showing in the header exactly as it
-  // does in the drawer title below. isIfThenV2Enabled is hardcoded true: this
-  // component only ever mounts on the flag-ON render fork.
-  const headerLabel = getStepName(allApps, ifThenStep, true).stepName
+  const conditionPreviewParts = useMemo(
+    () => getConditionBlockPreviewParts(ifThenStep.parameters),
+    [ifThenStep.parameters],
+  )
+  const isSelected = currentStepId === ifThenStep.id
 
   // IMPORTANT: assumes allowReorder already excludes read-only. The caller
   // (StepsList) folds that in before passing it down.
@@ -231,7 +226,7 @@ export default function IfThen({
           minW={MIN_FLOW_STEP_WIDTH}
         >
           <Flex
-            {...flowStepGroupStyles.container}
+            {...conditionBlockStyles.container}
             display={isMobile ? 'block' : 'flex'}
             // Lets the box give up room to the inline drag handle below
             // instead of overflowing the slot.
@@ -249,198 +244,84 @@ export default function IfThen({
             }
             ml={blockHandleOffset ? `${blockHandleOffset}px` : undefined}
             minW="0"
-            // The header and branch run edge to edge, so the box clips them to
-            // its own rounded corners.
             overflow="hidden"
-            // The box carries the selected-state border its flush header drops.
+            borderWidth="1px"
             borderColor={
-              currentStepId === ifThenStep.id
-                ? 'base.content.brand'
-                : 'base.divider.medium'
+              isSelected ? 'base.content.brand' : 'base.divider.medium'
             }
           >
-            {/*
-              The header stands in for the whole block, not a step of its own to
-              configure. So it takes the block's name and drops click-to-configure
-              and its own border, letting the box read as one step rather than a
-              card holding cards.
-
-              Delete/duplicate are overlaid on the header's trailing edge
-              instead of laid out beside it, since hidden-until-hover buttons
-              would otherwise reserve width and pull the header in. They're
-              siblings of the header rather than children, so a click on them
-              never bubbles into the condition card's open-the-drawer handler.
-
-              Being overlaid means they sit outside the header's own padding, so
-              they re-create a step's trailing inset and button metrics
-              themselves (see FlowStep's header) to line up with the delete icon
-              of the steps above and below the block.
-            */}
-            <Flex alignItems="center" w="100%" role="group" pos="relative">
-              <FlowStep
-                step={ifThenStep}
-                stepNameOverride={headerLabel}
-                isContainerHeader
-                isClickable={false}
-                isNested={true}
-                isLastStep={isEmptyBlock}
-                allowReorder={false}
-              />
-
-              {!readOnly && (
-                <Flex
-                  pos="absolute"
-                  top={0}
-                  bottom={0}
-                  // The inset and gap a step's header gives its own
-                  // duplicate/delete pair. Insetting the overlay rather than
-                  // padding it keeps the strip beside the buttons part of the
-                  // header, so clicking there still opens the drawer.
-                  right={4}
-                  gap={1}
-                  alignItems="center"
-                  opacity={{ base: 1, lg: 0 }}
-                  _groupHover={{ opacity: 1 }}
-                >
-                  {canDuplicateBranch && (
+            <BlockHeader
+              badgeLabel="IF"
+              previewParts={conditionPreviewParts}
+              stepId={ifThenStep.id}
+              isSelected={isSelected}
+              actions={
+                !readOnly ? (
+                  <>
+                    {canDuplicateBranch && (
+                      <IconButton
+                        {...blockActionButtonStyles}
+                        onClick={onDuplicate}
+                        aria-label="Duplicate if-then"
+                        icon={<BiDuplicate />}
+                        isLoading={isDuplicatingBranch}
+                        isDisabled={isDuplicatingBranch || isDeletingBlock}
+                      />
+                    )}
                     <IconButton
                       {...blockActionButtonStyles}
-                      onClick={onDuplicate}
-                      aria-label="Duplicate if-then"
-                      icon={<BiDuplicate />}
-                      isLoading={isDuplicatingBranch}
-                      isDisabled={isDuplicatingBranch || isDeletingBlock}
-                    />
-                  )}
-                  <IconButton
-                    {...blockActionButtonStyles}
-                    onClick={openDeleteConfirmation}
-                    aria-label="Delete if-then"
-                    icon={<BiTrash />}
-                    isLoading={isDeletingBlock}
-                    isDisabled={isDeletingBlock || isDuplicatingBranch}
-                  />
-                </Flex>
-              )}
-            </Flex>
-
-            {/*
-              The condition step renders again here as a normal card, matching
-              how an if-then V1 branch draws its condition card and steps in one
-              panel. An empty block keeps this panel and placeholder rather than
-              looking like a different component.
-
-              The panel is white, not branchStyles.container's usual grey, since
-              a single-branch box doesn't need to visually separate branches the
-              way an if-then V1 group's side-by-side branches do.
-            */}
-            <Flex
-              {...branchStyles.container}
-              bg="white"
-              borderRadius="none"
-              // pb drops by the placeholder's own 4px bottom margin so the
-              // empty-block panel stays evenly padded overall.
-              pb={isEmptyBlock ? 2 : 3}
-            >
-              <Flex w="100%" flexDir="column">
-                {/*
-                  This is the same condition step the header above renders, now
-                  as a normal, clickable card. It drops its own name and
-                  position number since the header already carries both.
-                */}
-                <FlowStep
-                  step={ifThenStep}
-                  stepNameOverride="Condition"
-                  hideDisplayPosition
-                  isNested={true}
-                  isLastStep={false}
-                  allowReorder={false}
-                  // Matches the width sibling cards give up for their own drag
-                  // handles, exactly as an if-then V1 branch's condition card
-                  // does, so the condition card isn't wider than the cards
-                  // below it.
-                  canChildStepsReorder={children.length > 1}
-                />
-
-                {isEmptyBlock ? (
-                  // The placeholder card is `w="100%"`, which only resolves to the
-                  // panel's width because this column stretches it; left to the
-                  // block box, whose items are centred, it would shrink to fit its
-                  // own text.
-                  <HoverAddStepButton
-                    isDisabled={readOnly}
-                    isDrawerOpen={isDrawerOpen}
-                    isLastStep={true}
-                    prevStep={ifThenStep}
-                    showEmptyAction={true}
-                    step={ifThenStep}
-                    allowReorder={false}
-                    // The if-then step, this card's anchor, sits outside its
-                    // own block. This step sits inside it.
-                    anchorPlacement="inside-if-then-block"
-                  />
-                ) : (
-                  <>
-                    {/*
-                      Every other card-to-card transition in this panel has a
-                      connector; the condition card is no exception, so a
-                      populated block can insert a step directly after it too.
-                    */}
-                    <HoverAddStepButton
-                      // Reuses isDisabled for the sole-blank-placeholder edge
-                      // case (see isSoleBlankPlaceholder). pointerEvents: none
-                      // keeps the connector but makes the hover-+ itself inert.
-                      isDisabled={readOnly || isSoleBlankPlaceholder}
-                      isDrawerOpen={isDrawerOpen}
-                      isLastStep={false}
-                      prevStep={ifThenStep}
-                      step={ifThenStep}
-                      allowReorder={false}
-                      canChildStepsReorder={children.length > 1}
-                      // Same reasoning as the empty-block placeholder above:
-                      // this step also lands inside the block.
-                      anchorPlacement="inside-if-then-block"
-                    />
-                    <SortableList
-                      items={children.map((step, index) => ({
-                        id: step.id,
-                        step,
-                        index,
-                      }))}
-                      onChange={handleReorderSteps}
-                      renderItem={(item, isOverlay) => {
-                        const { step, index } = item
-                        const isLastStep = index === children.length - 1
-
-                        // Every step, last one included, gets the same hover +
-                        // to append after it — matching how a for-each body
-                        // (and an if-then V1 branch) appends, rather than the
-                        // last step handing off to its own separate,
-                        // always-visible "Add step" card.
-                        return (
-                          <SortableList.Item id={item.id}>
-                            <Flex w="100%" flexDir="column">
-                              <GroupStepWithAddButton
-                                step={step}
-                                // Same sole-blank-placeholder edge case as
-                                // the leading HoverAddStepButton above: no
-                                // trailing hover-+ after it either, so the
-                                // card reads as an empty block's own
-                                // add-first-step placeholder rather than a
-                                // populated block's last member.
-                                canAddStep={!isSoleBlankPlaceholder}
-                                isLastStep={isLastStep}
-                                isOverlay={isOverlay}
-                                allowReorder={children.length > 1}
-                              />
-                            </Flex>
-                          </SortableList.Item>
-                        )
-                      }}
+                      onClick={openDeleteConfirmation}
+                      aria-label="Delete if-then"
+                      icon={<BiTrash />}
+                      isLoading={isDeletingBlock}
+                      isDisabled={isDeletingBlock || isDuplicatingBranch}
                     />
                   </>
-                )}
-              </Flex>
+                ) : undefined
+              }
+            />
+
+            <Flex {...conditionBlockStyles.body} pb={isEmptyBlock ? 2 : 3}>
+              {isEmptyBlock ? (
+                <HoverAddStepButton
+                  isDisabled={readOnly}
+                  isDrawerOpen={isDrawerOpen}
+                  isLastStep={true}
+                  prevStep={ifThenStep}
+                  showEmptyAction={true}
+                  hideLeadingConnector
+                  step={ifThenStep}
+                  allowReorder={false}
+                />
+              ) : (
+                <SortableList
+                  items={children.map((step, index) => ({
+                    id: step.id,
+                    step,
+                    index,
+                  }))}
+                  onChange={handleReorderSteps}
+                  renderItem={(item, isOverlay) => {
+                    const { step, index } = item
+                    const isLastStep = index === children.length - 1
+
+                    return (
+                      <SortableList.Item id={item.id}>
+                        <Flex w="100%" flexDir="column">
+                          <GroupStepWithAddButton
+                            step={step}
+                            asConditionBlock
+                            canAddStep={!isSoleBlankPlaceholder}
+                            isLastStep={isLastStep}
+                            isOverlay={isOverlay}
+                            allowReorder={children.length > 1}
+                          />
+                        </Flex>
+                      </SortableList.Item>
+                    )
+                  }}
+                />
+              )}
             </Flex>
 
             <MenuAlertDialog

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -253,7 +253,7 @@ export default function IfThen({
             <BlockHeader
               badgeLabel="IF"
               previewParts={conditionPreviewParts}
-              stepId={ifThenStep.id}
+              step={ifThenStep}
               isSelected={isSelected}
               actions={
                 !readOnly ? (

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -38,7 +38,12 @@ import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPr
 
 import { AddAfterBlockButton } from './AddAfterBlockButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
-import { blockActionButtonStyles, conditionBlockStyles } from './styles'
+import {
+  blockActionButtonStyles,
+  CONDITION_BLOCK_BODY_PB,
+  conditionBlockStyles,
+  EMPTY_CONDITION_BLOCK_BODY_PB,
+} from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 
 interface IfThenProps {
@@ -281,7 +286,14 @@ export default function IfThen({
               }
             />
 
-            <Flex {...conditionBlockStyles.body} pb={isEmptyBlock ? 2 : 3}>
+            <Flex
+              {...conditionBlockStyles.body}
+              pb={
+                isEmptyBlock
+                  ? EMPTY_CONDITION_BLOCK_BODY_PB
+                  : CONDITION_BLOCK_BODY_PB
+              }
+            >
               {isEmptyBlock ? (
                 <HoverAddStepButton
                   isDisabled={readOnly}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx
@@ -292,6 +292,9 @@ export default function IfThen({
                   hideLeadingConnector
                   step={ifThenStep}
                   allowReorder={false}
+                  // The anchor is the if-then step itself, which reads as outside
+                  // its own block.
+                  anchorPlacement="inside-if-then-block"
                 />
               ) : (
                 <SortableList

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -42,6 +42,24 @@ export const blockActionButtonStyles = {
   colorScheme: 'secondary',
 }
 
+/**
+ * The strip a condition block's actions are overlaid in.
+ *
+ * IMPORTANT: `BLOCK_ACTIONS_OVERLAY_WIDTH_PX` must change with these values,
+ * or the header's reserved padding stops clearing the buttons.
+ */
+export const blockActionsOverlayStyles = {
+  pl: 2, // 8px
+  pr: 4, // 16px
+  gap: 1, // 4px
+}
+
+/**
+ * 8 + 32 + 4 + 32 + 16, from `blockActionsOverlayStyles` and
+ * `blockActionButtonStyles.boxSize`.
+ */
+export const BLOCK_ACTIONS_OVERLAY_WIDTH_PX = 92
+
 export const branchStyles = {
   container: {
     alignItems: 'center',
@@ -51,6 +69,39 @@ export const branchStyles = {
     overflow: 'hidden',
     px: 3,
     py: 3,
+    w: '100%',
+  },
+}
+
+/**
+ * The card a condition block (IF / CONTINUE IF / REPEAT) draws, distinct from
+ * `branchStyles` which an if-then V1 branch still uses.
+ */
+export const conditionBlockStyles = {
+  // No padding of its own, so the header can sit flush.
+  container: {
+    alignItems: 'stretch',
+    bg: 'white',
+    borderRadius: 'lg',
+    direction: 'column' as FlexProps['direction'],
+    overflow: 'hidden',
+    w: '100%',
+  },
+  header: {
+    bg: 'base.divider.subtle',
+    borderRadius: 'none',
+    px: 4,
+    py: 3,
+    minH: 12,
+    w: '100%',
+  },
+  body: {
+    alignItems: 'stretch',
+    bg: 'white',
+    direction: 'column' as FlexProps['direction'],
+    px: 3,
+    pt: 4,
+    pb: 0,
     w: '100%',
   },
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -95,16 +95,25 @@ export const conditionBlockStyles = {
     minH: 12,
     w: '100%',
   },
+  // Every consumer sets its own `pb`, so none is declared here.
   body: {
     alignItems: 'stretch',
     bg: 'white',
     direction: 'column' as FlexProps['direction'],
     px: 3,
     pt: 4,
-    pb: 0,
     w: '100%',
   },
 }
+
+/** Sits below the trailing hover-+ strip a block's last step reserves. */
+export const CONDITION_BLOCK_BODY_PB = 3
+
+/**
+ * An empty block reserves no such strip, so its padding stands in for one and
+ * every condition block's bottom lines up. The 4 is the strip's own height.
+ */
+export const EMPTY_CONDITION_BLOCK_BODY_PB = CONDITION_BLOCK_BODY_PB + 4
 
 export const hoverAddStepButtonStyles = {
   container: {

--- a/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
@@ -1,0 +1,199 @@
+import { IStep } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+import { BiSolidErrorCircle } from 'react-icons/bi'
+import { Box, Flex, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
+
+import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
+import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
+import DeleteStepButton from '@/components/FlowStep/components/DeleteStepButton'
+import DuplicateStepButton from '@/components/FlowStep/components/DuplicateStepButton'
+import FlowStepWrapper from '@/components/FlowStep/FlowStepWrapper'
+import { DragHandle } from '@/components/SortableList/components'
+import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
+import { EditorContext } from '@/contexts/Editor'
+import { getFlowStepHeaderWidth } from '@/helpers/editor'
+import { useStepMetadata } from '@/hooks/useStepMetadata'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+
+import BlockHeader from '../../components/BlockHeader'
+import { getConditionBlockPreviewParts } from '../../helpers/getConditionBlockPreview'
+import { conditionBlockStyles } from '../IfThen/styles'
+
+interface OnlyContinueIfProps {
+  step: IStep
+  isNested?: boolean
+  allowReorder?: boolean
+  canChildStepsReorder?: boolean
+  /** When true, omit the caption, since nothing follows this step to gate. */
+  isLastStep?: boolean
+}
+
+/**
+ * An only-continue-if step drawn like the IF / REPEAT condition headers.
+ *
+ * IMPORTANT: it holds no steps of its own, so a caption spells out that a
+ * failed check stops the flow there.
+ */
+export default function OnlyContinueIf({
+  step,
+  isNested = false,
+  allowReorder = true,
+  canChildStepsReorder = false,
+  isLastStep = false,
+}: OnlyContinueIfProps): JSX.Element {
+  const { currentStepId, isDrawerOpen, isMobile, readOnly } =
+    useContext(EditorContext)
+  const {
+    displayPosition,
+    isDeletable,
+    shouldShowDragHandle,
+    stepName,
+    warnsMrfNoGate,
+  } = useStepMetadata(step, allowReorder)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: () => undefined,
+  })
+
+  const isSelected = currentStepId === step.id
+  const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
+  const nestedHandleOffset =
+    isNested && shouldShowDragHandle ? NESTED_DRAG_HANDLE_WIDTH / 2 : 0
+
+  const previewParts = useMemo(
+    () => getConditionBlockPreviewParts(step.parameters),
+    [step.parameters],
+  )
+
+  return (
+    <FlowStepWrapper
+      canChildStepsReorder={canChildStepsReorder}
+      allowReorder={allowReorder}
+      isDrawerOpen={isDrawerOpen}
+      isReadOnly={readOnly}
+    >
+      <Flex flexDir="column" w="100%" alignItems="center">
+        <Flex
+          pos="relative"
+          alignItems="center"
+          w={headerWidth}
+          minW={MIN_FLOW_STEP_WIDTH}
+          flexDir="column"
+        >
+          {warnsMrfNoGate && (
+            <Box
+              borderColor={
+                isSelected ? 'base.content.brand' : 'base.divider.medium'
+              }
+              borderRadius="lg"
+              borderWidth="1px"
+              borderBottomRadius="none"
+              borderBottomWidth={0}
+              w="100%"
+              overflow="hidden"
+            >
+              <Infobox
+                icon={<BiSolidErrorCircle />}
+                variant="warning"
+                style={{
+                  borderBottomLeftRadius: '0',
+                  borderBottomRightRadius: '0',
+                }}
+              >
+                This won&rsquo;t stop the next respondent. FormSG still sends
+                them the form. &ldquo;Only continue if&rdquo; only skips the
+                Plumber steps below.
+              </Infobox>
+            </Box>
+          )}
+          <Flex w="100%" alignItems="center" pos="relative">
+            <Flex
+              {...conditionBlockStyles.container}
+              display={isMobile ? 'block' : 'flex'}
+              flex={nestedHandleOffset ? undefined : '1'}
+              flexShrink={nestedHandleOffset ? 0 : undefined}
+              w={
+                nestedHandleOffset
+                  ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+                  : undefined
+              }
+              ml={nestedHandleOffset ? `${nestedHandleOffset}px` : undefined}
+              minW="0"
+              overflow="hidden"
+              borderWidth="1px"
+              borderTopWidth={warnsMrfNoGate ? 0 : '1px'}
+              borderColor={
+                isSelected ? 'base.content.brand' : 'base.divider.medium'
+              }
+              borderTopRadius={warnsMrfNoGate ? 'none' : 'lg'}
+            >
+              <BlockHeader
+                badgeLabel="CONTINUE IF"
+                previewParts={previewParts}
+                stepId={step.id}
+                isSelected={isSelected}
+                actions={
+                  isDeletable && !readOnly ? (
+                    <>
+                      <DuplicateStepButton
+                        alwaysVisible
+                        isNested={isNested}
+                        step={step}
+                      />
+                      <DeleteStepButton
+                        alwaysVisible
+                        isNested={isNested}
+                        step={step}
+                        displayPosition={displayPosition}
+                        stepName={stepName}
+                      />
+                    </>
+                  ) : undefined
+                }
+              />
+            </Flex>
+            {shouldShowDragHandle &&
+              (isNested ? (
+                <DragHandle isNested={isNested} onWarningOpen={onWarningOpen} />
+              ) : (
+                <Box position="absolute" left="100%" alignSelf="center">
+                  <DragHandle onWarningOpen={onWarningOpen} />
+                </Box>
+              ))}
+          </Flex>
+        </Flex>
+
+        {!isLastStep && (
+          <Text
+            mt={3}
+            mb={1}
+            textAlign="center"
+            fontSize="0.6875rem"
+            lineHeight="0.875rem"
+            letterSpacing="0.03em"
+            textTransform="uppercase"
+            fontWeight="500"
+            color="base.divider.strong"
+          >
+            Otherwise flow stops here
+          </Text>
+        )}
+      </Flex>
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={discardChanges}
+      />
+    </FlowStepWrapper>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/OnlyContinueIf/index.tsx
@@ -138,7 +138,7 @@ export default function OnlyContinueIf({
               <BlockHeader
                 badgeLabel="CONTINUE IF"
                 previewParts={previewParts}
-                stepId={step.id}
+                step={step}
                 isSelected={isSelected}
                 actions={
                   isDeletable && !readOnly ? (

--- a/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
@@ -1,3 +1,5 @@
+import type { IStep } from '@plumber/types'
+
 import type { ReactNode } from 'react'
 import {
   useCallback,
@@ -24,7 +26,7 @@ import type { ConditionPreviewPart } from '../helpers/getConditionBlockPreview'
 interface BlockHeaderProps {
   badgeLabel: string
   previewParts: ConditionPreviewPart[]
-  stepId: string
+  step: IStep
   isSelected?: boolean
   actions?: ReactNode
 }
@@ -38,7 +40,7 @@ interface BlockHeaderProps {
 export default function BlockHeader({
   badgeLabel,
   previewParts,
-  stepId,
+  step,
   isSelected = false,
   actions,
 }: BlockHeaderProps): JSX.Element {
@@ -59,13 +61,13 @@ export default function BlockHeader({
     handleLeave: discardChanges,
   } = useUnsavedChanges({
     onProceed: () => {
-      setCurrentStepId(stepId)
+      setCurrentStepId(step.id)
       onDrawerOpen()
     },
   })
 
   const handleClick = useCallback(() => {
-    if (isDrawerOpen && currentStepId === stepId) {
+    if (isDrawerOpen && currentStepId === step.id) {
       setCurrentStepId(null)
       onDrawerClose()
       return
@@ -78,19 +80,26 @@ export default function BlockHeader({
     isDrawerOpen,
     onDrawerClose,
     setCurrentStepId,
-    stepId,
+    step.id,
   ])
 
   const headerBg = isSelected ? 'primary.50' : conditionBlockStyles.header.bg
 
-  const { parts, fullSentence, isLeadingTruncated } = useMemo(
+  // Not `useStepMetadata`'s stepName, which falls back to "If-then" and would
+  // mask the condition on every unnamed block.
+  // IMPORTANT: clearing the name saves `''`, which must read as no name.
+  const customStepName = step.config?.stepName || undefined
+
+  const conditionSentence = useMemo(
     () =>
-      buildConditionSentence(
-        badgeLabel,
-        previewParts,
-        (id) => varInfoMap.get(`{{${id}}}`)?.label,
-      ),
-    [badgeLabel, previewParts, varInfoMap],
+      customStepName
+        ? undefined
+        : buildConditionSentence(
+            badgeLabel,
+            previewParts,
+            (id) => varInfoMap.get(`{{${id}}}`)?.label,
+          ),
+    [badgeLabel, customStepName, previewParts, varInfoMap],
   )
 
   // The value half is cut by layout, so only the rendered box can report a
@@ -111,7 +120,7 @@ export default function BlockHeader({
     const observer = new ResizeObserver(measure)
     observer.observe(element)
     return () => observer.disconnect()
-  }, [parts])
+  }, [conditionSentence, customStepName])
 
   return (
     <>
@@ -127,8 +136,12 @@ export default function BlockHeader({
       >
         <Tooltip
           // A tooltip repeating text already fully on screen is noise.
-          isDisabled={!isLeadingTruncated && !isClamped}
-          label={fullSentence}
+          isDisabled={!conditionSentence?.isLeadingTruncated && !isClamped}
+          label={
+            customStepName
+              ? `${badgeLabel} ${customStepName}`
+              : conditionSentence?.fullSentence
+          }
           placement="top-start"
           openDelay={300}
           hasArrow
@@ -162,26 +175,29 @@ export default function BlockHeader({
             >
               {badgeLabel}
             </Text>
-            {parts.map((part, index) => {
-              if (part.type === 'text' || part.type === 'literal') {
-                return <span key={`${part.type}-${index}`}>{part.display}</span>
-              }
+            {customStepName ??
+              conditionSentence?.parts.map((part, index) => {
+                if (part.type === 'text' || part.type === 'literal') {
+                  return (
+                    <span key={`${part.type}-${index}`}>{part.display}</span>
+                  )
+                }
 
-              return (
-                <Text
-                  as="span"
-                  key={
-                    part.type === 'emphasis'
-                      ? `em-${index}`
-                      : `var-${part.id}-${index}`
-                  }
-                  fontWeight="700"
-                  color="base.content.strong"
-                >
-                  {part.display}
-                </Text>
-              )
-            })}
+                return (
+                  <Text
+                    as="span"
+                    key={
+                      part.type === 'emphasis'
+                        ? `em-${index}`
+                        : `var-${part.id}-${index}`
+                    }
+                    fontWeight="700"
+                    color="base.content.strong"
+                  >
+                    {part.display}
+                  </Text>
+                )
+              })}
           </Text>
         </Tooltip>
 

--- a/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/BlockHeader.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { Flex, Text, Tooltip } from '@chakra-ui/react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+
+import UnsavedChangesAlert from '../../Editor/components/UnsavedChangesAlert'
+import {
+  BLOCK_ACTIONS_OVERLAY_WIDTH_PX,
+  blockActionsOverlayStyles,
+  conditionBlockStyles,
+} from '../Content/IfThen/styles'
+import { buildConditionSentence } from '../helpers/buildConditionSentence'
+import type { ConditionPreviewPart } from '../helpers/getConditionBlockPreview'
+
+interface BlockHeaderProps {
+  badgeLabel: string
+  previewParts: ConditionPreviewPart[]
+  stepId: string
+  isSelected?: boolean
+  actions?: ReactNode
+}
+
+/**
+ * Shared header for nested condition blocks (IF / CONTINUE IF / REPEAT).
+ *
+ * IMPORTANT: the actions overlay the trailing edge, so revealing them on hover
+ * does not reflow the sentence.
+ */
+export default function BlockHeader({
+  badgeLabel,
+  previewParts,
+  stepId,
+  isSelected = false,
+  actions,
+}: BlockHeaderProps): JSX.Element {
+  const {
+    currentStepId,
+    isDrawerOpen,
+    onDrawerClose,
+    onDrawerOpen,
+    setCurrentStepId,
+    varInfoMap,
+  } = useContext(EditorContext)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: () => {
+      setCurrentStepId(stepId)
+      onDrawerOpen()
+    },
+  })
+
+  const handleClick = useCallback(() => {
+    if (isDrawerOpen && currentStepId === stepId) {
+      setCurrentStepId(null)
+      onDrawerClose()
+      return
+    }
+
+    handleProceed()
+  }, [
+    currentStepId,
+    handleProceed,
+    isDrawerOpen,
+    onDrawerClose,
+    setCurrentStepId,
+    stepId,
+  ])
+
+  const headerBg = isSelected ? 'primary.50' : conditionBlockStyles.header.bg
+
+  const { parts, fullSentence, isLeadingTruncated } = useMemo(
+    () =>
+      buildConditionSentence(
+        badgeLabel,
+        previewParts,
+        (id) => varInfoMap.get(`{{${id}}}`)?.label,
+      ),
+    [badgeLabel, previewParts, varInfoMap],
+  )
+
+  // The value half is cut by layout, so only the rendered box can report a
+  // clamp.
+  const clampedTextRef = useRef<HTMLParagraphElement>(null)
+  const [isClamped, setIsClamped] = useState(false)
+
+  useEffect(() => {
+    const element = clampedTextRef.current
+    if (!element) {
+      return
+    }
+
+    const measure = () =>
+      setIsClamped(element.scrollHeight > element.clientHeight + 1)
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [parts])
+
+  return (
+    <>
+      <Flex
+        {...conditionBlockStyles.header}
+        position="relative"
+        role="group"
+        alignItems="center"
+        cursor="pointer"
+        bg={headerBg}
+        _hover={{ bg: 'interaction.muted.neutral.hover' }}
+        onClick={handleClick}
+      >
+        <Tooltip
+          // A tooltip repeating text already fully on screen is noise.
+          isDisabled={!isLeadingTruncated && !isClamped}
+          label={fullSentence}
+          placement="top-start"
+          openDelay={300}
+          hasArrow
+        >
+          <Text
+            ref={clampedTextRef}
+            flex="1"
+            minW={0}
+            noOfLines={2}
+            textStyle="body-2"
+            color="base.content.medium"
+            // Reserved only at the widths where the overlay is always on,
+            // since desktop hides it until hover.
+            pr={{
+              base: actions ? `${BLOCK_ACTIONS_OVERLAY_WIDTH_PX}px` : 0,
+              lg: 0,
+            }}
+          >
+            <Text
+              as="span"
+              display="inline-flex"
+              alignItems="center"
+              verticalAlign="text-bottom"
+              px={2}
+              py="2px"
+              mr={2}
+              borderRadius="md"
+              bg="primary.100"
+              color="primary.500"
+              textStyle="caption-3"
+            >
+              {badgeLabel}
+            </Text>
+            {parts.map((part, index) => {
+              if (part.type === 'text' || part.type === 'literal') {
+                return <span key={`${part.type}-${index}`}>{part.display}</span>
+              }
+
+              return (
+                <Text
+                  as="span"
+                  key={
+                    part.type === 'emphasis'
+                      ? `em-${index}`
+                      : `var-${part.id}-${index}`
+                  }
+                  fontWeight="700"
+                  color="base.content.strong"
+                >
+                  {part.display}
+                </Text>
+              )
+            })}
+          </Text>
+        </Tooltip>
+
+        {actions && (
+          <Flex
+            position="absolute"
+            top={0}
+            right={0}
+            bottom={0}
+            zIndex={1}
+            alignItems="center"
+            {...blockActionsOverlayStyles}
+            bg={headerBg}
+            // Always on for touch, since there is no hover there.
+            opacity={{ base: 1, lg: 0 }}
+            pointerEvents={{ base: 'auto', lg: 'none' }}
+            transition="opacity 0.15s ease-in-out"
+            _groupHover={{
+              opacity: 1,
+              pointerEvents: 'auto',
+              bg: 'interaction.muted.neutral.hover',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {actions}
+          </Flex>
+        )}
+      </Flex>
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={discardChanges}
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -4,8 +4,10 @@ import { useContext } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
 
 import { HoverAddStepButton } from '../Content/IfThen/HoverAddStepButton'
+import OnlyContinueIf from '../Content/OnlyContinueIf'
 
 interface GroupStepWithAddButtonProps {
   step: IStep
@@ -15,6 +17,8 @@ interface GroupStepWithAddButtonProps {
   allowReorder?: boolean
   showEmptyAction?: boolean
   canChildStepsReorder?: boolean
+  /** Draw an only-continue-if step as a CONTINUE IF condition block. */
+  asConditionBlock?: boolean
 }
 
 export default function GroupStepWithAddButton(
@@ -28,19 +32,30 @@ export default function GroupStepWithAddButton(
     allowReorder,
     showEmptyAction,
     canChildStepsReorder,
+    asConditionBlock = false,
   } = props
   const { isDrawerOpen, readOnly } = useContext(EditorContext)
 
   return (
     <>
-      <FlowStep
-        step={step}
-        // branch steps are always nested
-        isNested={true}
-        isLastStep={isLastStep}
-        allowReorder={allowReorder}
-        canChildStepsReorder={canChildStepsReorder}
-      />
+      {asConditionBlock && isOnlyContinueIfStep(step) ? (
+        <OnlyContinueIf
+          step={step}
+          isLastStep={isLastStep}
+          isNested={true}
+          allowReorder={allowReorder}
+          canChildStepsReorder={canChildStepsReorder}
+        />
+      ) : (
+        <FlowStep
+          step={step}
+          // branch steps are always nested
+          isNested={true}
+          isLastStep={isLastStep}
+          allowReorder={allowReorder}
+          canChildStepsReorder={canChildStepsReorder}
+        />
+      )}
       {!isOverlay && (
         <HoverAddStepButton
           isDisabled={readOnly || !canAddStep}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/buildConditionSentence.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildConditionSentence } from '../buildConditionSentence'
+import type { ConditionPreviewPart } from '../getConditionBlockPreview'
+import { MAX_CONDITION_LABEL_LENGTH } from '../truncateConditionLabel'
+
+const LONG = 'A'.repeat(MAX_CONDITION_LABEL_LENGTH + 10)
+
+const leadingVar = (id: string, label: string): ConditionPreviewPart => ({
+  type: 'variable',
+  id,
+  label,
+  position: 'leading',
+})
+
+const trailingVar = (id: string, label: string): ConditionPreviewPart => ({
+  type: 'variable',
+  id,
+  label,
+  position: 'trailing',
+})
+
+const never = () => undefined
+
+describe('buildConditionSentence', () => {
+  it('resolves a variable to its real label, not its path segment', () => {
+    const resolve = vi.fn().mockReturnValue('2. What is your full name?')
+
+    const { parts } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.fields.6483.answer', 'answer')],
+      resolve,
+    )
+
+    expect(resolve).toHaveBeenCalledWith('step.abc.fields.6483.answer')
+    // The resolved label is what gets cut, not the "answer" path segment.
+    expect(parts[0].display.startsWith('2. What is your')).toBe(true)
+  })
+
+  it('falls back to the path segment when nothing resolves', () => {
+    const { parts } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.row.a3f1', 'a3f1')],
+      never,
+    )
+
+    expect(parts[0].display).toBe('a3f1')
+  })
+
+  it('caps a leading part and reports it', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.x', LONG)],
+      never,
+    )
+
+    expect(isLeadingTruncated).toBe(true)
+    expect(parts[0].display).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(parts[0].display.endsWith('…')).toBe(true)
+  })
+
+  it('lets a trailing part run on, so layout can clip it', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'IF',
+      [trailingVar('step.abc.x', LONG)],
+      never,
+    )
+
+    expect(parts[0].display).toBe(LONG)
+    expect(isLeadingTruncated).toBe(false)
+  })
+
+  it('caps a typed leading value but not a typed trailing one', () => {
+    const { parts } = buildConditionSentence(
+      'IF',
+      [
+        { type: 'literal', text: LONG, position: 'leading' },
+        { type: 'literal', text: LONG, position: 'trailing' },
+      ],
+      never,
+    )
+
+    expect(parts[0].display).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(parts[1].display).toBe(LONG)
+  })
+
+  it('never truncates connectives or the emphasised keyword', () => {
+    const { parts, isLeadingTruncated } = buildConditionSentence(
+      'REPEAT',
+      [
+        { type: 'text', text: LONG },
+        { type: 'emphasis', text: LONG },
+      ],
+      never,
+    )
+
+    expect(parts[0].display).toBe(LONG)
+    expect(parts[1].display).toBe(LONG)
+    expect(isLeadingTruncated).toBe(false)
+  })
+
+  it('builds the tooltip sentence from untruncated text, badge first', () => {
+    const { fullSentence } = buildConditionSentence(
+      'IF',
+      [
+        leadingVar('step.abc.x', LONG),
+        { type: 'text', text: ' is equal to ' },
+        { type: 'literal', text: 'Yes', position: 'trailing' },
+      ],
+      never,
+    )
+
+    expect(fullSentence).toBe(`IF ${LONG} is equal to Yes`)
+  })
+
+  it('uses the resolved label in the tooltip too', () => {
+    const { fullSentence } = buildConditionSentence(
+      'IF',
+      [leadingVar('step.abc.row.a3f1', 'a3f1')],
+      () => 'Status',
+    )
+
+    expect(fullSentence).toBe('IF Status')
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
@@ -250,7 +250,7 @@ describe('getConditionBlockPreviewParts', () => {
     ).toBe('42 is equal to true')
   })
 
-  it('previews the first non-empty row, skipping blank rows and groups', () => {
+  it('previews the only non-empty row, skipping blank rows and groups', () => {
     expect(
       asText(
         getConditionBlockPreviewParts(
@@ -259,12 +259,63 @@ describe('getConditionBlockPreviewParts', () => {
             [
               { field: '', condition: '', text: '' },
               { field: variable('Second'), condition: 'equals', text: 'yes' },
-              { field: variable('Third'), condition: 'equals', text: 'no' },
             ],
           ]),
         ),
       ),
     ).toBe('Second is equal to yes')
+  })
+
+  it('labels two filled rows in one group as multiple conditions', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [
+            { field: variable('First'), condition: 'equals', text: 'yes' },
+            { field: variable('Second'), condition: 'equals', text: 'no' },
+          ],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
+  })
+
+  it('labels one filled row per group as multiple conditions', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [{ field: variable('First'), condition: 'equals', text: 'yes' }],
+          [{ field: variable('Second'), condition: 'equals', text: 'no' }],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
+  })
+
+  it('keeps the sentence when the second row is still blank', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              { field: variable('First'), condition: 'equals', text: 'yes' },
+              { field: '', condition: '', text: '' },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('First is equal to yes')
+  })
+
+  it('counts a half-filled second row as another condition', () => {
+    expect(
+      getConditionBlockPreviewParts(
+        conditions([
+          [
+            { field: variable('First'), condition: 'equals', text: 'yes' },
+            { field: variable('Second'), condition: '', text: '' },
+          ],
+        ]),
+      ),
+    ).toEqual([{ type: 'text', text: 'Multiple conditions' }])
   })
 
   it('tolerates a group with no rows array', () => {

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/getConditionBlockPreview.test.ts
@@ -1,0 +1,432 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  type ConditionPreviewPart,
+  getConditionBlockPreviewParts,
+  getForEachBlockPreviewParts,
+} from '../getConditionBlockPreview'
+
+const STEP_ID = '0191b4ee-1a2b-4c3d-8e9f-a1b2c3d4e5f6'
+const OTHER_STEP_ID = '0191b4ee-1a2b-4c3d-8e9f-000000000000'
+
+const variable = (path: string) => `{{step.${STEP_ID}.${path}}}`
+
+const conditions = (rows: Array<Record<string, unknown>>[]): IJSONObject =>
+  ({
+    conditions: rows.map((groupRows) => ({ rows: groupRows })),
+  } as unknown as IJSONObject)
+
+const asText = (parts: ConditionPreviewPart[]): string =>
+  parts
+    .map((part) => (part.type === 'variable' ? part.label : part.text))
+    .join('')
+
+const typesOf = (parts: ConditionPreviewPart[]): string[] =>
+  parts.map((part) => part.type)
+
+describe('getConditionBlockPreviewParts', () => {
+  it('falls back to a prompt when there are no conditions', () => {
+    expect(getConditionBlockPreviewParts(undefined)).toEqual([
+      { type: 'text', text: 'Specify condition' },
+    ])
+    expect(getConditionBlockPreviewParts({} as IJSONObject)).toEqual([
+      { type: 'text', text: 'Specify condition' },
+    ])
+    expect(
+      getConditionBlockPreviewParts({
+        conditions: [],
+      } as unknown as IJSONObject),
+    ).toEqual([{ type: 'text', text: 'Specify condition' }])
+  })
+
+  it('falls back to a prompt when every row is still blank', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: '', condition: '', text: '' }]]),
+        ),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('maps an operator key to its plain-language phrase', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Age'), condition: 'gte', text: '21' }],
+          ]),
+        ),
+      ),
+    ).toBe('Age is greater than or equal to 21')
+  })
+
+  it('renders "is not" for a negated row', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Status'),
+                is: 'not',
+                condition: 'equals',
+                text: 'Rejected',
+              },
+            ],
+          ]),
+        ),
+      ).trim(),
+    ).toBe('Status is not equal to Rejected')
+  })
+
+  it('omits the comparison value for the empty operator', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Email'), condition: 'empty', text: 'ignored' }],
+          ]),
+        ),
+      ).trim(),
+    ).toBe('Email is empty')
+  })
+
+  it('negates each operator with its own verb phrase, not a blanket "is not"', () => {
+    const preview = (condition: string, negated: boolean) =>
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Subject'),
+                is: negated ? 'not' : 'and',
+                condition,
+                text: 'x',
+              },
+            ],
+          ]),
+        ),
+      )
+
+    expect(preview('contains', false)).toBe('Subject contains x')
+    expect(preview('contains', true)).toBe('Subject does not contain x')
+    expect(preview('begins', false)).toBe('Subject begins with x')
+    expect(preview('begins', true)).toBe('Subject does not begin with x')
+    expect(preview('equals', true)).toBe('Subject is not equal to x')
+    expect(preview('after', true)).toBe('Subject is not after x')
+  })
+
+  it('falls back to the raw operator key when it has no phrase', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: variable('Score'), condition: 'weird', text: '3' }],
+          ]),
+        ),
+      ),
+    ).toBe('Score is weird 3')
+
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [
+              {
+                field: variable('Score'),
+                is: 'not',
+                condition: 'weird',
+                text: '3',
+              },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('Score is not weird 3')
+  })
+
+  it('splits a step variable out as its own part, labelled by last segment', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Responses.Email address'),
+            condition: 'equals',
+            text: 'a@b.gov.sg',
+          },
+        ],
+      ]),
+    )
+
+    expect(parts[0]).toEqual({
+      type: 'variable',
+      id: `step.${STEP_ID}.Responses.Email address`,
+      label: 'Email address',
+      position: 'leading',
+    })
+  })
+
+  it('drops a variable pipe modifier from the lookup id', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: `{{step.${STEP_ID}.Amount|currency}}`,
+            condition: 'gt',
+            text: '0',
+          },
+        ],
+      ]),
+    )
+
+    expect(parts[0]).toEqual({
+      type: 'variable',
+      id: `step.${STEP_ID}.Amount`,
+      label: 'Amount',
+      position: 'leading',
+    })
+  })
+
+  it('keeps literal text around a variable', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Name'),
+            condition: 'contains',
+            text: `Hi ${variable('Nickname')} !`,
+          },
+        ],
+      ]),
+    )
+
+    expect(asText(parts)).toBe('Name contains Hi Nickname !')
+    expect(parts.filter((part) => part.type === 'variable')).toHaveLength(2)
+  })
+
+  it('handles several variables in one value', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: `{{step.${STEP_ID}.First}} {{step.${OTHER_STEP_ID}.Last}}`,
+            condition: 'equals',
+            text: 'x',
+          },
+        ],
+      ]),
+    )
+
+    expect(
+      parts
+        .filter(
+          (part): part is Extract<ConditionPreviewPart, { type: 'variable' }> =>
+            part.type === 'variable',
+        )
+        .map((part) => part.label),
+    ).toEqual(['First', 'Last'])
+  })
+
+  it('treats a plain (non-variable) value as text', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: 'Age', condition: 'lt', text: '18' }]]),
+        ),
+      ),
+    ).toBe('Age is less than 18')
+  })
+
+  it('stringifies numeric and boolean parameter values', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: 42, condition: 'equals', text: true }]]),
+        ),
+      ),
+    ).toBe('42 is equal to true')
+  })
+
+  it('previews the first non-empty row, skipping blank rows and groups', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([
+            [{ field: '', condition: '', text: '' }],
+            [
+              { field: '', condition: '', text: '' },
+              { field: variable('Second'), condition: 'equals', text: 'yes' },
+              { field: variable('Third'), condition: 'equals', text: 'no' },
+            ],
+          ]),
+        ),
+      ),
+    ).toBe('Second is equal to yes')
+  })
+
+  it('tolerates a group with no rows array', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts({
+          conditions: [{}],
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('tolerates conditions that are not an array', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts({
+          conditions: 'nonsense',
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('Specify condition')
+  })
+
+  it('drops a field that is neither text nor a number', () => {
+    expect(
+      asText(
+        getConditionBlockPreviewParts(
+          conditions([[{ field: { a: 1 }, condition: 'equals', text: 'x' }]]),
+        ),
+      ),
+    ).toBe('is equal to x')
+  })
+
+  it('marks typed values as literals and the operator as a connective', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Amount'),
+            condition: 'gte',
+            text: 'Finance & Corporate Services Division',
+          },
+        ],
+      ]),
+    )
+
+    expect(typesOf(parts)).toEqual(['variable', 'text', 'text', 'literal'])
+    // The header leaves a `text` part intact and may truncate a `literal`.
+    expect(parts.find((part) => part.type === 'text')).toEqual({
+      type: 'text',
+      text: ' is greater than or equal to',
+    })
+  })
+
+  it('keeps literal runs around a variable as literals', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: 'Name',
+            condition: 'contains',
+            text: `Hi ${variable('Nickname')} !`,
+          },
+        ],
+      ]),
+    )
+
+    expect(typesOf(parts)).toEqual([
+      'literal',
+      'text',
+      'text',
+      'literal',
+      'variable',
+      'literal',
+    ])
+  })
+
+  it('marks the placeholder as a connective so it is never truncated', () => {
+    expect(typesOf(getConditionBlockPreviewParts(undefined))).toEqual(['text'])
+  })
+
+  it('marks where in the sentence each part sits', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([
+        [
+          {
+            field: variable('Name'),
+            condition: 'equals',
+            text: `Hi ${variable('Nickname')}`,
+          },
+        ],
+      ]),
+    )
+
+    const positions = parts
+      .filter(
+        (
+          part,
+        ): part is Extract<
+          ConditionPreviewPart,
+          { type: 'variable' | 'literal' }
+        > => part.type === 'variable' || part.type === 'literal',
+      )
+      .map((part) => part.position)
+
+    // field, then the value's literal prefix and its variable
+    expect(positions).toEqual(['leading', 'trailing', 'trailing'])
+  })
+
+  it('marks a typed field leading and a typed value trailing', () => {
+    const parts = getConditionBlockPreviewParts(
+      conditions([[{ field: 'Age', condition: 'lt', text: '18' }]]),
+    )
+
+    expect(parts).toEqual([
+      { type: 'literal', text: 'Age', position: 'leading' },
+      { type: 'text', text: ' is less than' },
+      { type: 'text', text: ' ' },
+      { type: 'literal', text: '18', position: 'trailing' },
+    ])
+  })
+})
+
+describe('getForEachBlockPreviewParts', () => {
+  it('falls back to a prompt when no list is set', () => {
+    const prompt = [{ type: 'text', text: 'Specify list' }]
+
+    expect(getForEachBlockPreviewParts(undefined)).toEqual(prompt)
+    expect(getForEachBlockPreviewParts({} as IJSONObject)).toEqual(prompt)
+    expect(
+      getForEachBlockPreviewParts({ items: '   ' } as unknown as IJSONObject),
+    ).toEqual(prompt)
+    expect(
+      getForEachBlockPreviewParts({ items: 12 } as unknown as IJSONObject),
+    ).toEqual(prompt)
+  })
+
+  it('reads as a sentence with "item" and the list name emphasised', () => {
+    const parts = getForEachBlockPreviewParts({
+      items: variable('Rows'),
+    } as unknown as IJSONObject)
+
+    expect(asText(parts)).toBe('For every item in Rows')
+    expect(parts).toEqual([
+      { type: 'text', text: 'For every ' },
+      { type: 'emphasis', text: 'item' },
+      { type: 'text', text: ' in ' },
+      {
+        type: 'variable',
+        id: `step.${STEP_ID}.Rows`,
+        label: 'Rows',
+        position: 'trailing',
+      },
+    ])
+  })
+
+  it('accepts a plain list name', () => {
+    expect(
+      asText(
+        getForEachBlockPreviewParts({
+          items: 'my rows',
+        } as unknown as IJSONObject),
+      ),
+    ).toBe('For every item in my rows')
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/__tests__/truncateConditionLabel.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_CONDITION_LABEL_LENGTH,
+  truncateConditionLabel,
+} from '../truncateConditionLabel'
+
+describe('truncateConditionLabel', () => {
+  it('leaves a label that already fits untouched', () => {
+    expect(truncateConditionLabel('Application status')).toBe(
+      'Application status',
+    )
+    expect(truncateConditionLabel('')).toBe('')
+  })
+
+  it('keeps a label of exactly the budget intact', () => {
+    const exact = 'FormSG Payments - Amount'
+    expect(exact).toHaveLength(MAX_CONDITION_LABEL_LENGTH)
+    expect(truncateConditionLabel(exact)).toBe(exact)
+  })
+
+  it('cuts one character short to make room for the ellipsis', () => {
+    expect(truncateConditionLabel('2. What is your full name?')).toBe(
+      '2. What is your full na…',
+    )
+    expect(truncateConditionLabel('2. What is your full name?')).toHaveLength(
+      MAX_CONDITION_LABEL_LENGTH,
+    )
+  })
+
+  it('drops a trailing separator so the ellipsis does not dangle', () => {
+    // FormSG table cell: the cut lands right after " - ".
+    expect(
+      truncateConditionLabel('2. Row 1 Postal Code - Delivery addresses'),
+    ).toBe('2. Row 1 Postal Code…')
+  })
+
+  it('drops a trailing space', () => {
+    // The cut lands on the space before "(before tax)".
+    expect(truncateConditionLabel('Household income range (before tax)')).toBe(
+      'Household income range…',
+    )
+  })
+
+  it('drops a trailing opening bracket', () => {
+    const label = `${'A'.repeat(22)}(before tax)`
+    expect(truncateConditionLabel(label)).toBe(`${'A'.repeat(22)}…`)
+  })
+
+  it('leaves interior whitespace alone', () => {
+    // The label is otherwise rendered as the form author wrote it.
+    expect(truncateConditionLabel('Finance & Corporate  Services')).toBe(
+      'Finance & Corporate  Se…',
+    )
+  })
+
+  it('cuts a label whose tail is all separators back to the ellipsis', () => {
+    expect(truncateConditionLabel(`${'-'.repeat(30)}`)).toBe('…')
+  })
+
+  it('still truncates a long label with no separator to trim', () => {
+    expect(truncateConditionLabel('a3f1c2e8-4b7d-4e91-9f2c-1d8e5a7b3c04')).toBe(
+      'a3f1c2e8-4b7d-4e91-9f2c…',
+    )
+    expect(truncateConditionLabel('data.results.0.customer.email')).toBe(
+      'data.results.0.customer…',
+    )
+  })
+})

--- a/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/buildConditionSentence.ts
@@ -1,0 +1,59 @@
+import type { ConditionPreviewPart } from './getConditionBlockPreview'
+import { truncateConditionLabel } from './truncateConditionLabel'
+
+export type ConditionSentencePart = ConditionPreviewPart & { display: string }
+
+export interface ConditionSentence {
+  parts: ConditionSentencePart[]
+  fullSentence: string
+  /** Whether a leading part was shortened. Only layout cuts trailing parts. */
+  isLeadingTruncated: boolean
+}
+
+/** Resolves a variable's real label from its `{{step.<id>.<path>}}` id. */
+export type ResolveVariableLabel = (id: string) => string | undefined
+
+/**
+ * Turns preview parts into what the header renders.
+ *
+ * IMPORTANT: a variable part's `label` is only the last path segment, so the
+ * real label comes from `resolveVariableLabel`.
+ */
+export function buildConditionSentence(
+  badgeLabel: string,
+  previewParts: ConditionPreviewPart[],
+  resolveVariableLabel: ResolveVariableLabel,
+): ConditionSentence {
+  let isLeadingTruncated = false
+  const plain: string[] = []
+
+  const parts = previewParts.map((part): ConditionSentencePart => {
+    if (part.type === 'text' || part.type === 'emphasis') {
+      plain.push(part.text)
+      return { ...part, display: part.text }
+    }
+
+    const full =
+      part.type === 'variable'
+        ? resolveVariableLabel(part.id) ?? part.label
+        : part.text
+
+    plain.push(full)
+
+    if (part.position === 'trailing') {
+      return { ...part, display: full }
+    }
+
+    const display = truncateConditionLabel(full)
+    if (display !== full) {
+      isLeadingTruncated = true
+    }
+    return { ...part, display }
+  })
+
+  return {
+    parts,
+    fullSentence: `${badgeLabel} ${plain.join('').trim()}`,
+    isLeadingTruncated,
+  }
+}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
@@ -1,0 +1,233 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { z } from 'zod'
+
+/**
+ * Where a part sits in the sentence, which decides whether it may spill.
+ *
+ * IMPORTANT: only `leading` parts are length-capped, since the block's own
+ * width clips a `trailing` part.
+ */
+export type ConditionSentencePosition = 'leading' | 'trailing'
+
+export type ConditionPreviewPart =
+  /** Sentence connective, never cut, since a clipped operator loses meaning. */
+  | { type: 'text'; text: string }
+  | { type: 'literal'; text: string; position: ConditionSentencePosition }
+  | {
+      type: 'variable'
+      id: string
+      label: string
+      position: ConditionSentencePosition
+    }
+  | { type: 'emphasis'; text: string }
+
+const EMPTY_CONDITION_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Specify condition' },
+]
+
+const EMPTY_FOR_EACH_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Specify list' },
+]
+
+// Not `GLOBAL_VARIABLE_REGEX` from RichTextEditor/utils.ts, which captures the
+// whole match rather than the path segment.
+const STEP_VARIABLE_GLOBAL_REGEX =
+  /\{\{step\.[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\.([^}|]+)(?:\|[^}]+)?\}\}/gi
+
+/**
+ * Lenient read of the parameters a half-configured step holds.
+ *
+ * IMPORTANT: every field falls back instead of throwing, so a malformed
+ * parameter previews as the placeholder rather than breaking the editor.
+ */
+const previewTextSchema = z
+  .union([z.string(), z.number(), z.boolean()])
+  .transform(String)
+  .catch('')
+
+const conditionRowSchema = z.object({
+  field: previewTextSchema,
+  is: previewTextSchema,
+  condition: previewTextSchema,
+  text: previewTextSchema,
+})
+
+const conditionGroupsSchema = z
+  .array(
+    z
+      .object({ rows: z.array(conditionRowSchema).catch([]) })
+      .catch({ rows: [] }),
+  )
+  .catch([])
+
+const forEachItemsSchema = z.string().catch('')
+
+type ConditionRowPreview = z.infer<typeof conditionRowSchema>
+
+/**
+ * The verb phrase for each condition operator, re-spelling the option labels in
+ * the backend's `get-condition-args.ts`, which the header cannot read.
+ *
+ * IMPORTANT: both polarities are spelled out, since "contains" negates to
+ * "does not contain", not "is not contains".
+ */
+const OPERATOR_PHRASES: Record<
+  string,
+  { affirmative: string; negative: string }
+> = {
+  equals: { affirmative: 'is equal to', negative: 'is not equal to' },
+  empty: { affirmative: 'is empty', negative: 'is not empty' },
+  contains: { affirmative: 'contains', negative: 'does not contain' },
+  begins: { affirmative: 'begins with', negative: 'does not begin with' },
+  gt: { affirmative: 'is greater than', negative: 'is not greater than' },
+  gte: {
+    affirmative: 'is greater than or equal to',
+    negative: 'is not greater than or equal to',
+  },
+  lt: { affirmative: 'is less than', negative: 'is not less than' },
+  lte: {
+    affirmative: 'is less than or equal to',
+    negative: 'is not less than or equal to',
+  },
+  before: { affirmative: 'is before', negative: 'is not before' },
+  after: { affirmative: 'is after', negative: 'is not after' },
+}
+
+/**
+ * Structured preview of a toolbox condition step for the block header.
+ * Variables are separate parts so the header can bold / truncate them.
+ */
+export function getConditionBlockPreviewParts(
+  parameters: IJSONObject | undefined,
+): ConditionPreviewPart[] {
+  const groups = conditionGroupsSchema.parse(parameters?.conditions)
+
+  for (const group of groups) {
+    for (const row of group.rows) {
+      const parts = formatConditionRow(row)
+      if (parts.length > 0) {
+        return parts
+      }
+    }
+  }
+
+  return EMPTY_CONDITION_PREVIEW
+}
+
+export function getForEachBlockPreviewParts(
+  parameters: IJSONObject | undefined,
+): ConditionPreviewPart[] {
+  const items = forEachItemsSchema.parse(parameters?.items).trim()
+  if (items.length === 0) {
+    return EMPTY_FOR_EACH_PREVIEW
+  }
+
+  const itemParts = valueToParts(items, 'trailing')
+  if (itemParts.length === 0) {
+    return EMPTY_FOR_EACH_PREVIEW
+  }
+
+  // "item" is emphasised alongside the list name, though it is not a variable.
+  return [
+    { type: 'text', text: 'For every ' },
+    { type: 'emphasis', text: 'item' },
+    { type: 'text', text: ' in ' },
+    ...itemParts,
+  ]
+}
+
+function formatConditionRow(row: ConditionRowPreview): ConditionPreviewPart[] {
+  const fieldParts = valueToParts(row.field, 'leading')
+  const isNegated = row.is === 'not'
+  const operatorKey = row.condition
+  const operatorPhrase = getOperatorPhrase(operatorKey, isNegated)
+  // "empty" is the one operator with nothing to compare against, so any value
+  // left over in the row from a previous operator choice is not shown.
+  const valueParts =
+    operatorKey === 'empty' ? [] : valueToParts(row.text, 'trailing')
+
+  if (fieldParts.length === 0 && !operatorPhrase && valueParts.length === 0) {
+    return []
+  }
+
+  const parts: ConditionPreviewPart[] = [...fieldParts]
+
+  if (operatorPhrase) {
+    parts.push({
+      type: 'text',
+      text: fieldParts.length > 0 ? ` ${operatorPhrase}` : operatorPhrase,
+    })
+  }
+
+  if (valueParts.length > 0) {
+    if (operatorPhrase || fieldParts.length > 0) {
+      parts.push({ type: 'text', text: ' ' })
+    }
+    parts.push(...valueParts)
+  }
+
+  return parts
+}
+
+/** Splits user-typed parameter text into `literal` and `variable` parts. */
+function valueToParts(
+  raw: string,
+  position: ConditionSentencePosition,
+): ConditionPreviewPart[] {
+  if (!raw) {
+    return []
+  }
+
+  const parts: ConditionPreviewPart[] = []
+  let lastIndex = 0
+
+  for (const match of raw.matchAll(STEP_VARIABLE_GLOBAL_REGEX)) {
+    const full = match[0]
+    const path = match[1]
+    const index = match.index ?? 0
+
+    if (index > lastIndex) {
+      parts.push({
+        type: 'literal',
+        text: raw.slice(lastIndex, index),
+        position,
+      })
+    }
+
+    const segments = path.split('.').filter(Boolean)
+    const label = segments[segments.length - 1] ?? path
+    // varInfoMap is keyed without the surrounding {{ }}.
+    const id = full.slice(2, -2).split('|')[0]
+
+    parts.push({ type: 'variable', id, label, position })
+    lastIndex = index + full.length
+  }
+
+  if (lastIndex < raw.length) {
+    parts.push({ type: 'literal', text: raw.slice(lastIndex), position })
+  }
+
+  if (parts.length === 0 && raw.trim()) {
+    parts.push({ type: 'literal', text: raw.trim(), position })
+  }
+
+  return parts
+}
+
+/**
+ * Spells an unmapped operator behind "is", so a new backend operator still
+ * previews instead of vanishing.
+ */
+function getOperatorPhrase(operatorKey: string, isNegated: boolean): string {
+  if (!operatorKey) {
+    return ''
+  }
+
+  const phrases = OPERATOR_PHRASES[operatorKey]
+  if (phrases) {
+    return isNegated ? phrases.negative : phrases.affirmative
+  }
+
+  return isNegated ? `is not ${operatorKey}` : `is ${operatorKey}`
+}

--- a/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/getConditionBlockPreview.ts
@@ -30,6 +30,10 @@ const EMPTY_FOR_EACH_PREVIEW: ConditionPreviewPart[] = [
   { type: 'text', text: 'Specify list' },
 ]
 
+const MULTIPLE_CONDITIONS_PREVIEW: ConditionPreviewPart[] = [
+  { type: 'text', text: 'Multiple conditions' },
+]
+
 // Not `GLOBAL_VARIABLE_REGEX` from RichTextEditor/utils.ts, which captures the
 // whole match rather than the path segment.
 const STEP_VARIABLE_GLOBAL_REGEX =
@@ -97,22 +101,32 @@ const OPERATOR_PHRASES: Record<
 /**
  * Structured preview of a toolbox condition step for the block header.
  * Variables are separate parts so the header can bold / truncate them.
+ *
+ * IMPORTANT: one condition reads as a sentence, several collapse to a label,
+ * since a sentence describing only the first would misstate the step.
  */
 export function getConditionBlockPreviewParts(
   parameters: IJSONObject | undefined,
 ): ConditionPreviewPart[] {
   const groups = conditionGroupsSchema.parse(parameters?.conditions)
+  let firstRowParts: ConditionPreviewPart[] | undefined
 
   for (const group of groups) {
     for (const row of group.rows) {
       const parts = formatConditionRow(row)
-      if (parts.length > 0) {
-        return parts
+      if (parts.length === 0) {
+        continue
       }
+
+      if (firstRowParts) {
+        return MULTIPLE_CONDITIONS_PREVIEW
+      }
+
+      firstRowParts = parts
     }
   }
 
-  return EMPTY_CONDITION_PREVIEW
+  return firstRowParts ?? EMPTY_CONDITION_PREVIEW
 }
 
 export function getForEachBlockPreviewParts(

--- a/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
+++ b/packages/frontend/src/components/FlowStepGroup/helpers/truncateConditionLabel.ts
@@ -1,0 +1,27 @@
+/**
+ * Character budget for the field half of a condition sentence, so the operator
+ * and the value stay visible.
+ *
+ * IMPORTANT: a `ch` max-width would measure the "0" glyph, which buys
+ * unpredictable amounts of proportional text.
+ */
+export const MAX_CONDITION_LABEL_LENGTH = 24
+
+/**
+ * Trailing characters worth dropping before the ellipsis, so a cut FormSG
+ * label does not read "2. Row 1 Postal Code - …".
+ */
+const TRAILING_SEPARATORS = /[\s\-–—,.:;/(&]+$/
+
+/** Shortens one part of the sentence to the shared budget. */
+export function truncateConditionLabel(label: string): string {
+  if (label.length <= MAX_CONDITION_LABEL_LENGTH) {
+    return label
+  }
+
+  const cut = label
+    .slice(0, MAX_CONDITION_LABEL_LENGTH - 1)
+    .replace(TRAILING_SEPARATORS, '')
+
+  return `${cut}…`
+}

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -9,12 +9,14 @@ import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/S
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth, getToolboxIcon } from '@/helpers/editor'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenV2Enabled } from '@/hooks/useIfThenV2Enabled'
 
 import { MIN_FLOW_STEP_WIDTH } from '../Editor/constants'
 
 import DeleteConfirmationDialog from './components/DeleteConfirmationDialog'
 import Error from './Content/Error'
 import ForEach from './Content/ForEach'
+import ForEachV1 from './Content/ForEach/ForEachV1'
 import IfThenV1 from './Content/IfThen/IfThenV1'
 import useDeleteStepConfirmation from './hooks/useDeleteStepConfirmation'
 import { flowStepGroupStyles } from './styles'
@@ -28,6 +30,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
   const { groupedSteps, stepsBeforeGroup } = props
   const { isDrawerOpen, isMobile, onDrawerClose, readOnly } =
     useContext(EditorContext)
+  const { isEnabled: isIfThenV2Enabled } = useIfThenV2Enabled()
 
   const { stepGroupType, stepGroupCaption } = useMemo(() => {
     let stepGroupType: string | null = null
@@ -71,22 +74,48 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
     (step) => step.key === TOOLBOX_ACTIONS.ForEach,
   )
 
+  const outerWidth =
+    isInsideForEach && stepsBeforeGroup.length > 2 && !isDrawerOpen
+      ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
+      : '100%'
+
+  const widthSlot = {
+    display: isMobile ? 'block' : 'flex',
+    w: getFlowStepHeaderWidth(isDrawerOpen, isMobile),
+    minW: MIN_FLOW_STEP_WIDTH,
+  }
+
+  /**
+   * A for-each V2 draws its own REPEAT-badge card and delete button, so it
+   * takes a bare width slot instead of the chrome below.
+   *
+   * IMPORTANT: that chrome, `ForEachV1` and this fork all go once the flag
+   * retires.
+   */
+  if (stepGroupType === TOOLBOX_ACTIONS.ForEach && isIfThenV2Enabled) {
+    return (
+      <Flex
+        w={outerWidth}
+        alignItems="center"
+        justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
+      >
+        <Flex {...widthSlot}>
+          <ForEach
+            groupedSteps={groupedSteps}
+            stepsBeforeGroup={stepsBeforeGroup}
+          />
+        </Flex>
+      </Flex>
+    )
+  }
+
   return (
     <Flex
-      w={
-        isInsideForEach && stepsBeforeGroup.length > 2 && !isDrawerOpen
-          ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
-          : '100%'
-      }
+      w={outerWidth}
       alignItems="center"
       justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
     >
-      <Flex
-        {...flowStepGroupStyles.container}
-        display={isMobile ? 'block' : 'flex'}
-        w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
-        minW={MIN_FLOW_STEP_WIDTH}
-      >
+      <Flex {...flowStepGroupStyles.container} {...widthSlot}>
         <Box {...flowStepGroupStyles.header} w="100%">
           <Flex
             px={4}
@@ -134,7 +163,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
           />
         ) : stepGroupType === TOOLBOX_ACTIONS.ForEach ? (
           <>
-            <ForEach
+            <ForEachV1
               groupedSteps={groupedSteps}
               stepsBeforeGroup={stepsBeforeGroup}
             />


### PR DESCRIPTION
TSIA, see PRs in commits for more context.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62429172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking editor UX regression affecting insertion at the beginning of populated condition blocks.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FFlowStepGroup%2FContent%2FIfThen%2FIfThen.tsx%3A311-312%0APopulated%20IF%20blocks%20now%20show%20add%20controls%20only%20after%20existing%20children.%20The%20same%20limitation%20affects%20populated%20REPEAT%20blocks%20in%20%60Content%2FForEach%2Findex.tsx%60.%20The%20removed%20leading%20control%20was%20the%20only%20direct%20way%20to%20insert%20a%20new%20first%20child%20after%20the%20condition%2C%20so%20users%20must%20add%20the%20step%20elsewhere%20and%20reorder%20it.%20Restore%20an%20inside-block%20add%20control%20before%20the%20first%20child.%0A%0AGreptile%20automatically%20discovered%20a%20related%20ticket%20stating%20that%20child%20steps%20should%20use%20the%20same%20step-adding%20flow%2C%20which%20informed%20this%20comment.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**First\-child insertion is missing** <a href="https://github.com/opengovsg/plumber/pull/2186#discussion_r3975067734">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/frontend/src/components/FlowStepGroup/Content/IfThen/IfThen.tsx:311-312
Populated IF blocks now show add controls only after existing children. The same limitation affects populated REPEAT blocks in `Content/ForEach/index.tsx`. The removed leading control was the only direct way to insert a new first child after the condition, so users must add the step elsewhere and reorder it. Restore an inside-block add control before the first child.

Greptile automatically discovered a related ticket stating that child steps should use the same step-adding flow, which informed this comment.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds IF, CONTINUE IF, and REPEAT block presentations with inline condition summaries.
- Updates action selectability and grouped-step rendering for the V2 model.
- Adds tests for condition preview formatting, label truncation, and app selectability.
- Leaves populated blocks without direct insertion before their first child.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  T[Trigger] --> A[Top-level action]
  A --> IF{IF condition}
  IF -->|true| C1[First child]
  C1 --> C2[Later child]
  IF -->|false| N[Next top-level step]
  C2 --> N
  N --> R{REPEAT list}
  R --> RC[Loop children]
  RC --> E[Continue flow]
```
</details>

<sub>Reviews (1) · Last reviewed commit: [a8a657c](https://github.com/opengovsg/plumber/commit/a8a657c9ac39383fc0a5ed4f32fa73ab3fe88d06)</sub>

<!-- /greptile_comment -->