### PR TITLE
fix(ai-builder): route embedded confetti survey through proxy domain

### DIFF
--- a/packages/frontend/src/components/ConfettiEmbeddedSurvey.tsx
+++ b/packages/frontend/src/components/ConfettiEmbeddedSurvey.tsx
@@ -22,6 +22,7 @@ export interface ConfettiEmbeddedSurveyRef {
 interface ConfettiEmbeddedSurveyProps {
   surveyId: string
   publishableKey: string
+  apiBaseUrl?: string
   respondent?: string
   metadata?: Record<string, string>
 }
@@ -38,7 +39,7 @@ function NotifyLoaded({ onLoaded }: { onLoaded: () => void }) {
 const ConfettiEmbeddedSurvey = forwardRef<
   ConfettiEmbeddedSurveyRef,
   ConfettiEmbeddedSurveyProps
->(({ surveyId, publishableKey, respondent, metadata }, ref) => {
+>(({ surveyId, publishableKey, apiBaseUrl, respondent, metadata }, ref) => {
   const submitRef = useRef<() => void>()
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -58,6 +59,7 @@ const ConfettiEmbeddedSurvey = forwardRef<
         <ConfettiProvider
           surveyId={surveyId}
           publishableKey={publishableKey}
+          apiBaseUrl={apiBaseUrl}
           respondent={respondent}
           metadata={metadata}
         >

--- a/packages/frontend/src/components/EditorLayout/ConfettiSurvey.tsx
+++ b/packages/frontend/src/components/EditorLayout/ConfettiSurvey.tsx
@@ -33,7 +33,7 @@ export function ConfettiSurvey() {
   return (
     <div className="confetti-survey">
       <PopoverConfetti
-        apiBaseUrl="https://confetti.plumber.gov.sg"
+        apiBaseUrl={appConfig.confettiApiBaseUrl}
         surveyId={appConfig.confettiSurveyId}
         publishableKey={appConfig.confettiSurveyPublishableKey}
         respondent={`${userEmail}-${flowId}`} // key to maintain the state

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -9,6 +9,7 @@ interface AppConfig {
   confettiSurveyPublishableKey: string
   confettiSurveyId: string
   confettiAiBuilderSurveyId: string
+  confettiApiBaseUrl: string
 }
 
 function getAppConfig(): AppConfig {
@@ -18,10 +19,14 @@ function getAppConfig(): AppConfig {
   const version = import.meta.env.PACKAGE_VERSION
   const confettiSurveyPublishableKey =
     'cfti_pk_dfde134552a318551e05559024f432ba'
+  // Routed through our own domain, since CSP only allows connecting to
+  // plumber.gov.sg domains directly (see packages/backend/src/helpers/csp.ts).
+  const confettiApiBaseUrl = 'https://confetti.plumber.gov.sg'
   const commonEnv = {
     env,
     version,
     confettiSurveyPublishableKey,
+    confettiApiBaseUrl,
   }
 
   switch (env) {

--- a/packages/frontend/src/pages/AiBuilder/components/ExitAlert.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ExitAlert.tsx
@@ -81,6 +81,7 @@ export default function ExitAlert({
               ref={confettiRef}
               surveyId={appConfig.confettiAiBuilderSurveyId}
               publishableKey={appConfig.confettiSurveyPublishableKey}
+              apiBaseUrl={appConfig.confettiApiBaseUrl}
               respondent={`${userEmail}-${chatId}`}
             />
           </AlertDialogBody>


### PR DESCRIPTION
## TL;DR

The embedded confetti survey (AI Builder exit survey) does not work on our deployments without going through our proxy domain.

## What changed?

- Added `confettiApiBaseUrl` to frontend `appConfig`, pointing at `https://confetti.plumber.gov.sg`.
- `ConfettiSurvey.tsx` (popover) now reads this from config instead of a hardcoded string.
- `ConfettiEmbeddedSurvey.tsx` now accepts an `apiBaseUrl` prop and passes it to `ConfettiProvider`.
- `ExitAlert.tsx` (AI Builder exit survey) now passes `appConfig.confettiApiBaseUrl` into `ConfettiEmbeddedSurvey`.

## Why?

`ConfettiEmbeddedSurvey` never passed `apiBaseUrl` to `ConfettiProvider`, so it fell back to the SDK's default API host. Our CSP only allows `connect-src` to `confetti.plumber.gov.sg` (see `packages/backend/src/helpers/csp.ts`), so on deployed environments the survey's network calls were blocked and it silently failed to load. The popover survey already worked around this with a hardcoded URL; this PR extracts that into shared config and threads it through the embedded survey too.

## Tests

- [ ] Open the AI Builder exit dialog on a deployed environment (dev/staging) and confirm the embedded survey loads and submits.
- [ ] Confirm the editor popover survey still loads as before.

## Deploy notes

None.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62466280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the proxy configuration consistently propagated and no actionable regressions identified.

<details><summary><h3>Summary</h3></summary>

- Adds `confettiApiBaseUrl` to shared frontend configuration.
- Passes the configured endpoint through `ConfettiEmbeddedSurvey` to `ConfettiProvider`.
- Reuses the same configuration for the existing editor popover survey.
- Aligns survey requests with the proxy host already allowed by the application CSP.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[appConfig.confettiApiBaseUrl] --> Exit[AI Builder ExitAlert]
  Config --> Popover[Editor popover survey]
  Exit --> Embedded[ConfettiEmbeddedSurvey]
  Embedded --> Provider[ConfettiProvider]
  Popover --> Proxy[confetti.plumber.gov.sg]
  Provider --> Proxy
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(ai-builder): route embedded confetti..."](https://github.com/opengovsg/plumber/commit/1869b6a0511f7c7f3040c833b0cee037a288b051)</sub>

<!-- /greptile_comment -->