### PR TITLE
PLU-927: Fall back to Redis/static prompts when Rome is down

### DIFF
--- a/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
+++ b/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  promptGet: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock('@/helpers/langfuse', () => ({
+  getLangfuseClient: vi.fn(() => ({
+    prompt: {
+      get: mocks.promptGet,
+    },
+  })),
+}))
+
+vi.mock('@/helpers/redis-app-data', () => ({
+  redisAppDataClient: {
+    get: mocks.redisGet,
+    set: mocks.redisSet,
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+  },
+}))
+
+import { FALLBACK_CHAT_PROMPT } from '@/helpers/ai/fallback-prompts/chat'
+import { getPrompt } from '@/helpers/ai/get-prompt'
+import {
+  makePromptCacheKey,
+  PROMPT_CACHE_TTL_SECONDS,
+} from '@/helpers/ai/get-prompt-cache'
+
+describe('getPrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the Langfuse prompt and writes it to Redis on success', async () => {
+    const livePrompt = {
+      prompt: 'live system prompt',
+      toJSON: () => '{"name":"chat"}',
+    }
+    mocks.promptGet.mockResolvedValueOnce(livePrompt)
+    mocks.redisSet.mockResolvedValueOnce('OK')
+
+    const result = await getPrompt('chat', 'aiBuilder', 'production')
+
+    expect(result).toBe(livePrompt)
+    expect(mocks.promptGet).toHaveBeenCalledWith('chat', {
+      label: 'production',
+    })
+    expect(mocks.redisSet).toHaveBeenCalledWith(
+      makePromptCacheKey('aiBuilder', 'chat', 'production'),
+      expect.stringContaining('live system prompt'),
+      'EX',
+      PROMPT_CACHE_TTL_SECONDS,
+    )
+  })
+
+  it('still returns the live prompt when Redis write fails', async () => {
+    const livePrompt = {
+      prompt: 'live system prompt',
+      toJSON: () => '{"name":"chat"}',
+    }
+    mocks.promptGet.mockResolvedValueOnce(livePrompt)
+    mocks.redisSet.mockRejectedValueOnce(new Error('redis down'))
+
+    const result = await getPrompt('chat', 'aiBuilder', 'production')
+
+    expect(result).toBe(livePrompt)
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Failed to write Langfuse prompt cache',
+      expect.objectContaining({
+        event: 'langfuse-prompt-cache-write-error',
+      }),
+    )
+  })
+
+  it('returns the Redis-cached prompt when Langfuse fails', async () => {
+    mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
+    mocks.redisGet.mockResolvedValueOnce(
+      JSON.stringify({
+        promptText: 'cached system prompt',
+        cachedAt: '2026-09-11T00:00:00.000Z',
+      }),
+    )
+
+    const result = await getPrompt('chat', 'aiBuilder', 'production')
+
+    expect(result.prompt).toBe('cached system prompt')
+    expect(JSON.parse(result.toJSON())).toMatchObject({
+      name: 'chat',
+      source: 'redis',
+      isFallback: true,
+    })
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Using Redis-cached Langfuse prompt',
+      expect.objectContaining({ source: 'redis' }),
+    )
+  })
+
+  it('returns the static fallback when Langfuse and Redis both miss', async () => {
+    mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
+    mocks.redisGet.mockResolvedValueOnce(null)
+
+    const result = await getPrompt('chat', 'aiBuilder', 'production')
+
+    expect(result.prompt).toBe(FALLBACK_CHAT_PROMPT)
+    expect(JSON.parse(result.toJSON())).toMatchObject({
+      name: 'chat',
+      source: 'static',
+      isFallback: true,
+    })
+  })
+
+  it('rethrows when Langfuse fails and no Redis or static fallback exists', async () => {
+    const romeError = new Error('Rome unavailable')
+    mocks.promptGet.mockRejectedValueOnce(romeError)
+    mocks.redisGet.mockResolvedValueOnce(null)
+
+    await expect(
+      getPrompt('unknown-prompt', 'aiBuilder', 'production'),
+    ).rejects.toBe(romeError)
+  })
+
+  it('falls through to static when Redis read fails after Langfuse failure', async () => {
+    mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
+    mocks.redisGet.mockRejectedValueOnce(new Error('redis read failed'))
+
+    const result = await getPrompt('chat', 'aiBuilder', 'production')
+
+    expect(result.prompt).toBe(FALLBACK_CHAT_PROMPT)
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Failed to read Langfuse prompt cache',
+      expect.objectContaining({
+        event: 'langfuse-prompt-cache-read-error',
+      }),
+    )
+  })
+})

--- a/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
+++ b/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   promptGet: vi.fn(),
-  redisGet: vi.fn(),
-  redisSet: vi.fn(),
+  readCachedPrompt: vi.fn(),
+  writeCachedPrompt: vi.fn(),
   loggerInfo: vi.fn(),
   loggerWarn: vi.fn(),
   loggerError: vi.fn(),
@@ -17,11 +17,10 @@ vi.mock('@/helpers/langfuse', () => ({
   })),
 }))
 
-vi.mock('@/helpers/redis-app-data', () => ({
-  redisAppDataClient: {
-    get: mocks.redisGet,
-    set: mocks.redisSet,
-  },
+// Mock the cache module so these unit tests never open a Redis connection.
+vi.mock('@/helpers/ai/get-prompt-cache', () => ({
+  readCachedPrompt: mocks.readCachedPrompt,
+  writeCachedPrompt: mocks.writeCachedPrompt,
 }))
 
 vi.mock('@/helpers/logger', () => ({
@@ -34,14 +33,12 @@ vi.mock('@/helpers/logger', () => ({
 
 import { FALLBACK_CHAT_PROMPT } from '@/helpers/ai/fallback-prompts/chat'
 import { getPrompt } from '@/helpers/ai/get-prompt'
-import {
-  makePromptCacheKey,
-  PROMPT_CACHE_TTL_SECONDS,
-} from '@/helpers/ai/get-prompt-cache'
 
 describe('getPrompt', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.writeCachedPrompt.mockResolvedValue(undefined)
+    mocks.readCachedPrompt.mockResolvedValue(null)
   })
 
   it('returns the Langfuse prompt and writes it to Redis on success', async () => {
@@ -50,7 +47,6 @@ describe('getPrompt', () => {
       toJSON: () => '{"name":"chat"}',
     }
     mocks.promptGet.mockResolvedValueOnce(livePrompt)
-    mocks.redisSet.mockResolvedValueOnce('OK')
 
     const result = await getPrompt('chat', 'aiBuilder', 'production')
 
@@ -58,41 +54,24 @@ describe('getPrompt', () => {
     expect(mocks.promptGet).toHaveBeenCalledWith('chat', {
       label: 'production',
     })
-    expect(mocks.redisSet).toHaveBeenCalledWith(
-      makePromptCacheKey('aiBuilder', 'chat', 'production'),
-      expect.stringContaining('live system prompt'),
-      'EX',
-      PROMPT_CACHE_TTL_SECONDS,
+    expect(mocks.writeCachedPrompt).toHaveBeenCalledWith(
+      'aiBuilder',
+      'chat',
+      'production',
+      'live system prompt',
     )
-  })
-
-  it('still returns the live prompt when Redis write fails', async () => {
-    const livePrompt = {
-      prompt: 'live system prompt',
-      toJSON: () => '{"name":"chat"}',
-    }
-    mocks.promptGet.mockResolvedValueOnce(livePrompt)
-    mocks.redisSet.mockRejectedValueOnce(new Error('redis down'))
-
-    const result = await getPrompt('chat', 'aiBuilder', 'production')
-
-    expect(result).toBe(livePrompt)
-    expect(mocks.loggerWarn).toHaveBeenCalledWith(
-      'Failed to write Langfuse prompt cache',
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      'Loaded Langfuse prompt',
       expect.objectContaining({
-        event: 'langfuse-prompt-cache-write-error',
+        event: 'langfuse-prompt-loaded',
+        source: 'langfuse',
       }),
     )
   })
 
   it('returns the Redis-cached prompt when Langfuse fails', async () => {
     mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
-    mocks.redisGet.mockResolvedValueOnce(
-      JSON.stringify({
-        promptText: 'cached system prompt',
-        cachedAt: '2026-09-11T00:00:00.000Z',
-      }),
-    )
+    mocks.readCachedPrompt.mockResolvedValueOnce('cached system prompt')
 
     const result = await getPrompt('chat', 'aiBuilder', 'production')
 
@@ -110,7 +89,7 @@ describe('getPrompt', () => {
 
   it('returns the static fallback when Langfuse and Redis both miss', async () => {
     mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
-    mocks.redisGet.mockResolvedValueOnce(null)
+    mocks.readCachedPrompt.mockResolvedValueOnce(null)
 
     const result = await getPrompt('chat', 'aiBuilder', 'production')
 
@@ -120,30 +99,19 @@ describe('getPrompt', () => {
       source: 'static',
       isFallback: true,
     })
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      'Using static Langfuse prompt fallback',
+      expect.objectContaining({ source: 'static' }),
+    )
   })
 
   it('rethrows when Langfuse fails and no Redis or static fallback exists', async () => {
     const romeError = new Error('Rome unavailable')
     mocks.promptGet.mockRejectedValueOnce(romeError)
-    mocks.redisGet.mockResolvedValueOnce(null)
+    mocks.readCachedPrompt.mockResolvedValueOnce(null)
 
     await expect(
       getPrompt('unknown-prompt', 'aiBuilder', 'production'),
     ).rejects.toBe(romeError)
-  })
-
-  it('falls through to static when Redis read fails after Langfuse failure', async () => {
-    mocks.promptGet.mockRejectedValueOnce(new Error('Rome unavailable'))
-    mocks.redisGet.mockRejectedValueOnce(new Error('redis read failed'))
-
-    const result = await getPrompt('chat', 'aiBuilder', 'production')
-
-    expect(result.prompt).toBe(FALLBACK_CHAT_PROMPT)
-    expect(mocks.loggerWarn).toHaveBeenCalledWith(
-      'Failed to read Langfuse prompt cache',
-      expect.objectContaining({
-        event: 'langfuse-prompt-cache-read-error',
-      }),
-    )
   })
 })

--- a/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
+++ b/packages/backend/src/helpers/ai/__tests__/get-prompt.test.ts
@@ -41,7 +41,7 @@ describe('getPrompt', () => {
     mocks.readCachedPrompt.mockResolvedValue(null)
   })
 
-  it('returns the Langfuse prompt and writes it to Redis on success', async () => {
+  it('returns the Langfuse prompt and fire-and-forgets the Redis write', async () => {
     const livePrompt = {
       prompt: 'live system prompt',
       toJSON: () => '{"name":"chat"}',
@@ -54,6 +54,7 @@ describe('getPrompt', () => {
     expect(mocks.promptGet).toHaveBeenCalledWith('chat', {
       label: 'production',
     })
+    // Cache write is intentionally not awaited on the happy path.
     expect(mocks.writeCachedPrompt).toHaveBeenCalledWith(
       'aiBuilder',
       'chat',

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
@@ -20,4 +20,3 @@ export const FALLBACK_CHAT_SUMMARY_PROMPT = `You are Plumber AI Builder wrapping
 - Do not expose secrets, API keys, or credentials.
 - Do not claim that a pipe has been published or is live unless a tool result confirms it.
 `
-

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
@@ -1,3 +1,5 @@
+import { WORKFLOW_METADATA_FORMAT } from './workflow-metadata-instructions'
+
 /**
  * Last-resort AI Builder chat-summary system prompt when Rome and Redis are
  * both unavailable. Refresh from Rome after meaningful prompt edits:
@@ -13,7 +15,8 @@ export const FALLBACK_CHAT_SUMMARY_PROMPT = `You are Plumber AI Builder wrapping
 
 ## Output
 - Keep the summary short.
-- If a createable workflow is ready, emit the workflow metadata block the product expects.
+- If a createable workflow is ready, emit the workflow metadata block:
+${WORKFLOW_METADATA_FORMAT}
 - If the design is incomplete, list the open questions briefly and point to {{SUPPORT_FORM_URL}} if the user is blocked.
 
 ## Safety

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat-summary.ts
@@ -1,0 +1,23 @@
+/**
+ * Last-resort AI Builder chat-summary system prompt when Rome and Redis are
+ * both unavailable. Refresh from Rome after meaningful prompt edits:
+ * `npm run get-prompt -- chat-summary --label=production`
+ */
+export const FALLBACK_CHAT_SUMMARY_PROMPT = `You are Plumber AI Builder wrapping up a long chat. The conversation has reached its message limit.
+
+## Role
+- Summarise the user's automation goal and the pipe design agreed so far.
+- Offer a clear next step the user can take (create/update the pipe, or continue in a new chat).
+- Prefer apps and actions the user can access. Never invent apps that do not exist in Plumber.
+- When you need the user to contact support, direct them to {{SUPPORT_FORM_URL}}.
+
+## Output
+- Keep the summary short.
+- If a createable workflow is ready, emit the workflow metadata block the product expects.
+- If the design is incomplete, list the open questions briefly and point to {{SUPPORT_FORM_URL}} if the user is blocked.
+
+## Safety
+- Do not expose secrets, API keys, or credentials.
+- Do not claim that a pipe has been published or is live unless a tool result confirms it.
+`
+

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
@@ -1,3 +1,5 @@
+import { WORKFLOW_METADATA_FORMAT } from './workflow-metadata-instructions'
+
 /**
  * Last-resort AI Builder chat system prompt when Rome and Redis are both
  * unavailable. Refresh from Rome after meaningful prompt edits:
@@ -13,7 +15,8 @@ export const FALLBACK_CHAT_PROMPT = `You are Plumber AI Builder, an assistant th
 
 ## Output
 - Keep answers concise and actionable.
-- When ready to create a pipe, emit the workflow metadata block the product expects so the UI can materialise steps.
+- When ready to create a pipe, emit the workflow metadata block so the UI can materialise steps.
+${WORKFLOW_METADATA_FORMAT}
 - If you cannot complete a request with the available tools or apps, say so and point the user to {{SUPPORT_FORM_URL}}.
 
 ## Safety

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
@@ -20,4 +20,3 @@ export const FALLBACK_CHAT_PROMPT = `You are Plumber AI Builder, an assistant th
 - Do not expose secrets, API keys, or credentials.
 - Do not claim that a pipe has been published or is live unless a tool result confirms it.
 `
-

--- a/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/chat.ts
@@ -1,0 +1,23 @@
+/**
+ * Last-resort AI Builder chat system prompt when Rome and Redis are both
+ * unavailable. Refresh from Rome after meaningful prompt edits:
+ * `npm run get-prompt -- chat --label=production`
+ */
+export const FALLBACK_CHAT_PROMPT = `You are Plumber AI Builder, an assistant that helps public officers in Singapore build automation workflows ("pipes") in Plumber.
+
+## Role
+- Ask clarifying questions when the user's goal is ambiguous.
+- Propose a concrete pipe (trigger + actions) the user can create in Plumber.
+- Prefer apps and actions the user can access. Never invent apps that do not exist in Plumber.
+- When you need the user to contact support, direct them to {{SUPPORT_FORM_URL}}.
+
+## Output
+- Keep answers concise and actionable.
+- When ready to create a pipe, emit the workflow metadata block the product expects so the UI can materialise steps.
+- If you cannot complete a request with the available tools or apps, say so and point the user to {{SUPPORT_FORM_URL}}.
+
+## Safety
+- Do not expose secrets, API keys, or credentials.
+- Do not claim that a pipe has been published or is live unless a tool result confirms it.
+`
+

--- a/packages/backend/src/helpers/ai/fallback-prompts/index.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/index.ts
@@ -1,0 +1,17 @@
+import { FALLBACK_CHAT_PROMPT } from './chat'
+import { FALLBACK_CHAT_SUMMARY_PROMPT } from './chat-summary'
+
+/**
+ * Static last-resort prompts keyed by Langfuse prompt name.
+ * Covers LD defaults from AI_BUILDER_FEATURE_FLAG_FALLBACK.
+ */
+const STATIC_PROMPT_FALLBACKS: Record<string, string> = {
+  chat: FALLBACK_CHAT_PROMPT,
+  'chat-summary': FALLBACK_CHAT_SUMMARY_PROMPT,
+}
+
+export function getStaticPromptFallback(
+  promptName: string,
+): string | undefined {
+  return STATIC_PROMPT_FALLBACKS[promptName]
+}

--- a/packages/backend/src/helpers/ai/fallback-prompts/workflow-metadata-instructions.ts
+++ b/packages/backend/src/helpers/ai/fallback-prompts/workflow-metadata-instructions.ts
@@ -1,0 +1,26 @@
+/**
+ * Compact WORKFLOW_METADATA schema shared by static prompt fallbacks.
+ * Kept in sync with parseWorkflowMetadata / VALID_WORKFLOW in unit tests.
+ */
+export const WORKFLOW_METADATA_FORMAT = `Emit exactly one HTML comment block in this form (YAML inside). The UI parses it strictly.
+
+<!-- WORKFLOW_METADATA
+name: Short pipe name
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    stepName: New form submission
+    description: Trigger when a new FormSG submission is received
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    stepName: Send email
+    description: Send a transactional email
+-->
+
+Rules:
+- First step is the trigger; later steps are actions.
+- Use only real Plumber appKey/key pairs the user can access.
+- Do not invent apps or action keys.
+- Put the block at the end of your reply. Do not wrap it in a markdown code fence.`

--- a/packages/backend/src/helpers/ai/get-prompt-cache.ts
+++ b/packages/backend/src/helpers/ai/get-prompt-cache.ts
@@ -1,6 +1,5 @@
 import type { LangfuseProject } from '@/helpers/langfuse'
 import logger from '@/helpers/logger'
-import { redisAppDataClient } from '@/helpers/redis-app-data'
 
 /** Keep stale prompts long enough to survive multi-day Rome outages. */
 export const PROMPT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30
@@ -20,6 +19,15 @@ export function makePromptCacheKey(
   return `${PROMPT_CACHE_KEY_PREFIX}:${project}:${promptName}:${label}`
 }
 
+/**
+ * Lazy-load Redis so importing this module during unit tests does not open a
+ * connection (ioredis connects on construct and can kill the vitest worker).
+ */
+async function getRedisAppDataClient() {
+  const { redisAppDataClient } = await import('@/helpers/redis-app-data')
+  return redisAppDataClient
+}
+
 export async function readCachedPrompt(
   project: LangfuseProject,
   promptName: string,
@@ -27,6 +35,7 @@ export async function readCachedPrompt(
 ): Promise<string | null> {
   const redisKey = makePromptCacheKey(project, promptName, label)
   try {
+    const redisAppDataClient = await getRedisAppDataClient()
     const raw = await redisAppDataClient.get(redisKey)
     if (!raw) {
       return null
@@ -64,6 +73,7 @@ export async function writeCachedPrompt(
   }
 
   try {
+    const redisAppDataClient = await getRedisAppDataClient()
     await redisAppDataClient.set(
       redisKey,
       JSON.stringify(payload),

--- a/packages/backend/src/helpers/ai/get-prompt-cache.ts
+++ b/packages/backend/src/helpers/ai/get-prompt-cache.ts
@@ -1,0 +1,84 @@
+import type { LangfuseProject } from '@/helpers/langfuse'
+import logger from '@/helpers/logger'
+import { redisAppDataClient } from '@/helpers/redis-app-data'
+
+/** Keep stale prompts long enough to survive multi-day Rome outages. */
+export const PROMPT_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30
+
+const PROMPT_CACHE_KEY_PREFIX = 'langfuse-prompt'
+
+type CachedPrompt = {
+  promptText: string
+  cachedAt: string
+}
+
+export function makePromptCacheKey(
+  project: LangfuseProject,
+  promptName: string,
+  label: string,
+): string {
+  return `${PROMPT_CACHE_KEY_PREFIX}:${project}:${promptName}:${label}`
+}
+
+export async function readCachedPrompt(
+  project: LangfuseProject,
+  promptName: string,
+  label: string,
+): Promise<string | null> {
+  const redisKey = makePromptCacheKey(project, promptName, label)
+  try {
+    const raw = await redisAppDataClient.get(redisKey)
+    if (!raw) {
+      return null
+    }
+
+    const parsed = JSON.parse(raw) as CachedPrompt
+    if (typeof parsed.promptText !== 'string' || !parsed.promptText) {
+      return null
+    }
+
+    return parsed.promptText
+  } catch (error) {
+    logger.warn('Failed to read Langfuse prompt cache', {
+      event: 'langfuse-prompt-cache-read-error',
+      redisKey,
+      promptName,
+      project,
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+export async function writeCachedPrompt(
+  project: LangfuseProject,
+  promptName: string,
+  label: string,
+  promptText: string,
+): Promise<void> {
+  const redisKey = makePromptCacheKey(project, promptName, label)
+  const payload: CachedPrompt = {
+    promptText,
+    cachedAt: new Date().toISOString(),
+  }
+
+  try {
+    await redisAppDataClient.set(
+      redisKey,
+      JSON.stringify(payload),
+      'EX',
+      PROMPT_CACHE_TTL_SECONDS,
+    )
+  } catch (error) {
+    // Live Rome fetch already succeeded; cache write must not fail the request.
+    logger.warn('Failed to write Langfuse prompt cache', {
+      event: 'langfuse-prompt-cache-write-error',
+      redisKey,
+      promptName,
+      project,
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/backend/src/helpers/ai/get-prompt.ts
+++ b/packages/backend/src/helpers/ai/get-prompt.ts
@@ -1,15 +1,112 @@
-import { getLangfuseClient, LangfuseProject } from '@/helpers/langfuse'
+import { getStaticPromptFallback } from '@/helpers/ai/fallback-prompts'
+import {
+  readCachedPrompt,
+  writeCachedPrompt,
+} from '@/helpers/ai/get-prompt-cache'
+import { getLangfuseClient, type LangfuseProject } from '@/helpers/langfuse'
+import logger from '@/helpers/logger'
 
+export type PromptSource = 'langfuse' | 'redis' | 'static'
+
+type PromptClientLike = {
+  prompt: string
+  toJSON: () => string
+}
+
+const DEFAULT_PROMPT_LABEL = 'production'
+
+function createFallbackPrompt(
+  promptName: string,
+  promptText: string,
+  source: Exclude<PromptSource, 'langfuse'>,
+  label: string,
+): PromptClientLike {
+  return {
+    prompt: promptText,
+    toJSON: () =>
+      JSON.stringify({
+        name: promptName,
+        version: 0,
+        label,
+        source,
+        isFallback: true,
+        type: 'text',
+        prompt: promptText,
+      }),
+  }
+}
+
+function extractPromptText(prompt: { prompt: unknown }): string | null {
+  return typeof prompt.prompt === 'string' && prompt.prompt.length > 0
+    ? prompt.prompt
+    : null
+}
+
+/**
+ * Fetches an AI Builder prompt from Rome (Langfuse), with Redis then static
+ * fallbacks so chat stays usable when Rome is down.
+ */
 export const getPrompt = async (
   promptName: string,
   project: LangfuseProject,
   version?: string,
-) => {
+): Promise<PromptClientLike> => {
+  const label = version ?? DEFAULT_PROMPT_LABEL
   const client = getLangfuseClient(project)
 
-  const prompt = await client.prompt.get(
-    promptName,
-    version ? { label: version } : undefined,
-  )
-  return prompt
+  try {
+    const prompt = await client.prompt.get(
+      promptName,
+      version ? { label: version } : undefined,
+    )
+
+    const promptText = extractPromptText(prompt)
+    if (promptText) {
+      await writeCachedPrompt(project, promptName, label, promptText)
+    }
+
+    logger.info('Loaded Langfuse prompt', {
+      event: 'langfuse-prompt-loaded',
+      source: 'langfuse' satisfies PromptSource,
+      promptName,
+      project,
+      label,
+    })
+
+    return prompt
+  } catch (error) {
+    logger.error('Failed to fetch Langfuse prompt; trying fallbacks', {
+      event: 'langfuse-prompt-fetch-error',
+      promptName,
+      project,
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    const cachedPromptText = await readCachedPrompt(project, promptName, label)
+    if (cachedPromptText) {
+      logger.warn('Using Redis-cached Langfuse prompt', {
+        event: 'langfuse-prompt-fallback',
+        source: 'redis' satisfies PromptSource,
+        promptName,
+        project,
+        label,
+      })
+      return createFallbackPrompt(promptName, cachedPromptText, 'redis', label)
+    }
+
+    const staticPromptText = getStaticPromptFallback(promptName)
+    if (staticPromptText) {
+      logger.warn('Using static Langfuse prompt fallback', {
+        event: 'langfuse-prompt-fallback',
+        source: 'static' satisfies PromptSource,
+        promptName,
+        project,
+        label,
+      })
+      return createFallbackPrompt(promptName, staticPromptText, 'static', label)
+    }
+
+    throw error
+  }
 }

--- a/packages/backend/src/helpers/ai/get-prompt.ts
+++ b/packages/backend/src/helpers/ai/get-prompt.ts
@@ -62,7 +62,8 @@ export const getPrompt = async (
 
     const promptText = extractPromptText(prompt)
     if (promptText) {
-      await writeCachedPrompt(project, promptName, label, promptText)
+      // Best-effort cache: do not delay the live Rome response on Redis.
+      void writeCachedPrompt(project, promptName, label, promptText)
     }
 
     logger.info('Loaded Langfuse prompt', {

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -54,6 +54,22 @@ vi.mock('@/models/connection', () => ({
   default: { query: vi.fn() },
 }))
 
+// Avoid loading apps → Redis via list-connections (ioredis connect-on-construct
+// can kill the vitest worker when Redis is unavailable in unit CI).
+vi.mock('@/services/mcp/list-connections', () => ({
+  connectionLabel: vi.fn(
+    (connection: {
+      formattedData?: { screenName?: string }
+      description?: string
+      key: string
+    }) =>
+      connection.formattedData?.screenName ??
+      connection.description ??
+      connection.key,
+  ),
+  listConnectionsService: vi.fn(),
+}))
+
 vi.mock('@/helpers/ai/get-prompt', () => ({
   getPrompt: vi.fn().mockResolvedValue({
     prompt: 'You are a helpful assistant. Support: {{SUPPORT_FORM_URL}}',


### PR DESCRIPTION
…s down

Keep AI Builder chat usable if Langfuse/Rome is unreachable by caching successful prompt fetches in Redis and serving committed last-resort chat/chat-summary prompts when the cache is cold.

## Problem

_What problem are you trying to solve? What issue does this close?_

Closes [insert issue #]

## Solution

_How did you solve the problem?_

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62921541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until a slow or unavailable Redis cache cannot delay otherwise-successful Langfuse prompt retrieval.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fbackend%2Fsrc%2Fhelpers%2Fai%2Fget-prompt.ts%3A63-66%0AThe%20successful%20Langfuse%20path%20waits%20for%20the%20best-effort%20Redis%20write%20before%20returning%20the%20prompt.%20If%20Redis%20is%20slow%20or%20unavailable%20and%20the%20command%20remains%20pending%20through%20retries%20or%20a%20timeout%2C%20an%20otherwise%20successful%20chat%20request%20is%20delayed%20and%20may%20time%20out.%20Swallowing%20the%20eventual%20write%20error%20does%20not%20prevent%20this%20availability%20regression%3B%20dispatch%20the%20cache%20write%20without%20blocking%20the%20live%20response.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20promptText%20%3D%20extractPromptText%28prompt%29%0A%20%20%20%20if%20%28promptText%29%20%7B%0A%20%20%20%20%20%20void%20writeCachedPrompt%28project%2C%20promptName%2C%20label%2C%20promptText%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%202%0Apackages%2Fbackend%2Fsrc%2Fhelpers%2Fai%2Ffallback-prompts%2Fchat.ts%3A16%0AThe%20static%20chat%20and%20chat-summary%20prompts%20tell%20the%20model%20to%20emit%20%E2%80%9Cthe%20workflow%20metadata%20block%20the%20product%20expects%2C%E2%80%9D%20but%20they%20do%20not%20define%20the%20required%20comment-delimited%20YAML%20format%20or%20its%20fields.%20During%20a%20cold-cache%20outage%2C%20this%20makes%20it%20more%20likely%20that%20the%20model%20will%20produce%20output%20rejected%20by%20the%20strict%20workflow%20parser%2C%20preventing%20the%20UI%20from%20materializing%20workflow%20steps.%20Include%20the%20actual%20schema%20and%20a%20valid%20example%20in%20both%20fallback%20prompts.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Cache write blocks response** <a href="https://github.com/opengovsg/plumber/pull/2192#discussion_r3985650616">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Metadata format is unspecified** <a href="https://github.com/opengovsg/plumber/pull/2192#discussion_r3985650634">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/backend/src/helpers/ai/get-prompt.ts:63-66
The successful Langfuse path waits for the best-effort Redis write before returning the prompt. If Redis is slow or unavailable and the command remains pending through retries or a timeout, an otherwise successful chat request is delayed and may time out. Swallowing the eventual write error does not prevent this availability regression; dispatch the cache write without blocking the live response.

```suggestion
    const promptText = extractPromptText(prompt)
    if (promptText) {
      void writeCachedPrompt(project, promptName, label, promptText)
    }
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
packages/backend/src/helpers/ai/fallback-prompts/chat.ts:16
The static chat and chat-summary prompts tell the model to emit “the workflow metadata block the product expects,” but they do not define the required comment-delimited YAML format or its fields. During a cold-cache outage, this makes it more likely that the model will produce output rejected by the strict workflow parser, preventing the UI from materializing workflow steps. Include the actual schema and a valid example in both fallback prompts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Caches successful text prompts in Redis for 30 days, scoped by project, prompt name, and label.
- Falls back from Langfuse to Redis and then to static chat prompts.
- Adds structured source logging and fallback metadata.
- Adds unit coverage for successful retrieval, cache failures, Redis fallback, static fallback, and unsupported prompts.
- The successful path currently blocks on the best-effort cache write, and the static prompts omit the workflow metadata schema required for reliable workflow creation.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Request AI Builder prompt] --> B[Fetch from Rome / Langfuse]
  B -->|Success| C[Write prompt text to Redis]
  C --> D[Return live prompt]
  B -->|Failure| E[Read Redis cache]
  E -->|Cache hit| F[Return cached prompt]
  E -->|Miss or read failure| G{Static fallback exists?}
  G -->|Yes| H[Return committed static prompt]
  G -->|No| I[Rethrow Langfuse error]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(ai-builder): fall back to Redis th..."](https://github.com/opengovsg/plumber/commit/9fc371e415f417050dff23f5a44657398f6a5305)</sub>

<!-- /greptile_comment -->