### PR TITLE
feat(frontend): animated Pro wordmark for PlumPro users

### DIFF
--- a/packages/frontend/src/components/AppBar/index.tsx
+++ b/packages/frontend/src/components/AppBar/index.tsx
@@ -1,9 +1,9 @@
-import { Box, Divider, Flex, Hide, Image, Show, Text } from '@chakra-ui/react'
+import { Box, Divider, Flex, Hide, Show, Text } from '@chakra-ui/react'
 import { Button, Link } from '@opengovsg/design-system-react'
 
-import mainLogo from '@/assets/logo.svg'
 import AvatarDropdownMenu from '@/components/AvatarDropdownMenu'
 import NewsDrawer from '@/components/NewsDrawer'
+import PlumberLogo from '@/components/PlumberLogo'
 import * as URLS from '@/config/urls'
 
 import NavigationDrawer from '../Layout/NavigationDrawer'
@@ -28,7 +28,7 @@ export default function AppBar(): React.ReactElement {
       >
         <Box flexGrow="1" flexShrink="0">
           <Show above="sm">
-            <Image src={mainLogo} h={8} w={8} />
+            <PlumberLogo />
           </Show>
           <Hide above="sm">
             <NavigationDrawer />

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
@@ -3,7 +3,6 @@
   height: 2rem;
   width: auto;
   overflow: visible;
-  filter: drop-shadow(0 1px 3px rgba(207, 26, 104, 0.25));
 }
 
 .mark {

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
@@ -1,0 +1,124 @@
+.wordmark {
+  display: block;
+  height: 2rem;
+  width: auto;
+  overflow: visible;
+  filter: drop-shadow(0 1px 3px rgba(207, 26, 104, 0.25));
+}
+
+.mark {
+  opacity: 0;
+  transform-origin: 19px 23.5px;
+  animation: markIn 520ms cubic-bezier(0.22, 1.25, 0.36, 1) both;
+}
+
+.letterR {
+  opacity: 0;
+  transform-origin: 8px 33px;
+  animation: letterIn 460ms cubic-bezier(0.22, 1.25, 0.36, 1) 220ms both;
+}
+
+.letterO {
+  opacity: 0;
+  transform-origin: 74.5px 33px;
+  animation: ringIn 640ms cubic-bezier(0.22, 1.2, 0.36, 1) 360ms both;
+}
+
+.sheen {
+  opacity: 0;
+  animation: sheenSweep 900ms ease-in-out 820ms both;
+}
+
+/* A second, identical animation lets hover restart the sweep. */
+.wordmark:hover .sheen {
+  animation: sheenReplay 900ms ease-in-out both;
+}
+
+@keyframes markIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.82);
+  }
+  60% {
+    opacity: 1;
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes letterIn {
+  from {
+    opacity: 0;
+    transform: translateX(-16px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes ringIn {
+  from {
+    opacity: 0;
+    transform: rotate(-170deg) scale(0.2);
+  }
+  70% {
+    opacity: 1;
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+@keyframes sheenSweep {
+  from {
+    opacity: 0;
+    transform: translateX(-34px) skewX(-18deg);
+  }
+  25% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(112px) skewX(-18deg);
+  }
+}
+
+@keyframes sheenReplay {
+  from {
+    opacity: 0;
+    transform: translateX(-34px) skewX(-18deg);
+  }
+  25% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(112px) skewX(-18deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mark,
+  .letterR,
+  .letterO {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  .sheen,
+  .wordmark:hover .sheen {
+    opacity: 0;
+    animation: none;
+  }
+}

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.module.css
@@ -26,12 +26,12 @@
 
 .sheen {
   opacity: 0;
-  animation: sheenSweep 900ms ease-in-out 820ms both;
+  animation: sheenSweep 1100ms ease-in-out 780ms both;
 }
 
 /* A second, identical animation lets hover restart the sweep. */
 .wordmark:hover .sheen {
-  animation: sheenReplay 900ms ease-in-out both;
+  animation: sheenReplay 1100ms ease-in-out both;
 }
 
 @keyframes markIn {
@@ -51,7 +51,10 @@
 @keyframes letterIn {
   from {
     opacity: 0;
-    transform: translateX(-16px) scale(0.9);
+    transform: translateX(-26px) scale(0.88);
+  }
+  50% {
+    opacity: 1;
   }
   to {
     opacity: 1;
@@ -76,34 +79,34 @@
 @keyframes sheenSweep {
   from {
     opacity: 0;
-    transform: translateX(-34px) skewX(-18deg);
+    transform: translateX(-40px) skewX(-18deg);
   }
-  25% {
+  20% {
     opacity: 1;
   }
-  80% {
+  85% {
     opacity: 1;
   }
   to {
     opacity: 0;
-    transform: translateX(112px) skewX(-18deg);
+    transform: translateX(116px) skewX(-18deg);
   }
 }
 
 @keyframes sheenReplay {
   from {
     opacity: 0;
-    transform: translateX(-34px) skewX(-18deg);
+    transform: translateX(-40px) skewX(-18deg);
   }
-  25% {
+  20% {
     opacity: 1;
   }
-  80% {
+  85% {
     opacity: 1;
   }
   to {
     opacity: 0;
-    transform: translateX(112px) skewX(-18deg);
+    transform: translateX(116px) skewX(-18deg);
   }
 }
 

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
@@ -42,14 +42,7 @@ export default function PlumProLogo(): JSX.Element {
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>
-        <linearGradient
-          id={gradientId}
-          x1="0"
-          y1="0"
-          x2="90"
-          y2="47"
-          gradientUnits="userSpaceOnUse"
-        >
+        <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
           <stop offset="0" stopColor="#AA004B" />
           <stop offset="0.55" stopColor="#CF1A68" />
           <stop offset="1" stopColor="#E8558F" />

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
@@ -1,0 +1,106 @@
+import { useId } from 'react'
+
+import styles from './PlumProLogo.module.css'
+
+/**
+ * Paths lifted verbatim from the Plumber mark in `@/assets/logo.svg`, so the
+ * PlumPro wordmark stays pixel-identical to the standard logo.
+ */
+const MARK_TOP_BAR = 'M0 0H22.6035V9.64103H0V0Z'
+const MARK_STEM =
+  'M2.62069 29.6662C2.62069 23.7537 7.58792 18.9607 13.7153 18.9607L22.5341 18.9607V27.7878H18.9747C16.7986 27.7878 14.9011 28.9385 13.9 30.6437L13.7729 30.8438L13.7153 30.9852C13.3506 31.7198 13.1464 32.5428 13.1464 33.4118V47H2.62069V29.6662Z'
+const MARK_BOWL =
+  'M23.7761 0.0201051C31.6317 0.0201051 38 6.28888 38 13.869C38 21.4492 31.6317 27.718 23.7761 27.718V19.1316H24.0169C26.712 19.1316 28.8967 17.0235 28.8967 14.423C28.8967 11.6941 26.6041 9.43736 23.7761 9.43736V0.0201051Z'
+
+/**
+ * The "r" is the mark's own stem glyph, shifted right of the P. The offset is
+ * as tight as the bowl allows: any less and the shoulder of the r touches it.
+ */
+const LETTER_R_OFFSET = 35
+const LETTER_R_TRANSFORM = `translate(${LETTER_R_OFFSET} 0)`
+
+/**
+ * The "o" is an annulus matching the bowl of the P: outer radius 14, ring
+ * thickness 9.2, seated on the same 47 baseline.
+ */
+const LETTER_O =
+  'M74.5 19A14 14 0 1 1 74.5 47A14 14 0 1 1 74.5 19ZM74.5 28.2A4.8 4.8 0 1 0 74.5 37.8A4.8 4.8 0 1 0 74.5 28.2Z'
+
+export default function PlumProLogo(): JSX.Element {
+  const id = useId()
+  const gradientId = `plumpro-gradient-${id}`
+  const sheenGradientId = `plumpro-sheen-${id}`
+  const clipId = `plumpro-clip-${id}`
+
+  return (
+    <svg
+      className={styles.wordmark}
+      viewBox="0 0 90 47"
+      fill="none"
+      role="img"
+      aria-label="Plumber Pro"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="0"
+          y1="0"
+          x2="90"
+          y2="47"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#AA004B" />
+          <stop offset="0.55" stopColor="#CF1A68" />
+          <stop offset="1" stopColor="#E8558F" />
+        </linearGradient>
+
+        <linearGradient
+          id={sheenGradientId}
+          x1="0"
+          y1="0"
+          x2="20"
+          y2="0"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#FFFFFF" stopOpacity="0" />
+          <stop offset="0.5" stopColor="#FFFFFF" stopOpacity="0.85" />
+          <stop offset="1" stopColor="#FFFFFF" stopOpacity="0" />
+        </linearGradient>
+
+        <clipPath id={clipId}>
+          <path d={MARK_TOP_BAR} />
+          <path d={MARK_STEM} />
+          <path d={MARK_BOWL} />
+          <path d={MARK_STEM} transform={LETTER_R_TRANSFORM} />
+          <path d={LETTER_O} fillRule="evenodd" />
+        </clipPath>
+      </defs>
+
+      <g fill={`url(#${gradientId})`}>
+        <g className={styles.mark}>
+          <path d={MARK_TOP_BAR} />
+          <path d={MARK_STEM} />
+          <path d={MARK_BOWL} />
+        </g>
+
+        <g transform={LETTER_R_TRANSFORM}>
+          <path className={styles.letterR} d={MARK_STEM} />
+        </g>
+
+        <path className={styles.letterO} d={LETTER_O} fillRule="evenodd" />
+      </g>
+
+      <g clipPath={`url(#${clipId})`}>
+        <rect
+          className={styles.sheen}
+          x="0"
+          y="-10"
+          width="20"
+          height="67"
+          fill={`url(#${sheenGradientId})`}
+        />
+      </g>
+    </svg>
+  )
+}

--- a/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
+++ b/packages/frontend/src/components/PlumberLogo/PlumProLogo.tsx
@@ -59,12 +59,13 @@ export default function PlumProLogo(): JSX.Element {
           id={sheenGradientId}
           x1="0"
           y1="0"
-          x2="20"
+          x2="26"
           y2="0"
           gradientUnits="userSpaceOnUse"
         >
           <stop offset="0" stopColor="#FFFFFF" stopOpacity="0" />
-          <stop offset="0.5" stopColor="#FFFFFF" stopOpacity="0.85" />
+          <stop offset="0.45" stopColor="#FFFFFF" stopOpacity="0.95" />
+          <stop offset="0.55" stopColor="#FFFFFF" stopOpacity="0.95" />
           <stop offset="1" stopColor="#FFFFFF" stopOpacity="0" />
         </linearGradient>
 
@@ -96,7 +97,7 @@ export default function PlumProLogo(): JSX.Element {
           className={styles.sheen}
           x="0"
           y="-10"
-          width="20"
+          width="26"
           height="67"
           fill={`url(#${sheenGradientId})`}
         />

--- a/packages/frontend/src/components/PlumberLogo/index.tsx
+++ b/packages/frontend/src/components/PlumberLogo/index.tsx
@@ -1,0 +1,16 @@
+import { Image } from '@chakra-ui/react'
+
+import mainLogo from '@/assets/logo.svg'
+import useIsPlumPro from '@/hooks/useIsPlumPro'
+
+import PlumProLogo from './PlumProLogo'
+
+export default function PlumberLogo(): JSX.Element {
+  const isPlumPro = useIsPlumPro()
+
+  if (isPlumPro) {
+    return <PlumProLogo />
+  }
+
+  return <Image src={mainLogo} alt="Plumber" h={8} w={8} />
+}

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -15,6 +15,7 @@ export const SSO_FEATURE_FLAG = 'ogp-sso-enabled'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
 export const IF_THEN_THEN_FEATURE_FLAG = 'feature_if_then_then'
+export const PLUMPRO_FEATURE_FLAG = 'plumpro'
 
 /**
  * App/events flags

--- a/packages/frontend/src/hooks/__tests__/useIsPlumPro.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useIsPlumPro.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PLUMPRO_FEATURE_FLAG } from '@/config/flags'
+
+import { resolveIsPlumPro } from '../useIsPlumPro'
+
+describe('resolveIsPlumPro', () => {
+  it('reads the PlumPro flag, defaulting to off', () => {
+    const getFlagValue = vi.fn().mockReturnValue(false)
+
+    resolveIsPlumPro(getFlagValue)
+
+    expect(getFlagValue).toHaveBeenCalledWith(PLUMPRO_FEATURE_FLAG, false)
+  })
+
+  it('is true when the flag is on', () => {
+    expect(resolveIsPlumPro(() => true)).toBe(true)
+  })
+
+  it('is false when the flag is off', () => {
+    expect(resolveIsPlumPro(() => false)).toBe(false)
+  })
+
+  it('is false when the flag is missing', () => {
+    expect(resolveIsPlumPro(() => undefined)).toBe(false)
+  })
+})

--- a/packages/frontend/src/hooks/useIsPlumPro.ts
+++ b/packages/frontend/src/hooks/useIsPlumPro.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react'
+
+import { PLUMPRO_FEATURE_FLAG } from '@/config/flags'
+import type { LaunchDarklyContextData } from '@/contexts/LaunchDarkly'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+
+export function resolveIsPlumPro(
+  getFlagValue: LaunchDarklyContextData['getFlagValue'],
+): boolean {
+  return Boolean(getFlagValue(PLUMPRO_FEATURE_FLAG, false))
+}
+
+/**
+ * Whether the logged-in user is a PlumPro (power user).
+ */
+export default function useIsPlumPro(): boolean {
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  return resolveIsPlumPro(getFlagValue)
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/a44c56de-c164-4199-b458-67d99831e33b


## Deploy notes
- [x] LD Flag created, defaults to true for test and staging, targets PlumPros for Prod

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63003878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable correctness, security, accessibility, or compatibility failures identified.

<details><summary><h3>Summary</h3></summary>

- Adds an accessible SVG wordmark with entry, sheen, hover, and reduced-motion states.
- Encapsulates logo selection in `PlumberLogo`.
- Adds a feature-flag resolver and unit coverage for enabled, disabled, and missing values.
- Preserves the existing logo for users outside the flag.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  AppBar[Desktop App Bar] --> Logo[PlumberLogo]
  Logo --> Hook[useIsPlumPro]
  Hook --> LD[LaunchDarklyContext]
  LD --> Flag{plumpro enabled?}
  Flag -->|Yes| Pro[Animated PlumPro wordmark]
  Flag -->|No or unavailable| Standard[Standard Plumber mark]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(frontend): sharpen Pro wordmark and ..."](https://github.com/opengovsg/plumber/commit/f3b9f122d7771ca25262f8644082fabf77056ae3)</sub>

<!-- /greptile_comment -->