### PR TITLE
feat(analytics): integrate PostHog product analytics

### DIFF
--- a/.claude/skills/integration-react-react-router-6/references/identify-users.md
+++ b/.claude/skills/integration-react-react-router-6/references/identify-users.md
@@ -1,0 +1,307 @@
+> AI agents: this is one page from PostHog's docs. Full index of Markdown docs for LLMs: https://posthog.com/llms.txt
+
+# Identify users - Docs
+
+Copy page
+
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/usage.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/usage.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    'email': 'max@hedgehogmail.com', // optional: set additional person properties
+    'name': 'Max Hedgehog',
+  },
+);
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+#### Identify users when the web SDK loads
+
+If your app already knows the signed-in user when you initialize the JavaScript web SDK, the [`loaded` callback](/docs/libraries/js/config.md) is a convenient place to call `identify`. This identifies the user as soon as the SDK has loaded:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.init('<ph_project_token>', {
+    api_host: 'https://us.i.posthog.com',
+    defaults: '2026-05-30',
+    loaded: (posthog) => {
+        if (currentUser?.id) {
+            posthog.identify(currentUser.id, {
+                email: currentUser.email,
+                name: currentUser.name,
+            })
+        }
+    },
+})
+```
+
+In this example, `currentUser` represents user data already available from your authentication system. If your app loads the user asynchronously, call `posthog.identify()` as soon as that data becomes available instead.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+await Posthog().reset();
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+**\`$set\` and \`$set\_once\` aren't stored on events**
+
+These properties only tell PostHog how to update person data during ingestion — they aren't kept on the stored event, so you can't filter, break down, or query events by them. To query the values you set, use [person properties](/docs/product-analytics/person-properties.md) instead.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/usage.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/usage.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Still have questions?
+
+Ask PostHog AI
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-react-react-router-6/references/react-router-v6.md
+++ b/.claude/skills/integration-react-react-router-6/references/react-router-v6.md
@@ -1,0 +1,394 @@
+> AI agents: this is one page from PostHog's docs. Full index of Markdown docs for LLMs: https://posthog.com/llms.txt
+
+# React Router V6 - Docs
+
+Copy page
+
+# React Router V6 - Docs
+
+This guide walks you through setting up PostHog for React Router V6. If you're using React Router v7, find the guide for that mode in the [React Router page](/docs/libraries/react-router.md). If you're using React with another framework, go to the [React integration guide](/docs/libraries/react.md).
+
+1.  1
+
+    ## Install client-side SDKs
+
+    Required
+
+    First, you'll need to install [`posthog-js`](https://github.com/posthog/posthog-js) and `@posthog/react` using your package manager. These packages allow you to capture **client-side** events.
+
+    PostHog AI
+
+    ### npm
+
+    ```bash
+    npm install --save posthog-js @posthog/react
+    ```
+
+    ### Yarn
+
+    ```bash
+    yarn add posthog-js @posthog/react
+    ```
+
+    ### pnpm
+
+    ```bash
+    pnpm add posthog-js @posthog/react
+    ```
+
+    ### Bun
+
+    ```bash
+    bun add posthog-js @posthog/react
+    ```
+
+    > **If your site sets a Content-Security-Policy**, it needs to allow PostHog. This applies to the snippet and to package installs alike: the SDK lazy-loads extra bundles (session replay, surveys) from PostHog's CDN, and sends events to the ingestion host. PostHog serves from subdomains of `posthog.com` that change over time, so allow the wildcard:
+    >
+    > PostHog AI
+    >
+    > ```
+    > script-src 'self' https://*.posthog.com;
+    > connect-src 'self' https://*.posthog.com;
+    > worker-src 'self' blob: data:;
+    > ```
+    >
+    > `script-src` covers the snippet and the lazy-loaded bundles, `connect-src` covers event ingestion and feature flags, and `worker-src` covers session replay. The [toolbar needs a few more](/docs/advanced/content-security-policy.md), or use a [reverse proxy](/docs/advanced/proxy.md) so everything is first-party. Failing to do so causes silent failures where `capture` and `identify` calls never send, so the integration looks complete while zero events arrive. Remember `connect-src` falls back to `default-src`, so `default-src 'self'` blocks event delivery even when the script itself is bundled.
+
+2.  2
+
+    ## Add your environment variables
+
+    Required
+
+    Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project token and host in [your project settings](https://us.posthog.com/settings/project). If you're using Vite, prefixing variable names with `VITE_` ensures they are accessible in the frontend.
+
+    .env.local
+
+    PostHog AI
+
+    ```shell
+    VITE_POSTHOG_PROJECT_TOKEN=<ph_project_token>
+    VITE_POSTHOG_HOST=https://us.i.posthog.com
+    ```
+
+3.  3
+
+    ## Add the PostHogProvider to your app
+
+    Required
+
+    In declarative mode, you'll need to wrap your `BrowserRouter` with the `PostHogProvider` context. This passes an initialized PostHog client to your app.
+
+    src/main.tsx
+
+    PostHog AI
+
+    ```jsx
+    import { StrictMode } from "react";
+    import ReactDOM from "react-dom/client";
+    import { BrowserRouter, Routes, Route } from "react-router";
+    import posthog from 'posthog-js';
+    import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react'
+    // Initialize PostHog
+    posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
+      api_host: import.meta.env.VITE_POSTHOG_HOST,
+      defaults: '2026-05-30',
+    });
+    const root = document.getElementById("root");
+    ReactDOM.createRoot(root).render(
+      <StrictMode>
+        {/* Pass PostHog client through PostHogProvider */}
+        <PostHogProvider client={posthog}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Root />}>
+            {/* ... Your routes ... */}
+            </Route>
+          </Routes>
+        </BrowserRouter>
+        </PostHogProvider>
+      </StrictMode>,
+    );
+    ```
+
+    This initializes PostHog and passes it to your app through the `PostHogProvider` context.
+
+    TypeError: Cannot read properties of undefined
+
+    If you see the error `TypeError: Cannot read properties of undefined (reading '...')` this is likely because you tried to call a posthog function when posthog was not initialized (such as during the initial render). On purpose, we still render the children even if PostHog is not initialized so that your app still loads even if PostHog can't load.
+
+    To fix this error, add a check that posthog has been initialized such as:
+
+    React
+
+    PostHog AI
+
+    ```jsx
+    useEffect(() => {
+      posthog?.capture('test') // using optional chaining (recommended)
+      if (posthog) {
+        posthog.capture('test') // using an if statement
+      }
+    }, [posthog])
+    ```
+
+    Typescript helps protect against these errors.
+
+4.  ## Verify client-side events are captured
+
+    Checkpoint
+
+    *Confirm that you can capture client-side events and see them in your PostHog project*
+
+    At this point, you should be able to capture client-side events and see them in your PostHog project. This includes basic events like page views and button clicks that are [autocaptured](/docs/product-analytics/autocapture.md).
+
+    You can also try to capture a custom event to verify it's working. You can access PostHog in any component using the `usePostHog` hook.
+
+    TSX
+
+    PostHog AI
+
+    ```jsx
+    import { usePostHog } from '@posthog/react'
+    function App() {
+      const posthog = usePostHog()
+      return <button onClick={() => posthog?.capture('button_clicked')}>Click me</button>
+    }
+    ```
+
+    You should see these events in a minute or two in the [activity tab](https://app.posthog.com/activity/explore).
+
+5.  4
+
+    ## Access PostHog methods
+
+    Required
+
+    On the client-side, you can access the PostHog client using the `usePostHog` hook. This hook returns the initialized PostHog client, which you can use to call PostHog methods. For example:
+
+    TSX
+
+    PostHog AI
+
+    ```jsx
+    import { usePostHog } from '@posthog/react'
+    function App() {
+      const posthog = usePostHog()
+      return <button onClick={() => posthog?.capture('button_clicked')}>Click me</button>
+    }
+    ```
+
+    For a complete list of available methods, see the [posthog-js documentation](/docs/libraries/js.md).
+
+6.  5
+
+    ## Identify your user
+
+    Recommended
+
+    Now that you can capture basic client-side events, you'll want to identify your user so you can associate users with captured events.
+
+    Generally, you identify users when they log in or when they input some identifiable information (e.g. email, name, etc.). You can identify users by calling the `identify` method on the PostHog client:
+
+    TSX
+
+    PostHog AI
+
+    ```jsx
+    export default function Login() {
+      const { user, login } = useAuth();
+      const posthog = usePostHog();
+      const handleLogin = async (e: React.FormEvent) => {
+        // existing code to handle login...
+        const user = await login({ email, password });
+        posthog?.identify(user.email,
+          {
+            email: user.email,
+            name: user.name,
+          }
+        );
+        posthog?.capture('user_logged_in');
+      };
+      return (
+        <div>
+          {/* ... existing code ... */}
+          <button onClick={handleLogin}>Login</button>
+        </div>
+      );
+    }
+    ```
+
+    PostHog automatically generates anonymous IDs for users before they're identified. When you call identify, a new identified person is created. All previous events tracked with the anonymous ID link to the new identified distinct ID, and all future captures on the same browser associate with the identified person.
+
+7.  6
+
+    ## Create an error boundary
+
+    Recommended
+
+    PostHog can capture exceptions thrown in your app through an error boundary. PostHog provides a `PostHogErrorBoundary` component that you can use to capture exceptions. You can wrap your app with this component to capture exceptions.
+
+    TSX
+
+    PostHog AI
+
+    ```jsx
+    ReactDOM.createRoot(root).render(
+      <StrictMode>
+        <PostHogProvider client={posthog}>
+        <PostHogErrorBoundary>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Root />}>
+              {/* ... Your routes ... */}
+            </Route>
+          </Routes>
+        </BrowserRouter>
+        </PostHogErrorBoundary>
+        </PostHogProvider>
+      </StrictMode>,
+    );
+    ```
+
+    This automatically captures exceptions thrown in your React Router app using the `posthog.captureException()` method.
+
+8.  7
+
+    ## Tracking element visibility
+
+    Recommended
+
+    The `PostHogCaptureOnViewed` component enables you to automatically capture events when elements scroll into view in the browser. This is useful for tracking impressions of important content, monitoring user engagement with specific sections, or understanding which parts of your page users are actually seeing.
+
+    The component wraps your content and sends a `$element_viewed` event to PostHog when the wrapped element becomes visible in the viewport. It only fires once per component instance.
+
+    **Basic usage:**
+
+    React
+
+    PostHog AI
+
+    ```jsx
+    import { PostHogCaptureOnViewed } from '@posthog/react'
+    function App() {
+        return (
+            <PostHogCaptureOnViewed name="hero-banner">
+                <div>Your important content here</div>
+            </PostHogCaptureOnViewed>
+        )
+    }
+    ```
+
+    **With custom properties:**
+
+    You can include additional properties with the event to provide more context:
+
+    React
+
+    PostHog AI
+
+    ```jsx
+    <PostHogCaptureOnViewed
+        name="product-card"
+        properties={{
+            product_id: '123',
+            category: 'electronics',
+            price: 299.99
+        }}
+    >
+        <ProductCard />
+    </PostHogCaptureOnViewed>
+    ```
+
+    **Tracking multiple children:**
+
+    Use `trackAllChildren` to track each child element separately. This is useful for galleries or lists where you want to know which specific items were viewed:
+
+    React
+
+    PostHog AI
+
+    ```jsx
+    <PostHogCaptureOnViewed
+        name="product-gallery"
+        properties={{ gallery_type: 'featured' }}
+        trackAllChildren
+    >
+        <ProductCard id="1" />
+        <ProductCard id="2" />
+        <ProductCard id="3" />
+    </PostHogCaptureOnViewed>
+    ```
+
+    When `trackAllChildren` is enabled, each child element sends its own event with a `child_index` property indicating its position.
+
+    **Custom intersection observer options:**
+
+    You can customize when elements are considered "viewed" by passing options to the `IntersectionObserver`:
+
+    React
+
+    PostHog AI
+
+    ```jsx
+    <PostHogCaptureOnViewed
+        name="footer"
+        observerOptions={{
+            threshold: 0.5,  // Element is 50% visible
+            rootMargin: '0px'
+        }}
+    >
+        <Footer />
+    </PostHogCaptureOnViewed>
+    ```
+
+    The component passes all other props to the wrapper `div`, so you can add styling, classes, or other HTML attributes as needed.
+
+9.  8
+
+    ## Set up server-side analytics
+
+    Recommended
+
+    Now that you've set up PostHog for React Router V7 in declarative mode, you can continue to set up server-side analytics. You can find our other SDKs in the [SDKs page](/docs/libraries.md).
+
+    To help PostHog track your user sessions across the client and server, you'll need to add the `tracing_headers: ['your-backend-hostname1.com', 'your-backend-hostname2.com', ...]` option to your PostHog initialization:
+
+    TSX
+
+    PostHog AI
+
+    ```jsx
+    posthog.init(import.meta.env.VITE_POSTHOG_PROJECT_TOKEN, {
+      api_host: import.meta.env.VITE_POSTHOG_HOST,
+      defaults: '2026-05-30',
+      tracing_headers: [ window.location.hostname, 'localhost' ],
+    });
+    ```
+
+    This adds the `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to requests sent to the configured hostnames, which you can later use on the server-side.
+
+10.  9
+
+     ## Next steps
+
+     Recommended
+
+     Now that you've set up PostHog for React Router, you can start capturing events and exceptions in your app.
+
+     To get the most out of PostHog, you should familiarize yourself with the following:
+
+     -   [PostHog Web SDK docs](/docs/libraries/js.md): Learn more about the PostHog Web SDK and how to use it on the client-side.
+     -   [PostHog Node SDK docs](/docs/libraries/node.md): Learn more about the PostHog Node SDK and how to use it on the server-side.
+     -   [Identify users](/docs/product-analytics/identify.md): Learn more about how to identify users in your app.
+     -   [Group analytics](/docs/product-analytics/group-analytics.md): Learn more about how to use group analytics in your app.
+     -   [PostHog AI](/docs/posthog-ai.md): After capturing events, use PostHog AI to help you understand your data and build insights.
+     -   [Feature flags and experiments](/docs/libraries/react.md#feature-flags): Feature flag and experiment setup is the same as React. You can find more details in the React integration guide.
+
+### Still have questions?
+
+Ask PostHog AI
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,9 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 80,
+  "sortPackageJson": false,
+  "ignorePatterns": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.84.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
+      "dependencies": {
+        "posthog-js": "^1.428.7"
+      },
       "devDependencies": {
         "@1password/sdk": "0.5.0",
         "@eddeee888/gcg-typescript-resolver-files": "0.7.2",
@@ -7695,6 +7698,31 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.8.2.tgz",
+      "integrity": "sha512-8g7+ijrx8bfWmpDjmP07e0ZmdRnJoFqZ6PCcMQvfBTUrr422GRXvQWpQn7yD028zIJHIIn/rUTipKgUC5UkWpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.51.0",
+        "@posthog/types": "^1.409.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.51.0.tgz",
+      "integrity": "sha512-LilmmtjcrjV1LgaVNQXrAUt4IXcWIYMrwEtx6VJUUFDeBBdmeI99jshKGtAWugYeB3Wkcp9xQIVCrxIYRpNiRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.409.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.409.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.2.tgz",
+      "integrity": "sha512-hZ4EXZ1+BstMaxUkmAEg3qvgMR/S00Xb+wEwY/Tx2Dr9dBgiBWrERxaq2UwICh/Fh/vVXpKZT/0SkRtO8JKQ2A==",
+      "license": "MIT"
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -9512,6 +9540,24 @@
         "tslib": "^2.3.1",
         "uuid": "^11.1.0"
       }
+    },
+    "node_modules/@taskforcesh/bullmq-pro/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@taskforcesh/bullmq-pro/node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@testcontainers/postgresql": {
       "version": "11.14.0",
@@ -14331,6 +14377,20 @@
       "peer": true,
       "dependencies": {
         "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -20151,16 +20211,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inquirer/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/inter-ui": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/inter-ui/-/inter-ui-3.19.3.tgz",
@@ -21837,16 +21887,6 @@
         "enquirer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/listr2/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/listr2/node_modules/wrap-ansi": {
@@ -27781,11 +27821,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.428.7",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.428.7.tgz",
+      "integrity": "sha512-ztFOoipQ1eOEl1xkkEldy1x8TEPKhNRb6ZZbuODoXqILqcHgHCUF1hATENY36HBuSV7TwXq16pQ3QYYI1rBCuQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.8.2",
+        "@posthog/core": "^1.51.0",
+        "@posthog/types": "^1.409.2",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^6.2.1",
+        "web-vitals-soft-navs": "npm:web-vitals@6.2.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
+    },
     "node_modules/pprof-format": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.2.tgz",
       "integrity": "sha512-hd90rHVDhNOhgHTmazVzDSVwTLOBjpZQ26AO/0j46sAFZ9uSWY0DcK2zJcwnuo2R6EzufBbOoWlPazA5nSyHcg==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -28351,6 +28445,12 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
     "node_modules/queue-lit": {
@@ -30153,22 +30253,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/sade": {
       "version": "1.8.1",
@@ -34459,16 +34551,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/wait-on/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -34508,6 +34590,19 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "vitest": "^3.2.6",
     "wait-on": "^7.2.0"
   },
-  "version": "1.84.0"
+  "version": "1.84.0",
+  "dependencies": {
+    "posthog-js": "^1.428.7"
+  }
 }

--- a/packages/backend/src/helpers/csp.ts
+++ b/packages/backend/src/helpers/csp.ts
@@ -1,11 +1,11 @@
-import helmet, { HelmetOptions } from "helmet";
+import helmet, { HelmetOptions } from 'helmet'
 
-import appConfig from "@/config/app";
+import appConfig from '@/config/app'
 
-const posthogHost = process.env.VITE_PUBLIC_POSTHOG_HOST;
+const posthogHost = 'https://a.plumber.gov.sg'
 const posthogAssetsHost = posthogHost
-  ? `https://*.${new URL(posthogHost).hostname.split(".").slice(-3).join(".")}`
-  : undefined;
+  ? `https://*.${new URL(posthogHost).hostname.split('.').slice(-3).join('.')}`
+  : undefined
 
 const helmetOptions: HelmetOptions = {
   contentSecurityPolicy: {
@@ -17,62 +17,65 @@ const helmetOptions: HelmetOptions = {
         "'self'",
         posthogHost,
         // For Datadog RUM
-        "https://browser-intake-datadoghq.com",
-        "https://*.browser-intake-datadoghq.com",
+        'https://browser-intake-datadoghq.com',
+        'https://*.browser-intake-datadoghq.com',
         // Launch Darkly feature flags
-        "https://*.launchdarkly.com",
+        'https://*.launchdarkly.com',
         // For proxying datadog rum
-        "https://rum-proxy.plumber.gov.sg",
+        'https://rum-proxy.plumber.gov.sg',
         // For proxying Confetti Survey
-        "https://confetti.plumber.gov.sg",
+        'https://confetti.plumber.gov.sg',
         // For S3 bucket
-        "https://plumber-uat-attachment-bucket-private-0d9400e.s3.ap-southeast-1.amazonaws.com",
-        "https://plumber-staging-attachment-bucket-private-ab28487.s3.ap-southeast-1.amazonaws.com",
-        "https://plumber-prod-attachment-bucket-private-beb3aa3.s3.ap-southeast-1.amazonaws.com",
+        'https://plumber-uat-attachment-bucket-private-0d9400e.s3.ap-southeast-1.amazonaws.com',
+        'https://plumber-staging-attachment-bucket-private-ab28487.s3.ap-southeast-1.amazonaws.com',
+        'https://plumber-prod-attachment-bucket-private-beb3aa3.s3.ap-southeast-1.amazonaws.com',
         appConfig.baseUrl,
       ].filter(Boolean),
       // for google fonts
-      fontSrc: ["'self'", "https://fonts.gstatic.com"],
+      fontSrc: ["'self'", 'https://fonts.gstatic.com'],
       frameAncestors: ["'none'"],
       frameSrc: [
         "'self'",
-        "https://demo.arcade.software",
-        appConfig.isDev && "https://*.apollographql.com",
+        'https://demo.arcade.software',
+        appConfig.isDev && 'https://*.apollographql.com',
       ].filter(Boolean),
       imgSrc: [
         "'self'",
-        "data:",
-        "https://file.go.gov.sg",
-        "https://www.google-analytics.com",
-        "https://www.googletagmanager.com",
-        appConfig.isDev && "https://*.apollographql.com",
+        'data:',
+        'https://file.go.gov.sg',
+        'https://www.google-analytics.com',
+        'https://www.googletagmanager.com',
+        appConfig.isDev && 'https://*.apollographql.com',
         appConfig.baseUrl,
       ].filter(Boolean),
       objectSrc: ["'none'"],
       // for google fonts
-      styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+      styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
       scriptSrcAttr: ["'none'"],
       scriptSrc: [
         "'self'",
         posthogAssetsHost,
-        "https://www.google-analytics.com",
-        "https://www.googletagmanager.com",
-        appConfig.isDev && "https://*.apollographql.com",
+        'https://www.google-analytics.com',
+        'https://www.googletagmanager.com',
+        appConfig.isDev && 'https://*.apollographql.com',
         appConfig.isDev && "'unsafe-inline'",
       ].filter(Boolean),
-      manifestSrc: ["'self'", !appConfig.isDev && "https://*.apollographql.com"].filter(Boolean),
+      manifestSrc: [
+        "'self'",
+        !appConfig.isDev && 'https://*.apollographql.com',
+      ].filter(Boolean),
       upgradeInsecureRequests: [],
-      workerSrc: ["blob:", "'self'"],
+      workerSrc: ['blob:', "'self'"],
     },
   },
   crossOriginOpenerPolicy: {
     // required for using window.opener
-    policy: "unsafe-none",
+    policy: 'unsafe-none',
   },
   crossOriginResourcePolicy: {
-    policy: appConfig.isDev ? "cross-origin" : "same-site",
+    policy: appConfig.isDev ? 'cross-origin' : 'same-site',
   },
   crossOriginEmbedderPolicy: false,
-};
+}
 
-export default helmet(helmetOptions);
+export default helmet(helmetOptions)

--- a/packages/backend/src/helpers/csp.ts
+++ b/packages/backend/src/helpers/csp.ts
@@ -1,6 +1,11 @@
-import helmet, { HelmetOptions } from 'helmet'
+import helmet, { HelmetOptions } from "helmet";
 
-import appConfig from '@/config/app'
+import appConfig from "@/config/app";
+
+const posthogHost = process.env.VITE_PUBLIC_POSTHOG_HOST;
+const posthogAssetsHost = posthogHost
+  ? `https://*.${new URL(posthogHost).hostname.split(".").slice(-3).join(".")}`
+  : undefined;
 
 const helmetOptions: HelmetOptions = {
   contentSecurityPolicy: {
@@ -10,65 +15,64 @@ const helmetOptions: HelmetOptions = {
       blockAllMixedContent: [],
       connectSrc: [
         "'self'",
+        posthogHost,
         // For Datadog RUM
-        'https://browser-intake-datadoghq.com',
-        'https://*.browser-intake-datadoghq.com',
+        "https://browser-intake-datadoghq.com",
+        "https://*.browser-intake-datadoghq.com",
         // Launch Darkly feature flags
-        'https://*.launchdarkly.com',
+        "https://*.launchdarkly.com",
         // For proxying datadog rum
-        'https://rum-proxy.plumber.gov.sg',
+        "https://rum-proxy.plumber.gov.sg",
         // For proxying Confetti Survey
-        'https://confetti.plumber.gov.sg',
+        "https://confetti.plumber.gov.sg",
         // For S3 bucket
-        'https://plumber-uat-attachment-bucket-private-0d9400e.s3.ap-southeast-1.amazonaws.com',
-        'https://plumber-staging-attachment-bucket-private-ab28487.s3.ap-southeast-1.amazonaws.com',
-        'https://plumber-prod-attachment-bucket-private-beb3aa3.s3.ap-southeast-1.amazonaws.com',
+        "https://plumber-uat-attachment-bucket-private-0d9400e.s3.ap-southeast-1.amazonaws.com",
+        "https://plumber-staging-attachment-bucket-private-ab28487.s3.ap-southeast-1.amazonaws.com",
+        "https://plumber-prod-attachment-bucket-private-beb3aa3.s3.ap-southeast-1.amazonaws.com",
         appConfig.baseUrl,
-      ],
+      ].filter(Boolean),
       // for google fonts
-      fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+      fontSrc: ["'self'", "https://fonts.gstatic.com"],
       frameAncestors: ["'none'"],
       frameSrc: [
         "'self'",
-        'https://demo.arcade.software',
-        appConfig.isDev && 'https://*.apollographql.com',
+        "https://demo.arcade.software",
+        appConfig.isDev && "https://*.apollographql.com",
       ].filter(Boolean),
       imgSrc: [
         "'self'",
-        'data:',
-        'https://file.go.gov.sg',
-        'https://www.google-analytics.com',
-        'https://www.googletagmanager.com',
-        appConfig.isDev && 'https://*.apollographql.com',
+        "data:",
+        "https://file.go.gov.sg",
+        "https://www.google-analytics.com",
+        "https://www.googletagmanager.com",
+        appConfig.isDev && "https://*.apollographql.com",
         appConfig.baseUrl,
       ].filter(Boolean),
       objectSrc: ["'none'"],
       // for google fonts
-      styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+      styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       scriptSrcAttr: ["'none'"],
       scriptSrc: [
         "'self'",
-        'https://www.google-analytics.com',
-        'https://www.googletagmanager.com',
-        appConfig.isDev && 'https://*.apollographql.com',
+        posthogAssetsHost,
+        "https://www.google-analytics.com",
+        "https://www.googletagmanager.com",
+        appConfig.isDev && "https://*.apollographql.com",
         appConfig.isDev && "'unsafe-inline'",
       ].filter(Boolean),
-      manifestSrc: [
-        "'self'",
-        !appConfig.isDev && 'https://*.apollographql.com',
-      ].filter(Boolean),
+      manifestSrc: ["'self'", !appConfig.isDev && "https://*.apollographql.com"].filter(Boolean),
       upgradeInsecureRequests: [],
-      workerSrc: ['blob:', "'self'"],
+      workerSrc: ["blob:", "'self'"],
     },
   },
   crossOriginOpenerPolicy: {
     // required for using window.opener
-    policy: 'unsafe-none',
+    policy: "unsafe-none",
   },
   crossOriginResourcePolicy: {
-    policy: appConfig.isDev ? 'cross-origin' : 'same-site',
+    policy: appConfig.isDev ? "cross-origin" : "same-site",
   },
   crossOriginEmbedderPolicy: false,
-}
+};
 
-export default helmet(helmetOptions)
+export default helmet(helmetOptions);

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -22,6 +22,7 @@ import InputCreator from '@/components/InputCreator'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
 import { getOpenerOrigin } from '@/helpers/window'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 import Form from '../Form'
 
@@ -106,6 +107,9 @@ export default function AddAppConnection(
         stepIndex++
 
         if (stepIndex === steps.length) {
+          if (isPostHogConfigured) {
+            posthog.capture('app_connection_connected', { app_key: key })
+          }
           onClose(response)
         }
       }

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -5,6 +5,7 @@ import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
 import { hasEmptyIfThenV2Block } from '@/components/Editor/helpers/steps-utils'
 import { EditorContext } from '@/contexts/Editor'
 import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 const unpublishButtonStyles = {
   bg: 'base.content.strong',
@@ -93,8 +94,14 @@ export default function PublishButton({
         {...(flow?.active ? unpublishButtonStyles : {})}
         onClick={(e) => {
           if (flow.active) {
+            if (isPostHogConfigured) {
+              posthog.capture('flow_unpublished')
+            }
             onUnpublish()
             return
+          }
+          if (isPostHogConfigured) {
+            posthog.capture('flow_published')
           }
           if (shouldWarnOnLeave) {
             setShouldWarnOnPublish(true)

--- a/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
@@ -7,6 +7,7 @@ import { Button, useToast } from '@opengovsg/design-system-react'
 import client from '@/graphql/client'
 import { RETRY_EXECUTION_STEP } from '@/graphql/mutations/retry-execution-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 export type RetryVariant = 'retry' | 'resume'
 
@@ -61,6 +62,11 @@ const RetryButton = ({
       },
     },
     onCompleted: () => {
+      if (isPostHogConfigured) {
+        posthog.capture('execution_step_retry_started', {
+          retry_variant: variant,
+        })
+      }
       toast({
         title: config.successMessage,
         status: 'success',

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -15,6 +15,7 @@ import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 import { findAdjacentSteps, shouldCreateEmptyStep } from '../utils'
 
@@ -110,6 +111,9 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
       await client.refetchQueries({
         include: [GET_FLOW, GET_TEST_EXECUTION_STEPS],
       })
+      if (isPostHogConfigured) {
+        posthog.capture('flow_step_deleted')
+      }
 
       // NOTE: this ensures that the drawer is closed and step headers
       // return to the original width when the drawer is closed

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -11,6 +11,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 interface DuplicateStepButtonProps {
   isNested?: boolean
@@ -57,6 +58,9 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     })
 
     const newStep = createdStep.data.createStep
+    if (isPostHogConfigured) {
+      posthog.capture('flow_step_duplicated')
+    }
     setCurrentStepId(newStep.id)
     onDrawerOpen()
   }, [flow, step, createStep, setCurrentStepId, onDrawerOpen])

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -10,6 +10,8 @@ interface AppConfig {
   confettiSurveyId: string
   confettiAiBuilderSurveyId: string
   confettiApiBaseUrl: string
+  posthogProjectToken: string
+  posthogHost: string
 }
 
 function getAppConfig(): AppConfig {
@@ -22,11 +24,15 @@ function getAppConfig(): AppConfig {
   // Routed through our own domain, since CSP only allows connecting to
   // plumber.gov.sg domains directly (see packages/backend/src/helpers/csp.ts).
   const confettiApiBaseUrl = 'https://confetti.plumber.gov.sg'
+  const posthogProjectToken = 'phc_nwcM6rC7WU7CzdW9Z4zvB3dcZWFM9fn2URbqs35FFQQQ'
+  const posthogHost = 'https://a.plumber.gov.sg'
   const commonEnv = {
     env,
     version,
     confettiSurveyPublishableKey,
     confettiApiBaseUrl,
+    posthogProjectToken,
+    posthogHost,
   }
 
   switch (env) {

--- a/packages/frontend/src/contexts/Authentication.tsx
+++ b/packages/frontend/src/contexts/Authentication.tsx
@@ -8,6 +8,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { LOGOUT } from '@/graphql/mutations/logout'
 import { GET_CURRENT_USER } from '@/graphql/queries/get-current-user'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 type CurrentUser = Pick<
   IUser,
@@ -42,6 +43,9 @@ export const AuthenticationProvider = ({
     onCompleted: () => {
       // force datadog rum to stop tracking once logged out
       datadogRum.setTrackingConsent('not-granted')
+      if (isPostHogConfigured) {
+        posthog.reset()
+      }
     },
   })
 
@@ -50,6 +54,9 @@ export const AuthenticationProvider = ({
       datadogRum.setUser(currentUser)
       // grant consent to start tracking once logged in
       datadogRum.setTrackingConsent('granted')
+      if (isPostHogConfigured) {
+        posthog.identify(currentUser.id, { email: currentUser.email })
+      }
     }
   }, [currentUser])
 

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import '@fontsource/space-grotesk'
 import '@opengovsg/confetti/confetti.css'
+import './posthog'
 
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -29,6 +29,7 @@ import {
   buildNoOptionsFoundMessage,
   containsSecretKey,
 } from '@/pages/AiBuilder/helpers'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 import { buildColumnTableReply } from './helpers/columnTableReply'
 import { isTilesListTablesPicker } from './helpers/isTilesListTablesPicker'
@@ -132,6 +133,9 @@ export default function PromptInput({
   }, [clarification])
 
   const doSend = () => {
+    if (isPostHogConfigured) {
+      posthog.capture('ai_builder_message_sent')
+    }
     sendMessage(input)
     setInput('')
     setSelectedAnswers({})

--- a/packages/frontend/src/pages/Flows/hooks/useFlowCreation.ts
+++ b/packages/frontend/src/pages/Flows/hooks/useFlowCreation.ts
@@ -8,6 +8,7 @@ import {
   FLOW_CREATE_MODE,
   useCreateFlowContext,
 } from '@/pages/Flows/contexts/CreateFlowContext'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 export const useFlowCreation = () => {
   const navigate = useNavigate()
@@ -31,6 +32,9 @@ export const useFlowCreation = () => {
           },
         },
       })
+      if (response.data?.createFlow && isPostHogConfigured) {
+        posthog.capture('flow_created')
+      }
       navigate(URLS.FLOW_EDITOR(response.data?.createFlow?.id), {
         replace: true,
       })

--- a/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
+++ b/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
@@ -29,6 +29,7 @@ import { DatabaseType } from '@/graphql/__generated__/graphql'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
 import { ImportCsvModalContent } from '@/pages/Tile/components/TableBanner/ImportCsvButton'
 import { TableContextProvider } from '@/pages/Tile/contexts/TableContext'
+import posthog, { isPostHogConfigured } from '@/posthog'
 
 type TILE_CREATE_MODE = 'import' | 'new'
 
@@ -123,6 +124,11 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
         return
       }
       setTableData(data.createTable)
+      if (isPostHogConfigured) {
+        posthog.capture('tile_created', {
+          creation_mode: isBlank ? 'import' : 'new',
+        })
+      }
       return data.createTable
     },
     [createTableMutation, tableName],

--- a/packages/frontend/src/posthog.ts
+++ b/packages/frontend/src/posthog.ts
@@ -1,23 +1,13 @@
 import posthog from 'posthog-js'
 
-const projectToken = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
-const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
+import appConfig from '@/config/app'
 
-export const isPostHogConfigured = Boolean(projectToken && host)
+const projectToken = appConfig.posthogProjectToken
+const host = appConfig.posthogHost
 
-if (!projectToken) {
-  if (import.meta.env.DEV) {
-    throw new Error(
-      'VITE_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once VITE_PUBLIC_POSTHOG_PROJECT_TOKEN is configured',
-    )
-  }
-} else if (!host) {
-  if (import.meta.env.DEV) {
-    throw new Error(
-      'VITE_PUBLIC_POSTHOG_HOST variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once VITE_PUBLIC_POSTHOG_HOST is configured',
-    )
-  }
-} else {
+export const isPostHogConfigured = projectToken && host
+
+if (projectToken && host) {
   posthog.init(projectToken, {
     api_host: host,
     defaults: '2026-01-30',

--- a/packages/frontend/src/posthog.ts
+++ b/packages/frontend/src/posthog.ts
@@ -1,0 +1,32 @@
+import posthog from 'posthog-js'
+
+const projectToken = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
+const host = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
+
+export const isPostHogConfigured = Boolean(projectToken && host)
+
+if (!projectToken) {
+  if (import.meta.env.DEV) {
+    throw new Error(
+      'VITE_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once VITE_PUBLIC_POSTHOG_PROJECT_TOKEN is configured',
+    )
+  }
+} else if (!host) {
+  if (import.meta.env.DEV) {
+    throw new Error(
+      'VITE_PUBLIC_POSTHOG_HOST variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once VITE_PUBLIC_POSTHOG_HOST is configured',
+    )
+  }
+} else {
+  posthog.init(projectToken, {
+    api_host: host,
+    defaults: '2026-01-30',
+    capture_exceptions: {
+      capture_unhandled_errors: true,
+      capture_unhandled_rejections: true,
+      capture_console_errors: false,
+    },
+  })
+}
+
+export default posthog


### PR DESCRIPTION
## Problem

Plumber has no product analytics. We can't measure feature adoption or usage funnels for flows, tiles, and the AI builder.

## Solution

Integrate PostHog for frontend product analytics, alongside the existing Datadog RUM setup.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Initialize PostHog (`posthog-js`) in `packages/frontend/src/posthog.ts`, gated by `isPostHogConfigured` so tracking no-ops if the project token or host isn't set.
- Identify users on login and reset the PostHog session on logout, mirroring the existing Datadog RUM consent lifecycle in `Authentication.tsx`.
- Allow PostHog's script and connect origins in the backend CSP (`csp.ts`), scoped to the `a.plumber.gov.sg` domain and its subdomains.
- Capture product events: app connection completed, flow published/unpublished, flow created, flow step deleted/duplicated, execution step retried, tile created, and AI builder message sent.

**Improvements**:

- Add `.oxfmtrc.json` for consistent formatting config.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

No automated tests added — this is instrumentation with no user-facing behavior change. Manually verify in a deployed environment (PostHog can't be reached from `dev:sample-env`):

- Log in and confirm a PostHog `identify` call fires with the user's id and email.
- Log out and confirm PostHog session resets.
- Publish/unpublish a flow, create a flow, delete/duplicate a flow step, retry an execution step, create a tile, and send an AI builder message; confirm each event appears in PostHog.
- Confirm the app still loads with no CSP violations in the browser console.

**New scripts**:

- None.

**New dependencies**:

- `posthog-js`: PostHog's browser SDK, used to initialize tracking and capture events.

**New dev dependencies**:

- None.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=64271002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 0/5</h2>

The PR is not safe to merge until PostHog is correctly gated and separated by environment and analytics events are tied to actual completed actions across all intended paths.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Ffrontend%2Fsrc%2Fposthog.ts%3A10-19%0APostHog%20initializes%20when%20the%20application%20module%20loads%2C%20without%20the%20opt-out%20or%20authentication%20gate%20used%20by%20Datadog.%20This%20allows%20unauthenticated%20activity%20and%20enabled%20exception%20reporting%20to%20be%20transmitted%20before%20%60currentUser%60%20is%20known.%20The%20authentication%20effect%20also%20does%20nothing%20when%20the%20user%20is%20null%20and%20resets%20PostHog%20only%20after%20a%20successful%20explicit%20logout%2C%20so%20activity%20after%20session%20expiry%20or%20a%20shared-browser%20reload%20can%20remain%20associated%20with%20the%20previous%20user.%20Gate%20collection%20until%20authentication%20and%20reset%20or%20opt%20out%20whenever%20the%20resolved%20user%20is%20absent.%0A%0A**How%20this%20was%20verified%3A**%20The%20SDK%20initializes%20before%20React%20authentication%20without%20an%20opt-out%2C%20while%20the%20only%20reset%20is%20inside%20successful%20explicit%20logout%20and%20the%20null-user%20effect%20has%20no%20reset%20branch.%0A%0A%23%23%23%20Issue%202%0Apackages%2Ffrontend%2Fsrc%2Fconfig%2Fapp.ts%3A27-35%0AThe%20same%20nonempty%20PostHog%20token%20and%20host%20are%20included%20in%20the%20common%20configuration%20for%20production%2C%20staging%2C%20UAT%2C%20and%20local%20development.%20Because%20no%20environment%20property%20distinguishes%20these%20events%2C%20all%20environments%20initialize%20and%20send%20to%20one%20analytics%20project%2C%20including%20identified%20user%20emails.%20This%20pollutes%20the%20shared%20analytics%20data%20and%20makes%20the%20advertised%20no-op%20configuration%20path%20unreachable.%20Configure%20PostHog%20separately%20by%20environment%20or%20disable%20it%20where%20it%20is%20not%20intended.%0A%0A%23%23%23%20Issue%203%0Apackages%2Ffrontend%2Fsrc%2Fcomponents%2FEditorLayout%2FPublishButton.tsx%3A95-110%0AThe%20publish%20and%20unpublish%20events%20are%20emitted%20on%20the%20initial%20click%2C%20before%20confirmation%20or%20the%20status%20mutation.%20Cancelling%20the%20unsaved-changes%20warning%20records%20%60flow_published%60%20without%20publishing%2C%20while%20choosing%20%E2%80%9CKeep%20pipe%20published%E2%80%9D%20records%20%60flow_unpublished%60%20without%20unpublishing.%20A%20mutation%20failure%20produces%20the%20same%20false%20positive.%20Capture%20these%20events%20only%20after%20%60UPDATE_FLOW_STATUS%60%20completes%20successfully.%0A%0A%23%23%23%20Issue%204%0Apackages%2Ffrontend%2Fsrc%2Fpages%2FAiBuilder%2Fcomponents%2FChatInterface%2FPromptInput.tsx%3A135-139%0A%60ai_builder_message_sent%60%20is%20emitted%20only%20by%20the%20free-text%20%60doSend%60%20path.%20Clarification%20answers%2C%20tile%20and%20column%20setup%2C%20dynamic-picker%20selections%2C%20skips%2C%20and%20%E2%80%9Ccreate%20new%E2%80%9D%20actions%20call%20%60sendMessage%60%20directly%2C%20so%20these%20supported%20interactions%20advance%20the%20conversation%20without%20being%20counted.%20Route%20all%20user-originated%20sends%20through%20a%20shared%20instrumented%20helper.%0A%0A%23%23%23%20Issue%205%0Apackages%2Fbackend%2Fsrc%2Fhelpers%2Fcsp.ts%3A5-8%0ADeriving%20%60posthogAssetsHost%60%20from%20the%20final%20three%20hostname%20labels%20turns%20%60a.plumber.gov.sg%60%20into%20%60https%3A%2F%2F*.plumber.gov.sg%60.%20This%20permits%20scripts%20from%20every%20sibling%20Plumber%20subdomain%2C%20rather%20than%20only%20the%20PostHog%20proxy.%20If%20any%20sibling%20is%20compromised%20or%20serves%20user-controlled%20content%2C%20the%20browser%20will%20accept%20its%20scripts%20under%20this%20CSP.%20Allow%20the%20exact%20proxy%20origin%20and%20only%20explicitly%20required%20asset%20origins.%0A%0A**How%20this%20was%20verified%3A**%20The%20configured%20%60a.plumber.gov.sg%60%20hostname%20deterministically%20becomes%20%60*.plumber.gov.sg%60%20and%20that%20wildcard%20is%20inserted%20into%20the%20production%20%60script-src%60%20directive.%0A%0A%23%23%23%20Issue%206%0Apackage.json%3A79-81%0A%60posthog-js%60%20is%20imported%20by%20the%20frontend%20but%20declared%20only%20in%20the%20repository%20root%2C%20while%20the%20frontend's%20other%20runtime%20dependencies%20live%20in%20%60packages%2Ffrontend%2Fpackage.json%60.%20Root%20installs%20currently%20hoist%20it%2C%20but%20an%20isolated%20frontend%20install%20or%20stricter%20workspace%20dependency%20check%20will%20not%20be%20able%20to%20resolve%20the%20import.%20Declare%20the%20dependency%20in%20the%20consuming%20frontend%20workspace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fplumber&pr=2209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Analytics starts before authentication** <a href="https://github.com/opengovsg/plumber/pull/2209#discussion_r4011637297">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Environments share analytics project** <a href="https://github.com/opengovsg/plumber/pull/2209#discussion_r4011637301">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Status events precede confirmation** <a href="https://github.com/opengovsg/plumber/pull/2209/files#diff-ac508991a1fe122b242541aee54839dfff10feb6eb7de26771d43d29a7dc0954R110">▶</a>
4. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Structured messages bypass analytics** <a href="https://github.com/opengovsg/plumber/pull/2209#discussion_r4011637306">▶</a>
5. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**CSP trusts sibling subdomains** <a href="https://github.com/opengovsg/plumber/pull/2209#discussion_r4011637313">▶</a>
6. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Dependency belongs to frontend** <a href="https://github.com/opengovsg/plumber/pull/2209#discussion_r4011637319">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/frontend/src/posthog.ts:10-19
PostHog initializes when the application module loads, without the opt-out or authentication gate used by Datadog. This allows unauthenticated activity and enabled exception reporting to be transmitted before `currentUser` is known. The authentication effect also does nothing when the user is null and resets PostHog only after a successful explicit logout, so activity after session expiry or a shared-browser reload can remain associated with the previous user. Gate collection until authentication and reset or opt out whenever the resolved user is absent.

**How this was verified:** The SDK initializes before React authentication without an opt-out, while the only reset is inside successful explicit logout and the null-user effect has no reset branch.

### Issue 2
packages/frontend/src/config/app.ts:27-35
The same nonempty PostHog token and host are included in the common configuration for production, staging, UAT, and local development. Because no environment property distinguishes these events, all environments initialize and send to one analytics project, including identified user emails. This pollutes the shared analytics data and makes the advertised no-op configuration path unreachable. Configure PostHog separately by environment or disable it where it is not intended.

### Issue 3
packages/frontend/src/components/EditorLayout/PublishButton.tsx:95-110
The publish and unpublish events are emitted on the initial click, before confirmation or the status mutation. Cancelling the unsaved-changes warning records `flow_published` without publishing, while choosing “Keep pipe published” records `flow_unpublished` without unpublishing. A mutation failure produces the same false positive. Capture these events only after `UPDATE_FLOW_STATUS` completes successfully.

### Issue 4
packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx:135-139
`ai_builder_message_sent` is emitted only by the free-text `doSend` path. Clarification answers, tile and column setup, dynamic-picker selections, skips, and “create new” actions call `sendMessage` directly, so these supported interactions advance the conversation without being counted. Route all user-originated sends through a shared instrumented helper.

### Issue 5
packages/backend/src/helpers/csp.ts:5-8
Deriving `posthogAssetsHost` from the final three hostname labels turns `a.plumber.gov.sg` into `https://*.plumber.gov.sg`. This permits scripts from every sibling Plumber subdomain, rather than only the PostHog proxy. If any sibling is compromised or serves user-controlled content, the browser will accept its scripts under this CSP. Allow the exact proxy origin and only explicitly required asset origins.

**How this was verified:** The configured `a.plumber.gov.sg` hostname deterministically becomes `*.plumber.gov.sg` and that wildcard is inserted into the production `script-src` directive.

### Issue 6
package.json:79-81
`posthog-js` is imported by the frontend but declared only in the repository root, while the frontend's other runtime dependencies live in `packages/frontend/package.json`. Root installs currently hoist it, but an isolated frontend install or stricter workspace dependency check will not be able to resolve the import. Declare the dependency in the consuming frontend workspace.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

This PR adds PostHog product analytics to the frontend, identifies authenticated users, resets identity on explicit logout, extends backend CSP policy, and instruments flow, connection, execution, tile, and AI Builder actions.

- Initializes the browser SDK through the first-party analytics endpoint.
- Adds authentication-linked identification and event capture across product workflows.
- Adds CSP allowances and the `posthog-js` dependency.
- The current implementation needs corrections to its authentication/environment lifecycle and several event-success semantics before its analytics data is reliable.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Frontend module load] --> B[PostHog init]
  B --> C[a.plumber.gov.sg]
  D[GET_CURRENT_USER] -->|Authenticated| E[Identify ID and email]
  D -->|Unauthenticated| F[No reset or opt-out]
  E --> C
  G[Product actions] --> H[Capture analytics events]
  H --> C
  I[Backend CSP] -->|connect-src| C
  I -->|script-src wildcard| J[*.plumber.gov.sg]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore: inject token"](https://github.com/opengovsg/plumber/commit/218ab99cc228136bf736043ca1185240f8bdc49e)</sub>

<!-- /greptile_comment -->